### PR TITLE
add arb as a library

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "lib/arb"]
+	path = lib/arb
+	url = https://github.com/fredrik-johansson/arb.git


### PR DESCRIPTION
This PR adds arb as a submodule under 'lib/arb' 
Maintaining submodules can be a bit tricky
We can talk about it in person

## TODO
We will need to update the code to use this local version rather that the dynamically linked version