### PR TITLE
Enforce each input parameter to be used only once

### DIFF
--- a/src/quartz/dag/dag.h
+++ b/src/quartz/dag/dag.h
@@ -52,7 +52,13 @@ namespace quartz {
 		[[nodiscard]] int get_num_internal_parameters() const;
 		[[nodiscard]] int get_num_gates() const;
 		[[nodiscard]] bool qubit_used(int qubit_index) const;
+		// Used by a parameter gate is considered as used here.
 		[[nodiscard]] bool input_param_used(int param_index) const;
+		// Returns a pair. The first component denotes the input parameters
+		// already used in this DAG. The second component denotes the input
+		// parameters used in each of the parameters in this DAG.
+        [[nodiscard]] std::pair<InputParamMaskType,
+                                std::vector<InputParamMaskType>> get_input_param_mask() const;
 		DAGHashType hash(Context *ctx);
         // Evaluate the output distribution 2^|num_qubits| times, with the i-th
         // time the input distribution being a vector with only the i-th entry

--- a/src/quartz/generator/generator.cpp
+++ b/src/quartz/generator/generator.cpp
@@ -24,7 +24,8 @@ namespace quartz {
 	void Generator::generate(int num_qubits, int num_input_parameters,
 	                         int max_num_quantum_gates, int max_num_param_gates,
 	                         Dataset *dataset, bool verify_equivalences,
-	                         EquivalenceSet *equiv_set, bool verbose) {
+                             EquivalenceSet *equiv_set, bool unique_parameters,
+                             bool verbose) {
 		auto empty_dag =
 		    std::make_unique< DAG >(num_qubits, num_input_parameters);
 		// Generate all possible parameter gates at the beginning.

--- a/src/quartz/generator/generator.h
+++ b/src/quartz/generator/generator.h
@@ -26,6 +26,9 @@ namespace quartz {
 		//     parameters, restrict the order (for example, if a CX gate uses
 		//     two fresh new qubits, the control qubit must have the smaller
 		//     index).
+        // If |unique_parameters| is true, we only search for DAGs that use
+        // each input parameters only once (note: use a doubled parameter, i.e.,
+        // Rx(2theta) is considered using the parameter theta once).
 		void generate_dfs(int num_qubits, int max_num_input_parameters,
 		                  int max_num_quantum_gates, int max_num_param_gates,
 		                  Dataset &dataset, bool restrict_search_space,
@@ -34,6 +37,9 @@ namespace quartz {
 		// Use BFS to generate all equivalent DAGs with |num_qubits| qubits,
 		// |num_input_parameters| input parameters (probably with some unused),
 		// and <= |max_num_quantum_gates| gates.
+		// If |unique_parameters| is true, we only search for DAGs that use
+		// each input parameters only once (note: use a doubled parameter, i.e.,
+		// Rx(2theta) is considered using the parameter theta once).
 		void generate(int num_qubits, int num_input_parameters,
 		              int max_num_quantum_gates, int max_num_param_gates,
 		              Dataset *dataset, bool verify_equivalences,

--- a/src/quartz/generator/generator.h
+++ b/src/quartz/generator/generator.h
@@ -36,7 +36,8 @@ namespace quartz {
 		void generate(int num_qubits, int num_input_parameters,
 		              int max_num_quantum_gates, int max_num_param_gates,
 		              Dataset *dataset, bool verify_equivalences,
-		              EquivalenceSet *equiv_set, bool verbose = false);
+		              EquivalenceSet *equiv_set, bool unique_parameters,
+		              bool verbose = false);
 
 	private:
 		void dfs(int gate_idx, int max_num_gates, int max_remaining_param_gates,

--- a/src/quartz/generator/generator.h
+++ b/src/quartz/generator/generator.h
@@ -28,7 +28,8 @@ namespace quartz {
 		//     index).
 		void generate_dfs(int num_qubits, int max_num_input_parameters,
 		                  int max_num_quantum_gates, int max_num_param_gates,
-		                  Dataset &dataset, bool restrict_search_space);
+		                  Dataset &dataset, bool restrict_search_space,
+                          bool unique_parameters);
 
 		// Use BFS to generate all equivalent DAGs with |num_qubits| qubits,
 		// |num_input_parameters| input parameters (probably with some unused),
@@ -42,7 +43,8 @@ namespace quartz {
 	private:
 		void dfs(int gate_idx, int max_num_gates, int max_remaining_param_gates,
 		         DAG *dag, std::vector< int > &used_parameters,
-		         Dataset &dataset, bool restrict_search_space);
+		         Dataset &dataset, bool restrict_search_space,
+                 bool unique_parameters);
 
 		// |dags[i]| is the DAGs with |i| gates.
 		void bfs(const std::vector< std::vector< DAG * > > &dags,

--- a/src/quartz/generator/generator.h
+++ b/src/quartz/generator/generator.h
@@ -48,7 +48,8 @@ namespace quartz {
 		void bfs(const std::vector< std::vector< DAG * > > &dags,
 		         int max_num_param_gates, Dataset &dataset,
 		         std::vector< DAG * > *new_representatives,
-		         bool verify_equivalences, const EquivalenceSet *equiv_set);
+		         bool verify_equivalences, const EquivalenceSet *equiv_set,
+                 bool unique_parameters);
 
 		void dfs_parameter_gates(std::unique_ptr< DAG > dag,
 		                         int remaining_gates, int max_unused_params,

--- a/src/quartz/utils/utils.h
+++ b/src/quartz/utils/utils.h
@@ -11,6 +11,7 @@ using ComplexType = std::complex< double >;
 using DAGHashType = unsigned long long;
 using PhaseShiftIdType = int;
 using EquivalenceHashType = std::pair< unsigned long long, int >;
+using InputParamMaskType = unsigned long long;
 
 using namespace std::complex_literals; // so that we can write stuff like 1.0i
 

--- a/src/test/test_bfs.cpp
+++ b/src/test/test_bfs.cpp
@@ -26,7 +26,7 @@ int main() {
 		gen.generate_dfs(num_qubits, num_input_parameters,
 		                 max_num_quantum_gates, max_num_param_gates,
 		                 dataset1, /*restrict_search_space=*/
-		                 true);
+		                 true, /*unique_parameters=*/false);
 		end = std::chrono::steady_clock::now();
 		std::cout
 		    << std::dec
@@ -67,7 +67,7 @@ int main() {
 		gen.generate_dfs(num_qubits, num_input_parameters,
 		                 max_num_quantum_gates, max_num_param_gates,
 		                 dataset1, /*restrict_search_space=*/
-		                 false);
+		                 false, /*unique_parameters=*/false);
 		end = std::chrono::steady_clock::now();
 		std::cout
 		    << std::dec << "DFS for all DAGs: " << dataset1.num_total_dags()

--- a/src/test/test_bfs.cpp
+++ b/src/test/test_bfs.cpp
@@ -105,10 +105,15 @@ int main() {
 
 		Dataset dataset2;
 		start = std::chrono::steady_clock::now();
-		gen.generate(num_qubits, num_input_parameters, max_num_quantum_gates,
-		             max_num_param_gates, &dataset2, /*verify_equivalences=*/
-		             false, nullptr,                 /*verbose=*/
-		             true);
+        gen.generate(num_qubits,
+                     num_input_parameters,
+                     max_num_quantum_gates,
+                     max_num_param_gates,
+                     &dataset2, /*verify_equivalences=*/
+                     false,
+                     nullptr, /*unique_parameters=*/
+                     false,                /*verbose=*/
+                     true);
 		end = std::chrono::steady_clock::now();
 		std::cout
 		    << std::dec << "BFS unverified: " << dataset2.num_total_dags()
@@ -147,10 +152,15 @@ int main() {
 	if (run_bfs_verified) {
 		Dataset dataset3;
 		start = std::chrono::steady_clock::now();
-		gen.generate(num_qubits, num_input_parameters, max_num_quantum_gates,
-		             max_num_param_gates, &dataset3, /*verify_equivalences=*/
-		             true, &equiv_set,               /*verbose=*/
-		             true);
+        gen.generate(num_qubits,
+                     num_input_parameters,
+                     max_num_quantum_gates,
+                     max_num_param_gates,
+                     &dataset3, /*verify_equivalences=*/
+                     true,
+                     &equiv_set, /*unique_parameters=*/
+                     false,              /*verbose=*/
+                     true);
 		end = std::chrono::steady_clock::now();
 		std::cout
 		    << std::dec << "BFS verified: " << dataset3.num_total_dags()

--- a/src/test/test_generator.cpp
+++ b/src/test/test_generator.cpp
@@ -10,7 +10,7 @@ int main() {
 	Dataset dataset;
 	gen.generate_dfs(3 /*num_qubits*/, 3 /*max_num_input_parameters*/,
 	                 3 /*max_num_gates*/, 1 /*max_num_param_gates*/, dataset,
-	                 true /*restrict_search_space*/);
+	                 true /*restrict_search_space*/, /*unique_parameters=*/false);
 	for (const auto &it : dataset.dataset) {
 		bool is_first = true;
 		DAG *first_dag = NULL;

--- a/src/test/test_generator.h
+++ b/src/test/test_generator.h
@@ -19,7 +19,7 @@ void test_generator(const std::vector< GateType > &support_gates,
 	EquivalenceSet equiv_set;
 	generator.generate(num_qubits, max_num_input_parameters, max_num_gates,
 	                   /*max_num_param_gates=*/1, &dataset,
-	                   /*verify_equivalences=*/false, &equiv_set);
+	                   /*verify_equivalences=*/false, &equiv_set, /*unique_parameters=*/false);
 	auto end = std::chrono::steady_clock::now();
 	if (verbose) {
 		for (auto &it : dataset.dataset) {

--- a/src/test/test_phase_shift.cpp
+++ b/src/test/test_phase_shift.cpp
@@ -24,7 +24,7 @@ int main() {
 	auto start = std::chrono::steady_clock::now();
 	gen.generate(num_qubits, num_input_parameters, max_num_gates,
 	             max_num_param_gates, &dataset, /*verify_equivalences=*/
-	             true, &equiv_set,              /*verbose=*/
+	             true, &equiv_set, /*unique_parameters=*/false, /*verbose=*/
 	             true);
 	auto end = std::chrono::steady_clock::now();
 	std::cout

--- a/src/test/test_pruning.cpp
+++ b/src/test/test_pruning.cpp
@@ -1,6 +1,8 @@
 #include "test_pruning.h"
 
 int main() {
+  test_pruning({GateType::u1, GateType::u2, GateType::u3, GateType::add},
+               "IBM_with_U3_2_1_", 1, 4, 2, true, 1, true, false, false, false, true);
   test_pruning({GateType::rz, GateType::h, GateType::cx, GateType::x,
                 GateType::add}, "Nam_3_", 3, 2, 3, true, 1, true, true, false, true);
   test_pruning({GateType::rz, GateType::h, GateType::cx, GateType::x,

--- a/src/test/test_pruning.cpp
+++ b/src/test/test_pruning.cpp
@@ -1,8 +1,8 @@
 #include "test_pruning.h"
 
 int main() {
-  test_pruning({GateType::u1, GateType::u2, GateType::u3, GateType::add},
-               "IBM_with_U3_2_1_", 1, 4, 2, true, 1, true, false, false, false, true);
+  test_pruning({GateType::u1, GateType::u2, GateType::u3, GateType::cx, GateType::add},
+               "IBM_with_U3_4_2_", 2, 4, 4, false, 1, true, false, false, false, true);
   test_pruning({GateType::rz, GateType::h, GateType::cx, GateType::x,
                 GateType::add}, "Nam_3_", 3, 2, 3, true, 1, true, true, false, true);
   test_pruning({GateType::rz, GateType::h, GateType::cx, GateType::x,

--- a/src/test/test_pruning.h
+++ b/src/test/test_pruning.h
@@ -42,7 +42,7 @@ void test_pruning(const std::vector<GateType> &supported_gates,
       gen.generate(num_qubits, num_input_parameters,
                    max_num_quantum_gates, max_num_param_gates,
                    &dataset1,        /*verify_equivalences=*/
-                   true, &equiv_set, /*verbose=*/
+                   true, &equiv_set, /*unique_parameters=*/false, /*verbose=*/
                    true);
       end = std::chrono::steady_clock::now();
       running_time_with_all_pruning_techniques += end - start;

--- a/src/test/test_pruning.h
+++ b/src/test/test_pruning.h
@@ -16,7 +16,8 @@ void test_pruning(const std::vector<GateType> &supported_gates,
                   bool run_representative_pruning = true,
                   bool run_original = true,
                   bool run_original_unverified = false,
-                  bool run_original_verified = true) {
+                  bool run_original_verified = true,
+                  bool unique_parameters = false) {
   Context ctx(supported_gates);
   Generator gen(&ctx);
 
@@ -42,7 +43,7 @@ void test_pruning(const std::vector<GateType> &supported_gates,
       gen.generate(num_qubits, num_input_parameters,
                    max_num_quantum_gates, max_num_param_gates,
                    &dataset1,        /*verify_equivalences=*/
-                   true, &equiv_set, /*unique_parameters=*/false, /*verbose=*/
+                   true, &equiv_set, unique_parameters, /*verbose=*/
                    true);
       end = std::chrono::steady_clock::now();
       running_time_with_all_pruning_techniques += end - start;
@@ -165,7 +166,7 @@ void test_pruning(const std::vector<GateType> &supported_gates,
       gen.generate_dfs(num_qubits, num_input_parameters,
                        max_num_quantum_gates, max_num_param_gates,
                        dataset1, /*restrict_search_space=*/
-                       false, /*unique_parameters=*/false);
+                       false, unique_parameters);
       end = std::chrono::steady_clock::now();
       std::cout << std::dec << "Original: " << dataset1.num_total_dags()
                 << " circuits with " << dataset1.num_hash_values()

--- a/src/test/test_pruning.h
+++ b/src/test/test_pruning.h
@@ -165,7 +165,7 @@ void test_pruning(const std::vector<GateType> &supported_gates,
       gen.generate_dfs(num_qubits, num_input_parameters,
                        max_num_quantum_gates, max_num_param_gates,
                        dataset1, /*restrict_search_space=*/
-                       false);
+                       false, /*unique_parameters=*/false);
       end = std::chrono::steady_clock::now();
       std::cout << std::dec << "Original: " << dataset1.num_total_dags()
                 << " circuits with " << dataset1.num_hash_values()

--- a/src/test/test_sparsity.cpp
+++ b/src/test/test_sparsity.cpp
@@ -40,7 +40,7 @@ void test_sparsity(const std::vector<GateType> &supported_gates,
   gen.generate(num_qubits, num_input_parameters,
                max_num_quantum_gates, max_num_param_gates,
                &dataset,
-               true, &equiv_set,
+               true, &equiv_set, /*unique_parameters=*/false,
                true);
   end = std::chrono::steady_clock::now();
   std::cout << std::dec


### PR DESCRIPTION
This PR adds an argument `unique_parameters` to `generate()` and `test_pruning()`. If `unique_parameters` is true, then we only search for circuits that use each input parameter only once (note that doubling a parameter is not considered as using twice). So we will search for circuits using parameters like `p1, 2p2`, `p1 + p2, p3`, but not `p1, p1 + p2`.

Setting `unique_parameters=false` will make the behavior the same as before.