### PR TITLE
[Generator] Use canonical sequence representation for RepGen

### DIFF
--- a/src/quartz/dag/dag.cpp
+++ b/src/quartz/dag/dag.cpp
@@ -1044,8 +1044,8 @@ namespace quartz {
 		return result;
 	}
 
-	bool DAG::minimal_circuit_representation(std::unique_ptr< DAG > *output_dag,
-	                                         bool output) const {
+	bool DAG::canonical_representation(std::unique_ptr<DAG > *output_dag,
+                                       bool output) const {
 		if (output) {
 			// |output_dag| cannot be nullptr but its content can (and should)
 			// be nullptr.
@@ -1227,8 +1227,8 @@ namespace quartz {
 		return this_is_minimal_circuit_representation;
 	}
 
-	bool DAG::is_minimal_circuit_representation() const {
-		return minimal_circuit_representation(nullptr, false);
+	bool DAG::is_canonical_representation() const {
+		return canonical_representation(nullptr, false);
 	}
 
 	std::unique_ptr< DAG >

--- a/src/quartz/dag/dag.cpp
+++ b/src/quartz/dag/dag.cpp
@@ -10,1040 +10,1024 @@
 #include <utility>
 
 namespace quartz {
-	DAG::DAG(int num_qubits, int num_input_parameters)
-	    : num_qubits(num_qubits), num_input_parameters(num_input_parameters),
-	      hash_value_(0), hash_value_valid_(false) {
-		nodes.reserve(num_qubits + num_input_parameters);
-		outputs.reserve(num_qubits);
-		parameters.reserve(num_input_parameters);
-		// Initialize num_qubits qubits
-		for (int i = 0; i < num_qubits; i++) {
-			auto node = std::make_unique< DAGNode >();
-			node->type = DAGNode::input_qubit;
-			node->index = i;
-			outputs.push_back(node.get());
-			nodes.push_back(std::move(node));
-		}
-		// Initialize num_input_parameters parameters
-		for (int i = 0; i < num_input_parameters; i++) {
-			auto node = std::make_unique< DAGNode >();
-			node->type = DAGNode::input_param;
-			node->index = i;
-			parameters.push_back(node.get());
-			nodes.push_back(std::move(node));
-		}
-	}
+DAG::DAG(int num_qubits, int num_input_parameters)
+    : num_qubits(num_qubits), num_input_parameters(num_input_parameters),
+      hash_value_(0), hash_value_valid_(false) {
+  nodes.reserve(num_qubits + num_input_parameters);
+  outputs.reserve(num_qubits);
+  parameters.reserve(num_input_parameters);
+  // Initialize num_qubits qubits
+  for (int i = 0; i < num_qubits; i++) {
+    auto node = std::make_unique<DAGNode>();
+    node->type = DAGNode::input_qubit;
+    node->index = i;
+    outputs.push_back(node.get());
+    nodes.push_back(std::move(node));
+  }
+  // Initialize num_input_parameters parameters
+  for (int i = 0; i < num_input_parameters; i++) {
+    auto node = std::make_unique<DAGNode>();
+    node->type = DAGNode::input_param;
+    node->index = i;
+    parameters.push_back(node.get());
+    nodes.push_back(std::move(node));
+  }
+}
 
-	DAG::DAG(const DAG &other) { clone_from(other, {}, {}); }
+DAG::DAG(const DAG &other) { clone_from(other, {}, {}); }
 
-	std::unique_ptr< DAG > DAG::clone() const {
-		return std::make_unique< DAG >(*this);
-	}
+std::unique_ptr<DAG> DAG::clone() const {
+  return std::make_unique<DAG>(*this);
+}
 
-	bool DAG::fully_equivalent(const DAG &other) const {
-	    if (this == &other) {
-	      return true;
-	    }
-		// Do not check the hash value because of floating point errors
-		// and it is possible that one of the two DAGs may have not calculated
-		// the hash value.
-		if (num_qubits != other.num_qubits ||
-		    num_input_parameters != other.num_input_parameters) {
-			return false;
-		}
-		if (nodes.size() != other.nodes.size() ||
-		    edges.size() != other.edges.size()) {
-			return false;
-		}
-		std::unordered_map< DAGNode *, DAGNode * > nodes_mapping;
-		for (int i = 0; i < (int)nodes.size(); i++) {
-			nodes_mapping[other.nodes[i].get()] = nodes[i].get();
-		}
-		for (int i = 0; i < (int)edges.size(); i++) {
-			if (edges[i]->gate->tp != other.edges[i]->gate->tp) {
-				return false;
-			}
-			if (edges[i]->input_nodes.size() !=
-			        other.edges[i]->input_nodes.size() ||
-			    edges[i]->output_nodes.size() !=
-			        other.edges[i]->output_nodes.size()) {
-				return false;
-			}
-			for (int j = 0; j < (int)edges[i]->input_nodes.size(); j++) {
-				if (nodes_mapping[other.edges[i]->input_nodes[j]] !=
-				    edges[i]->input_nodes[j]) {
-					return false;
-				}
-			}
-			for (int j = 0; j < (int)edges[i]->output_nodes.size(); j++) {
-				if (nodes_mapping[other.edges[i]->output_nodes[j]] !=
-				    edges[i]->output_nodes[j]) {
-					return false;
-				}
-			}
-		}
-		return true;
-	}
+bool DAG::fully_equivalent(const DAG &other) const {
+  if (this == &other) {
+    return true;
+  }
+  // Do not check the hash value because of floating point errors
+  // and it is possible that one of the two DAGs may have not calculated
+  // the hash value.
+  if (num_qubits != other.num_qubits ||
+      num_input_parameters != other.num_input_parameters) {
+    return false;
+  }
+  if (nodes.size() != other.nodes.size() ||
+      edges.size() != other.edges.size()) {
+    return false;
+  }
+  std::unordered_map<DAGNode *, DAGNode *> nodes_mapping;
+  for (int i = 0; i < (int) nodes.size(); i++) {
+    nodes_mapping[other.nodes[i].get()] = nodes[i].get();
+  }
+  for (int i = 0; i < (int) edges.size(); i++) {
+    if (edges[i]->gate->tp != other.edges[i]->gate->tp) {
+      return false;
+    }
+    if (edges[i]->input_nodes.size() !=
+        other.edges[i]->input_nodes.size() ||
+        edges[i]->output_nodes.size() !=
+            other.edges[i]->output_nodes.size()) {
+      return false;
+    }
+    for (int j = 0; j < (int) edges[i]->input_nodes.size(); j++) {
+      if (nodes_mapping[other.edges[i]->input_nodes[j]] !=
+          edges[i]->input_nodes[j]) {
+        return false;
+      }
+    }
+    for (int j = 0; j < (int) edges[i]->output_nodes.size(); j++) {
+      if (nodes_mapping[other.edges[i]->output_nodes[j]] !=
+          edges[i]->output_nodes[j]) {
+        return false;
+      }
+    }
+  }
+  return true;
+}
 
-	bool DAG::fully_equivalent(Context *ctx, DAG &other) {
-		if (hash(ctx) != other.hash(ctx)) {
-			return false;
-		}
-		return fully_equivalent(other);
-	}
+bool DAG::fully_equivalent(Context *ctx, DAG &other) {
+  if (hash(ctx) != other.hash(ctx)) {
+    return false;
+  }
+  return fully_equivalent(other);
+}
 
-	bool DAG::less_than(const DAG &other) const {
-        if (this == &other) {
-          return false;
+bool DAG::less_than(const DAG &other) const {
+  if (this == &other) {
+    return false;
+  }
+  if (num_qubits != other.num_qubits) {
+    return num_qubits < other.num_qubits;
+  }
+  if (get_num_gates() != other.get_num_gates()) {
+    return get_num_gates() < other.get_num_gates();
+  }
+  if (get_num_input_parameters() != other.get_num_input_parameters()) {
+    return get_num_input_parameters() <
+        other.get_num_input_parameters();
+  }
+  if (get_num_total_parameters() != other.get_num_total_parameters()) {
+    // We want fewer quantum gates, i.e., more traditional parameters.
+    return get_num_total_parameters() >
+        other.get_num_total_parameters();
+  }
+  for (int i = 0; i < (int) edges.size(); i++) {
+    if (edges[i]->gate->tp != other.edges[i]->gate->tp) {
+      return edges[i]->gate->tp < other.edges[i]->gate->tp;
+    }
+    assert(edges[i]->input_nodes.size() ==
+        other.edges[i]->input_nodes.size());
+    assert(edges[i]->output_nodes.size() ==
+        other.edges[i]->output_nodes.size());
+    for (int j = 0; j < (int) edges[i]->input_nodes.size(); j++) {
+      if (edges[i]->input_nodes[j]->is_qubit() !=
+          other.edges[i]->input_nodes[j]->is_qubit()) {
+        return edges[i]->input_nodes[j]->is_qubit();
+      }
+      if (edges[i]->input_nodes[j]->index !=
+          other.edges[i]->input_nodes[j]->index) {
+        return edges[i]->input_nodes[j]->index <
+            other.edges[i]->input_nodes[j]->index;
+      }
+    }
+    for (int j = 0; j < (int) edges[i]->output_nodes.size(); j++) {
+      if (edges[i]->output_nodes[j]->is_qubit() !=
+          other.edges[i]->output_nodes[j]->is_qubit()) {
+        return edges[i]->output_nodes[j]->is_qubit();
+      }
+      if (edges[i]->output_nodes[j]->index !=
+          other.edges[i]->output_nodes[j]->index) {
+        return edges[i]->output_nodes[j]->index <
+            other.edges[i]->output_nodes[j]->index;
+      }
+    }
+  }
+  return false; // fully equivalent
+}
+
+bool DAG::add_gate(const std::vector<int> &qubit_indices,
+                   const std::vector<int> &parameter_indices, Gate *gate,
+                   int *output_para_index) {
+  if (gate->get_num_qubits() != qubit_indices.size())
+    return false;
+  if (gate->get_num_parameters() != parameter_indices.size())
+    return false;
+  if (gate->is_parameter_gate() && output_para_index == nullptr)
+    return false;
+  // qubit indices must stay in range
+  for (auto qubit_idx : qubit_indices)
+    if ((qubit_idx < 0) || (qubit_idx >= get_num_qubits()))
+      return false;
+  // parameter indices must stay in range
+  for (auto para_idx : parameter_indices)
+    if ((para_idx < 0) || (para_idx >= parameters.size()))
+      return false;
+  auto edge = std::make_unique<DAGHyperEdge>();
+  edge->gate = gate;
+  for (auto qubit_idx : qubit_indices) {
+    edge->input_nodes.push_back(outputs[qubit_idx]);
+    outputs[qubit_idx]->output_edges.push_back(edge.get());
+  }
+  for (auto para_idx : parameter_indices) {
+    edge->input_nodes.push_back(parameters[para_idx]);
+    parameters[para_idx]->output_edges.push_back(edge.get());
+  }
+  if (gate->is_parameter_gate()) {
+    auto node = std::make_unique<DAGNode>();
+    node->type = DAGNode::internal_param;
+    node->index = *output_para_index = (int) parameters.size();
+    node->input_edges.push_back(edge.get());
+    edge->output_nodes.push_back(node.get());
+    parameters.push_back(node.get());
+    nodes.push_back(std::move(node));
+  } else {
+    assert(gate->is_quantum_gate());
+    for (auto qubit_idx : qubit_indices) {
+      auto node = std::make_unique<DAGNode>();
+      node->type = DAGNode::internal_qubit;
+      node->index = qubit_idx;
+      node->input_edges.push_back(edge.get());
+      edge->output_nodes.push_back(node.get());
+      outputs[qubit_idx] = node.get(); // Update outputs
+      nodes.push_back(std::move(node));
+    }
+  }
+  edges.push_back(std::move(edge));
+  hash_value_valid_ = false;
+  return true;
+}
+
+void DAG::add_input_parameter() {
+  auto node = std::make_unique<DAGNode>();
+  node->type = DAGNode::input_param;
+  node->index = num_input_parameters;
+  parameters.insert(parameters.begin() + num_input_parameters,
+                    node.get());
+  nodes.insert(nodes.begin() + num_input_parameters, std::move(node));
+
+  num_input_parameters++;
+
+  // Update internal parameters' indices
+  for (auto &it : nodes) {
+    if (it->type == DAGNode::internal_param) {
+      it->index++;
+    }
+  }
+
+  // This function should not modify the hash value.
+}
+
+bool DAG::remove_last_gate() {
+  if (edges.empty()) {
+    return false;
+  }
+
+  auto *edge = edges.back().get();
+  auto *gate = edge->gate;
+  // Remove edges from input nodes.
+  for (auto *input_node : edge->input_nodes) {
+    assert(!input_node->output_edges.empty());
+    assert(input_node->output_edges.back() == edge);
+    input_node->output_edges.pop_back();
+  }
+
+  if (gate->is_parameter_gate()) {
+    // Remove the parameter.
+    assert(!nodes.empty());
+    assert(nodes.back()->type == DAGNode::internal_param);
+    assert(nodes.back()->index == (int) parameters.size() - 1);
+    parameters.pop_back();
+    nodes.pop_back();
+  } else {
+    assert(gate->is_quantum_gate());
+    // Restore the outputs.
+    for (auto *input_node : edge->input_nodes) {
+      if (input_node->is_qubit()) {
+        outputs[input_node->index] = input_node;
+      }
+    }
+    // Remove the qubit wires.
+    while (!nodes.empty() && !nodes.back()->input_edges.empty() &&
+        nodes.back()->input_edges.back() == edge) {
+      nodes.pop_back();
+    }
+  }
+
+  // Remove the edge.
+  edges.pop_back();
+
+  hash_value_valid_ = false;
+  return true;
+}
+
+void DAG::generate_parameter_gates(Context *ctx, int max_recursion_depth) {
+  assert(max_recursion_depth == 1);
+  for (const auto &idx : ctx->get_supported_parameter_gates()) {
+    Gate *gate = ctx->get_gate(idx);
+    if (gate->get_num_parameters() == 1) {
+      std::vector<int> param_indices(1);
+      for (param_indices[0] = 0;
+           param_indices[0] < get_num_input_parameters();
+           param_indices[0]++) {
+        int output_param_index;
+        bool ret =
+            add_gate({}, param_indices, gate, &output_param_index);
+        assert(ret);
+      }
+    } else if (gate->get_num_parameters() == 2) {
+      // Case: 0-qubit operators with 2 parameters
+      std::vector<int> param_indices(2);
+      for (param_indices[0] = 0;
+           param_indices[0] < get_num_input_parameters();
+           param_indices[0]++) {
+        for (param_indices[1] = 0;
+             param_indices[1] < get_num_input_parameters();
+             param_indices[1]++) {
+          if (gate->is_commutative() &&
+              param_indices[0] > param_indices[1]) {
+            // For commutative gates, enforce param_indices[0]
+            // <= param_indices[1]
+            continue;
+          }
+          int output_param_index;
+          bool ret = add_gate({}, param_indices, gate,
+                              &output_param_index);
+          assert(ret);
         }
-		if (num_qubits != other.num_qubits) {
-			return num_qubits < other.num_qubits;
-		}
-		if (get_num_gates() != other.get_num_gates()) {
-			return get_num_gates() < other.get_num_gates();
-		}
-		if (get_num_input_parameters() != other.get_num_input_parameters()) {
-			return get_num_input_parameters() <
-			       other.get_num_input_parameters();
-		}
-		if (get_num_total_parameters() != other.get_num_total_parameters()) {
-			// We want fewer quantum gates, i.e., more traditional parameters.
-			return get_num_total_parameters() >
-			       other.get_num_total_parameters();
-		}
-		for (int i = 0; i < (int)edges.size(); i++) {
-			if (edges[i]->gate->tp != other.edges[i]->gate->tp) {
-				return edges[i]->gate->tp < other.edges[i]->gate->tp;
-			}
-			assert(edges[i]->input_nodes.size() ==
-			       other.edges[i]->input_nodes.size());
-			assert(edges[i]->output_nodes.size() ==
-			       other.edges[i]->output_nodes.size());
-			for (int j = 0; j < (int)edges[i]->input_nodes.size(); j++) {
-				if (edges[i]->input_nodes[j]->is_qubit() !=
-				    other.edges[i]->input_nodes[j]->is_qubit()) {
-					return edges[i]->input_nodes[j]->is_qubit();
-				}
-				if (edges[i]->input_nodes[j]->index !=
-				    other.edges[i]->input_nodes[j]->index) {
-					return edges[i]->input_nodes[j]->index <
-					       other.edges[i]->input_nodes[j]->index;
-				}
-			}
-			for (int j = 0; j < (int)edges[i]->output_nodes.size(); j++) {
-				if (edges[i]->output_nodes[j]->is_qubit() !=
-				    other.edges[i]->output_nodes[j]->is_qubit()) {
-					return edges[i]->output_nodes[j]->is_qubit();
-				}
-				if (edges[i]->output_nodes[j]->index !=
-				    other.edges[i]->output_nodes[j]->index) {
-					return edges[i]->output_nodes[j]->index <
-					       other.edges[i]->output_nodes[j]->index;
-				}
-			}
-		}
-		return false; // fully equivalent
-	}
+      }
+    } else {
+      assert(false && "Unsupported gate type");
+    }
+  }
+}
 
-	bool DAG::add_gate(const std::vector< int > &qubit_indices,
-	                   const std::vector< int > &parameter_indices, Gate *gate,
-	                   int *output_para_index) {
-		if (gate->get_num_qubits() != qubit_indices.size())
-			return false;
-		if (gate->get_num_parameters() != parameter_indices.size())
-			return false;
-		if (gate->is_parameter_gate() && output_para_index == nullptr)
-			return false;
-		// qubit indices must stay in range
-		for (auto qubit_idx : qubit_indices)
-			if ((qubit_idx < 0) || (qubit_idx >= get_num_qubits()))
-				return false;
-		// parameter indices must stay in range
-		for (auto para_idx : parameter_indices)
-			if ((para_idx < 0) || (para_idx >= parameters.size()))
-				return false;
-		auto edge = std::make_unique< DAGHyperEdge >();
-		edge->gate = gate;
-		for (auto qubit_idx : qubit_indices) {
-			edge->input_nodes.push_back(outputs[qubit_idx]);
-			outputs[qubit_idx]->output_edges.push_back(edge.get());
-		}
-		for (auto para_idx : parameter_indices) {
-			edge->input_nodes.push_back(parameters[para_idx]);
-			parameters[para_idx]->output_edges.push_back(edge.get());
-		}
-		if (gate->is_parameter_gate()) {
-			auto node = std::make_unique< DAGNode >();
-			node->type = DAGNode::internal_param;
-			node->index = *output_para_index = (int)parameters.size();
-			node->input_edges.push_back(edge.get());
-			edge->output_nodes.push_back(node.get());
-			parameters.push_back(node.get());
-			nodes.push_back(std::move(node));
-		}
-		else {
-			assert(gate->is_quantum_gate());
-			for (auto qubit_idx : qubit_indices) {
-				auto node = std::make_unique< DAGNode >();
-				node->type = DAGNode::internal_qubit;
-				node->index = qubit_idx;
-				node->input_edges.push_back(edge.get());
-				edge->output_nodes.push_back(node.get());
-				outputs[qubit_idx] = node.get(); // Update outputs
-				nodes.push_back(std::move(node));
-			}
-		}
-		edges.push_back(std::move(edge));
-		hash_value_valid_ = false;
-		return true;
-	}
+int DAG::remove_gate(DAGHyperEdge *edge) {
+  auto edge_pos = std::find_if(edges.begin(), edges.end(),
+                               [&](std::unique_ptr<DAGHyperEdge> &p) {
+                                 return p.get() == edge;
+                               });
+  if (edge_pos == edges.end()) {
+    return 0;
+  }
 
-	void DAG::add_input_parameter() {
-		auto node = std::make_unique< DAGNode >();
-		node->type = DAGNode::input_param;
-		node->index = num_input_parameters;
-		parameters.insert(parameters.begin() + num_input_parameters,
-		                  node.get());
-		nodes.insert(nodes.begin() + num_input_parameters, std::move(node));
+  auto *gate = edge->gate;
+  // Remove edges from input nodes.
+  for (auto *input_node : edge->input_nodes) {
+    assert(!input_node->output_edges.empty());
+    auto it = std::find(input_node->output_edges.begin(),
+                        input_node->output_edges.end(), edge);
+    assert(it != input_node->output_edges.end());
+    input_node->output_edges.erase(it);
+  }
 
-		num_input_parameters++;
+  int ret = 1;
 
-		// Update internal parameters' indices
-		for (auto &it : nodes) {
-			if (it->type == DAGNode::internal_param) {
-				it->index++;
-			}
-		}
+  if (gate->is_parameter_gate()) {
+    // Remove the parameter.
+    assert(edge->output_nodes.size() == 1);
+    auto node = edge->output_nodes[0];
+    assert(node->type == DAGNode::internal_param);
+    while (!node->output_edges.empty()) {
+      // Remove edges using the parameter at first.
+      // Note: we can't use a for loop with iterators because they
+      // will be invalidated.
+      ret += remove_gate(node->output_edges[0]);
+    }
+    auto it = std::find_if(
+        nodes.begin(), nodes.end(),
+        [&](std::unique_ptr<DAGNode> &p) { return p.get() == node; });
+    assert(it != nodes.end());
+    auto idx = node->index;
+    assert(idx >= get_num_input_parameters());
+    nodes.erase(it);
+    parameters.erase(parameters.begin() + idx);
+    // Update the parameter indices.
+    for (auto &j : nodes) {
+      if (j->is_parameter() && j->index > idx) {
+        j->index--;
+      }
+    }
+  } else {
+    assert(gate->is_quantum_gate());
+    int num_outputs = (int) edge->output_nodes.size();
+    int j = 0;
+    for (int i = 0; i < num_outputs; i++, j++) {
+      // Match the input qubits and the output qubits.
+      while (j < (int) edge->input_nodes.size() &&
+          !edge->input_nodes[j]->is_qubit()) {
+        j++;
+      }
+      assert(j < (int) edge->input_nodes.size());
+      assert(edge->input_nodes[j]->index ==
+          edge->output_nodes[i]->index);
+      if (outputs[edge->output_nodes[i]->index] ==
+          edge->output_nodes[i]) {
+        // Restore the outputs.
+        outputs[edge->output_nodes[i]->index] =
+            edge->input_nodes[j];
+      }
+      if (edge->output_nodes[i]->output_edges.empty()) {
+        // Remove the qubit wires.
+        auto it = std::find_if(nodes.begin(), nodes.end(),
+                               [&](std::unique_ptr<DAGNode> &p) {
+                                 return p.get() ==
+                                     edge->output_nodes[i];
+                               });
+        assert(it != nodes.end());
+        nodes.erase(it);
+      } else {
+        // Merge the adjacent qubit wires.
+        for (auto &e : edge->output_nodes[i]->output_edges) {
+          auto it = std::find(e->input_nodes.begin(),
+                              e->input_nodes.end(),
+                              edge->output_nodes[i]);
+          assert(it != e->input_nodes.end());
+          *it = edge->input_nodes[j];
+          edge->input_nodes[j]->output_edges.push_back(e);
+        }
+        // And then remove the disconnected qubit wire.
+        auto it = std::find_if(nodes.begin(), nodes.end(),
+                               [&](std::unique_ptr<DAGNode> &p) {
+                                 return p.get() ==
+                                     edge->output_nodes[i];
+                               });
+        assert(it != nodes.end());
+        nodes.erase(it);
+      }
+    }
+  }
 
-		// This function should not modify the hash value.
-	}
+  // Remove the edge.
+  edge_pos = std::find_if(edges.begin(), edges.end(),
+                          [&](std::unique_ptr<DAGHyperEdge> &p) {
+                            return p.get() == edge;
+                          });
+  assert(edge_pos != edges.end());
+  edges.erase(edge_pos);
 
-	bool DAG::remove_last_gate() {
-		if (edges.empty()) {
-			return false;
-		}
+  hash_value_valid_ = false;
+  return ret;
+}
 
-		auto *edge = edges.back().get();
-		auto *gate = edge->gate;
-		// Remove edges from input nodes.
-		for (auto *input_node : edge->input_nodes) {
-			assert(!input_node->output_edges.empty());
-			assert(input_node->output_edges.back() == edge);
-			input_node->output_edges.pop_back();
-		}
+int DAG::remove_first_quantum_gate() {
+  for (auto &edge : edges) {
+    if (edge->gate->is_quantum_gate()) {
+      return remove_gate(edge.get());
+    }
+  }
+  return 0; // nothing removed
+}
 
-		if (gate->is_parameter_gate()) {
-			// Remove the parameter.
-			assert(!nodes.empty());
-			assert(nodes.back()->type == DAGNode::internal_param);
-			assert(nodes.back()->index == (int)parameters.size() - 1);
-			parameters.pop_back();
-			nodes.pop_back();
-		}
-		else {
-			assert(gate->is_quantum_gate());
-			// Restore the outputs.
-			for (auto *input_node : edge->input_nodes) {
-				if (input_node->is_qubit()) {
-					outputs[input_node->index] = input_node;
-				}
-			}
-			// Remove the qubit wires.
-			while (!nodes.empty() && !nodes.back()->input_edges.empty() &&
-			       nodes.back()->input_edges.back() == edge) {
-				nodes.pop_back();
-			}
-		}
+bool DAG::evaluate(const Vector &input_dis,
+                   const std::vector<ParamType> &input_parameters,
+                   Vector &output_dis,
+                   std::vector<ParamType> *parameter_values) const {
+  // We should have 2**n entries for the distribution
+  if (input_dis.size() != (1 << get_num_qubits()))
+    return false;
+  if (input_parameters.size() != get_num_input_parameters())
+    return false;
+  assert(get_num_input_parameters() <= get_num_total_parameters());
+  bool output_parameter_values = true;
+  if (!parameter_values) {
+    parameter_values = new std::vector<ParamType>();
+    output_parameter_values = false;
+  }
+  *parameter_values = input_parameters;
+  parameter_values->resize(get_num_total_parameters());
 
-		// Remove the edge.
-		edges.pop_back();
+  output_dis = input_dis;
 
-		hash_value_valid_ = false;
-		return true;
-	}
+  // Assume the edges are already sorted in the topological order.
+  const int num_edges = (int) edges.size();
+  for (int i = 0; i < num_edges; i++) {
+    std::vector<int> qubit_indices;
+    std::vector<ParamType> params;
+    for (const auto &input_node : edges[i]->input_nodes) {
+      if (input_node->is_qubit()) {
+        qubit_indices.push_back(input_node->index);
+      } else {
+        params.push_back((*parameter_values)[input_node->index]);
+      }
+    }
+    if (edges[i]->gate->is_parameter_gate()) {
+      // A parameter gate. Compute the new parameter.
+      assert(edges[i]->output_nodes.size() == 1);
+      const auto &output_node = edges[i]->output_nodes[0];
+      (*parameter_values)[output_node->index] =
+          edges[i]->gate->compute(params);
+    } else {
+      // A quantum gate. Update the distribution.
+      assert(edges[i]->gate->is_quantum_gate());
+      auto *mat = edges[i]->gate->get_matrix(params);
+      output_dis.apply_matrix(mat, qubit_indices);
+    }
+  }
+  if (!output_parameter_values) {
+    // Delete the temporary variable newed in this function.
+    delete parameter_values;
+  }
+  return true;
+}
 
-	void DAG::generate_parameter_gates(Context *ctx, int max_recursion_depth) {
-		assert(max_recursion_depth == 1);
-		for (const auto &idx : ctx->get_supported_parameter_gates()) {
-			Gate *gate = ctx->get_gate(idx);
-			if (gate->get_num_parameters() == 1) {
-				std::vector< int > param_indices(1);
-				for (param_indices[0] = 0;
-				     param_indices[0] < get_num_input_parameters();
-				     param_indices[0]++) {
-					int output_param_index;
-					bool ret =
-					    add_gate({}, param_indices, gate, &output_param_index);
-					assert(ret);
-				}
-			}
-			else if (gate->get_num_parameters() == 2) {
-				// Case: 0-qubit operators with 2 parameters
-				std::vector< int > param_indices(2);
-				for (param_indices[0] = 0;
-				     param_indices[0] < get_num_input_parameters();
-				     param_indices[0]++) {
-					for (param_indices[1] = 0;
-					     param_indices[1] < get_num_input_parameters();
-					     param_indices[1]++) {
-						if (gate->is_commutative() &&
-						    param_indices[0] > param_indices[1]) {
-							// For commutative gates, enforce param_indices[0]
-							// <= param_indices[1]
-							continue;
-						}
-						int output_param_index;
-						bool ret = add_gate({}, param_indices, gate,
-						                    &output_param_index);
-						assert(ret);
-					}
-				}
-			}
-			else {
-				assert(false && "Unsupported gate type");
-			}
-		}
-	}
+int DAG::get_num_qubits() const { return num_qubits; }
 
-	int DAG::remove_gate(DAGHyperEdge *edge) {
-		auto edge_pos = std::find_if(edges.begin(), edges.end(),
-		                             [&](std::unique_ptr< DAGHyperEdge > &p) {
-			                             return p.get() == edge;
-		                             });
-		if (edge_pos == edges.end()) {
-			return 0;
-		}
+int DAG::get_num_input_parameters() const { return num_input_parameters; }
 
-		auto *gate = edge->gate;
-		// Remove edges from input nodes.
-		for (auto *input_node : edge->input_nodes) {
-			assert(!input_node->output_edges.empty());
-			auto it = std::find(input_node->output_edges.begin(),
-			                    input_node->output_edges.end(), edge);
-			assert(it != input_node->output_edges.end());
-			input_node->output_edges.erase(it);
-		}
+int DAG::get_num_total_parameters() const { return (int) parameters.size(); }
 
-		int ret = 1;
+int DAG::get_num_internal_parameters() const {
+  return (int) parameters.size() - num_input_parameters;
+}
 
-		if (gate->is_parameter_gate()) {
-			// Remove the parameter.
-			assert(edge->output_nodes.size() == 1);
-			auto node = edge->output_nodes[0];
-			assert(node->type == DAGNode::internal_param);
-			while (!node->output_edges.empty()) {
-				// Remove edges using the parameter at first.
-				// Note: we can't use a for loop with iterators because they
-				// will be invalidated.
-				ret += remove_gate(node->output_edges[0]);
-			}
-			auto it = std::find_if(
-			    nodes.begin(), nodes.end(),
-			    [&](std::unique_ptr< DAGNode > &p) { return p.get() == node; });
-			assert(it != nodes.end());
-			auto idx = node->index;
-			assert(idx >= get_num_input_parameters());
-			nodes.erase(it);
-			parameters.erase(parameters.begin() + idx);
-			// Update the parameter indices.
-			for (auto &j : nodes) {
-				if (j->is_parameter() && j->index > idx) {
-					j->index--;
-				}
-			}
-		}
-		else {
-			assert(gate->is_quantum_gate());
-			int num_outputs = (int)edge->output_nodes.size();
-			int j = 0;
-			for (int i = 0; i < num_outputs; i++, j++) {
-				// Match the input qubits and the output qubits.
-				while (j < (int)edge->input_nodes.size() &&
-				       !edge->input_nodes[j]->is_qubit()) {
-					j++;
-				}
-				assert(j < (int)edge->input_nodes.size());
-				assert(edge->input_nodes[j]->index ==
-				       edge->output_nodes[i]->index);
-				if (outputs[edge->output_nodes[i]->index] ==
-				    edge->output_nodes[i]) {
-					// Restore the outputs.
-					outputs[edge->output_nodes[i]->index] =
-					    edge->input_nodes[j];
-				}
-				if (edge->output_nodes[i]->output_edges.empty()) {
-					// Remove the qubit wires.
-					auto it = std::find_if(nodes.begin(), nodes.end(),
-					                       [&](std::unique_ptr< DAGNode > &p) {
-						                       return p.get() ==
-						                              edge->output_nodes[i];
-					                       });
-					assert(it != nodes.end());
-					nodes.erase(it);
-				}
-				else {
-					// Merge the adjacent qubit wires.
-					for (auto &e : edge->output_nodes[i]->output_edges) {
-						auto it = std::find(e->input_nodes.begin(),
-						                    e->input_nodes.end(),
-						                    edge->output_nodes[i]);
-						assert(it != e->input_nodes.end());
-						*it = edge->input_nodes[j];
-						edge->input_nodes[j]->output_edges.push_back(e);
-					}
-					// And then remove the disconnected qubit wire.
-					auto it = std::find_if(nodes.begin(), nodes.end(),
-					                       [&](std::unique_ptr< DAGNode > &p) {
-						                       return p.get() ==
-						                              edge->output_nodes[i];
-					                       });
-					assert(it != nodes.end());
-					nodes.erase(it);
-				}
-			}
-		}
+int DAG::get_num_gates() const { return (int) edges.size(); }
 
-		// Remove the edge.
-		edge_pos = std::find_if(edges.begin(), edges.end(),
-		                        [&](std::unique_ptr< DAGHyperEdge > &p) {
-			                        return p.get() == edge;
-		                        });
-		assert(edge_pos != edges.end());
-		edges.erase(edge_pos);
+bool DAG::qubit_used(int qubit_index) const {
+  return outputs[qubit_index] != nodes[qubit_index].get();
+}
 
-		hash_value_valid_ = false;
-		return ret;
-	}
+bool DAG::input_param_used(int param_index) const {
+  assert(nodes[get_num_qubits() + param_index]->type ==
+      DAGNode::input_param);
+  assert(nodes[get_num_qubits() + param_index]->index == param_index);
+  return !nodes[get_num_qubits() + param_index]->output_edges.empty();
+}
 
-	int DAG::remove_first_quantum_gate() {
-		for (auto &edge : edges) {
-			if (edge->gate->is_quantum_gate()) {
-				return remove_gate(edge.get());
-			}
-		}
-		return 0; // nothing removed
-	}
+std::pair<InputParamMaskType, std::vector<InputParamMaskType>>
+DAG::get_input_param_mask() const {
+  std::vector<InputParamMaskType> param_mask(get_num_total_parameters());
+  for (int i = 0; i < get_num_input_parameters(); i++) {
+    param_mask[i] = 1 << i;
+  }
+  for (int i = get_num_input_parameters(); i < get_num_total_parameters();
+       i++) {
+    param_mask[i] = 0;
+    assert(parameters[i]->input_edges.size() == 1);
+    for (auto &input_node : parameters[i]->input_edges[0]->input_nodes) {
+      param_mask[i] |= param_mask[input_node->index];
+    }
+  }
+  InputParamMaskType usage_mask{0};
+  for (auto &edge : edges) {
+    // Only consider quantum gate usages of parameters
+    if (edge->gate->is_parametrized_gate()) {
+      for (auto &input_node : edge->input_nodes) {
+        if (input_node->is_parameter()) {
+          usage_mask |= param_mask[input_node->index];
+        }
+      }
+    }
+  }
+  return std::make_pair(usage_mask, param_mask);
+}
 
-	bool DAG::evaluate(const Vector &input_dis,
-	                   const std::vector< ParamType > &input_parameters,
-	                   Vector &output_dis,
-	                   std::vector< ParamType > *parameter_values) const {
-		// We should have 2**n entries for the distribution
-		if (input_dis.size() != (1 << get_num_qubits()))
-			return false;
-		if (input_parameters.size() != get_num_input_parameters())
-			return false;
-		assert(get_num_input_parameters() <= get_num_total_parameters());
-		bool output_parameter_values = true;
-		if (!parameter_values) {
-			parameter_values = new std::vector< ParamType >();
-			output_parameter_values = false;
-		}
-		*parameter_values = input_parameters;
-		parameter_values->resize(get_num_total_parameters());
-
-		output_dis = input_dis;
-
-		// Assume the edges are already sorted in the topological order.
-		const int num_edges = (int)edges.size();
-		for (int i = 0; i < num_edges; i++) {
-			std::vector< int > qubit_indices;
-			std::vector< ParamType > params;
-			for (const auto &input_node : edges[i]->input_nodes) {
-				if (input_node->is_qubit()) {
-					qubit_indices.push_back(input_node->index);
-				}
-				else {
-					params.push_back((*parameter_values)[input_node->index]);
-				}
-			}
-			if (edges[i]->gate->is_parameter_gate()) {
-				// A parameter gate. Compute the new parameter.
-				assert(edges[i]->output_nodes.size() == 1);
-				const auto &output_node = edges[i]->output_nodes[0];
-				(*parameter_values)[output_node->index] =
-				    edges[i]->gate->compute(params);
-			}
-			else {
-				// A quantum gate. Update the distribution.
-				assert(edges[i]->gate->is_quantum_gate());
-				auto *mat = edges[i]->gate->get_matrix(params);
-				output_dis.apply_matrix(mat, qubit_indices);
-			}
-		}
-		if (!output_parameter_values) {
-			// Delete the temporary variable newed in this function.
-			delete parameter_values;
-		}
-		return true;
-	}
-
-	int DAG::get_num_qubits() const { return num_qubits; }
-
-	int DAG::get_num_input_parameters() const { return num_input_parameters; }
-
-	int DAG::get_num_total_parameters() const { return (int)parameters.size(); }
-
-	int DAG::get_num_internal_parameters() const {
-		return (int)parameters.size() - num_input_parameters;
-	}
-
-	int DAG::get_num_gates() const { return (int)edges.size(); }
-
-	bool DAG::qubit_used(int qubit_index) const {
-		return outputs[qubit_index] != nodes[qubit_index].get();
-	}
-
-	bool DAG::input_param_used(int param_index) const {
-		assert(nodes[get_num_qubits() + param_index]->type ==
-		       DAGNode::input_param);
-		assert(nodes[get_num_qubits() + param_index]->index == param_index);
-		return !nodes[get_num_qubits() + param_index]->output_edges.empty();
-	}
-
-    std::pair<InputParamMaskType, std::vector<InputParamMaskType>>
-    DAG::get_input_param_mask() const {
-	  std::vector<InputParamMaskType> param_mask(get_num_total_parameters());
-	  for (int i = 0; i < get_num_input_parameters(); i++) {
-	    param_mask[i] = 1 << i;
-	  }
-	  for (int i = get_num_input_parameters(); i < get_num_total_parameters(); i++) {
-	    param_mask[i] = 0;
-	    assert(parameters[i]->input_edges.size() == 1);
-	    for (auto &input_node : parameters[i]->input_edges[0]->input_nodes) {
-          param_mask[i] |= param_mask[input_node->index];
-	    }
-	  }
-      InputParamMaskType usage_mask{0};
-	  for (auto &edge : edges) {
-	    // Only consider quantum gate usages of parameters
-	    if (edge->gate->is_parametrized_gate()) {
-	      for (auto &input_node : edge->input_nodes) {
-	        if (input_node->is_parameter()) {
-	          usage_mask |= param_mask[input_node->index];
-	        }
-	      }
-	    }
-	  }
-	  return std::make_pair(usage_mask, param_mask);
-	}
-
-	void DAG::generate_hash_values(
-	    Context *ctx, const ComplexType &hash_value,
-	    const PhaseShiftIdType &phase_shift_id,
-	    const std::vector< ParamType > &param_values, DAGHashType *main_hash,
-	    std::vector< std::pair< DAGHashType, PhaseShiftIdType > > *other_hash) {
-		if (kFingerprintInvariantUnderPhaseShift) {
+void DAG::generate_hash_values(
+    Context *ctx, const ComplexType &hash_value,
+    const PhaseShiftIdType &phase_shift_id,
+    const std::vector<ParamType> &param_values, DAGHashType *main_hash,
+    std::vector<std::pair<DAGHashType, PhaseShiftIdType> > *other_hash) {
+  if (kFingerprintInvariantUnderPhaseShift) {
 #ifdef USE_ARBLIB
-			auto val = hash_value.abs();
-			auto max_error = hash_value.get_abs_max_error();
-			assert(max_error < kDAGHashMaxError);
+    auto val = hash_value.abs();
+    auto max_error = hash_value.get_abs_max_error();
+    assert(max_error < kDAGHashMaxError);
 #else
-			auto val = std::abs(hash_value);
+    auto val = std::abs(hash_value);
 #endif
-			*main_hash =
-			    (DAGHashType)std::floor((long double)val / (2 * kDAGHashMaxError));
-			// Besides rounding the hash value down, we might want to round it
-			// up to account for floating point errors.
-			other_hash->emplace_back(*main_hash + 1, phase_shift_id);
-			return;
-		}
+    *main_hash =
+        (DAGHashType) std::floor((long double) val / (2 * kDAGHashMaxError));
+    // Besides rounding the hash value down, we might want to round it
+    // up to account for floating point errors.
+    other_hash->emplace_back(*main_hash + 1, phase_shift_id);
+    return;
+  }
 
-		auto val = hash_value.real() * kDAGHashAlpha +
-		           hash_value.imag() * (1 - kDAGHashAlpha);
-		*main_hash =
-		    (DAGHashType)std::floor((long double)val / (2 * kDAGHashMaxError));
-		// Besides rounding the hash value down, we might want to round it up to
-		// account for floating point errors.
-		other_hash->emplace_back(*main_hash + 1, phase_shift_id);
-	}
+  auto val = hash_value.real() * kDAGHashAlpha +
+      hash_value.imag() * (1 - kDAGHashAlpha);
+  *main_hash =
+      (DAGHashType) std::floor((long double) val / (2 * kDAGHashMaxError));
+  // Besides rounding the hash value down, we might want to round it up to
+  // account for floating point errors.
+  other_hash->emplace_back(*main_hash + 1, phase_shift_id);
+}
 
-	DAGHashType DAG::hash(Context *ctx) {
-		if (hash_value_valid_) {
-			return hash_value_;
-		}
-		const Vector &input_dis =
-		    ctx->get_generated_input_dis(get_num_qubits());
-		Vector output_dis;
-		auto input_parameters =
-		    ctx->get_generated_parameters(get_num_input_parameters());
-		std::vector< ParamType > all_parameters;
-		evaluate(input_dis, input_parameters, output_dis, &all_parameters);
-		ComplexType dot_product =
-		    output_dis.dot(ctx->get_generated_hashing_dis(get_num_qubits()));
+DAGHashType DAG::hash(Context *ctx) {
+  if (hash_value_valid_) {
+    return hash_value_;
+  }
+  const Vector &input_dis =
+      ctx->get_generated_input_dis(get_num_qubits());
+  Vector output_dis;
+  auto input_parameters =
+      ctx->get_generated_parameters(get_num_input_parameters());
+  std::vector<ParamType> all_parameters;
+  evaluate(input_dis, input_parameters, output_dis, &all_parameters);
+  ComplexType dot_product =
+      output_dis.dot(ctx->get_generated_hashing_dis(get_num_qubits()));
 
-		original_fingerprint_ = dot_product;
+  original_fingerprint_ = dot_product;
 
-		other_hash_values_.clear();
-		generate_hash_values(ctx, dot_product, kNoPhaseShift, all_parameters,
-		                     &hash_value_, &other_hash_values_);
-		hash_value_valid_ = true;
+  other_hash_values_.clear();
+  generate_hash_values(ctx, dot_product, kNoPhaseShift, all_parameters,
+                       &hash_value_, &other_hash_values_);
+  hash_value_valid_ = true;
 
-		// Account for phase shifts.
-		// If |kFingerprintInvariantUnderPhaseShift| is true,
-		// this was already handled above in |generate_hash_values|.
-		if (!kFingerprintInvariantUnderPhaseShift &&
-		    kCheckPhaseShiftInGenerator) {
-			// We try the simplest version first:
-			// Apply phase shift for e^(ip) or e^(-ip) for p being a parameter
-			// (either input or internal).
-			DAGHashType tmp;
-			assert(all_parameters.size() == get_num_total_parameters());
-			const int num_total_params = get_num_total_parameters();
-			for (int i = 0; i < num_total_params; i++) {
-				const auto &param = all_parameters[i];
-				ComplexType shifted =
-				    dot_product * ComplexType{std::cos(param), std::sin(param)};
-				generate_hash_values(ctx, shifted, i, all_parameters, &tmp,
-				                     &other_hash_values_);
-				other_hash_values_.emplace_back(tmp, i);
-				shifted = dot_product *
-				          ComplexType{std::cos(param), -std::sin(param)};
-				generate_hash_values(ctx, shifted, i + num_total_params,
-				                     all_parameters, &tmp, &other_hash_values_);
-				other_hash_values_.emplace_back(tmp, i + num_total_params);
-			}
-			if (kCheckPhaseShiftOfPiOver4) {
-				// Check phase shift of pi/4, 2pi/4, ..., 7pi/4.
-				for (int i = 1; i < 8; i++) {
-					const double pi = std::acos(-1.0);
-					ComplexType shifted =
-					    dot_product *
-					    ComplexType{std::cos(pi / 4 * i), std::sin(pi / 4 * i)};
-					generate_hash_values(ctx, shifted, i, all_parameters, &tmp,
-					                     &other_hash_values_);
-					other_hash_values_.emplace_back(
-					    tmp, kCheckPhaseShiftOfPiOver4Index + i);
-				}
-			}
-		}
-		return hash_value_;
-	}
+  // Account for phase shifts.
+  // If |kFingerprintInvariantUnderPhaseShift| is true,
+  // this was already handled above in |generate_hash_values|.
+  if (!kFingerprintInvariantUnderPhaseShift &&
+      kCheckPhaseShiftInGenerator) {
+    // We try the simplest version first:
+    // Apply phase shift for e^(ip) or e^(-ip) for p being a parameter
+    // (either input or internal).
+    DAGHashType tmp;
+    assert(all_parameters.size() == get_num_total_parameters());
+    const int num_total_params = get_num_total_parameters();
+    for (int i = 0; i < num_total_params; i++) {
+      const auto &param = all_parameters[i];
+      ComplexType shifted =
+          dot_product * ComplexType{std::cos(param), std::sin(param)};
+      generate_hash_values(ctx, shifted, i, all_parameters, &tmp,
+                           &other_hash_values_);
+      other_hash_values_.emplace_back(tmp, i);
+      shifted = dot_product *
+          ComplexType{std::cos(param), -std::sin(param)};
+      generate_hash_values(ctx, shifted, i + num_total_params,
+                           all_parameters, &tmp, &other_hash_values_);
+      other_hash_values_.emplace_back(tmp, i + num_total_params);
+    }
+    if (kCheckPhaseShiftOfPiOver4) {
+      // Check phase shift of pi/4, 2pi/4, ..., 7pi/4.
+      for (int i = 1; i < 8; i++) {
+        const double pi = std::acos(-1.0);
+        ComplexType shifted =
+            dot_product *
+                ComplexType{std::cos(pi / 4 * i), std::sin(pi / 4 * i)};
+        generate_hash_values(ctx, shifted, i, all_parameters, &tmp,
+                             &other_hash_values_);
+        other_hash_values_.emplace_back(
+            tmp, kCheckPhaseShiftOfPiOver4Index + i);
+      }
+    }
+  }
+  return hash_value_;
+}
 
-	std::vector< Vector > DAG::get_matrix(Context *ctx) const {
-		const auto sz = 1 << get_num_qubits();
-		Vector input_dis(sz);
-		auto input_parameters =
-		    ctx->get_generated_parameters(get_num_input_parameters());
-		std::vector< ParamType > all_parameters;
-		std::vector< Vector > result(sz);
-		for (int S = 0; S < sz; S++) {
-			input_dis[S] = ComplexType(1);
-			if (S > 0) {
-				input_dis[S - 1] = ComplexType(0);
-			}
-			evaluate(input_dis, input_parameters, result[S], &all_parameters);
-		}
-		return result;
-	}
+std::vector<Vector> DAG::get_matrix(Context *ctx) const {
+  const auto sz = 1 << get_num_qubits();
+  Vector input_dis(sz);
+  auto input_parameters =
+      ctx->get_generated_parameters(get_num_input_parameters());
+  std::vector<ParamType> all_parameters;
+  std::vector<Vector> result(sz);
+  for (int S = 0; S < sz; S++) {
+    input_dis[S] = ComplexType(1);
+    if (S > 0) {
+      input_dis[S - 1] = ComplexType(0);
+    }
+    evaluate(input_dis, input_parameters, result[S], &all_parameters);
+  }
+  return result;
+}
 
-	bool DAG::hash_value_valid() const { return hash_value_valid_; }
+bool DAG::hash_value_valid() const { return hash_value_valid_; }
 
-	DAGHashType DAG::cached_hash_value() const {
-		assert(hash_value_valid_);
-		return hash_value_;
-	}
+DAGHashType DAG::cached_hash_value() const {
+  assert(hash_value_valid_);
+  return hash_value_;
+}
 
-	std::vector< DAGHashType > DAG::other_hash_values() const {
-		assert(hash_value_valid_);
-		std::vector< DAGHashType > result(other_hash_values_.size());
-		for (int i = 0; i < (int)other_hash_values_.size(); i++) {
-			result[i] = other_hash_values_[i].first;
-		}
-		return result;
-	}
+std::vector<DAGHashType> DAG::other_hash_values() const {
+  assert(hash_value_valid_);
+  std::vector<DAGHashType> result(other_hash_values_.size());
+  for (int i = 0; i < (int) other_hash_values_.size(); i++) {
+    result[i] = other_hash_values_[i].first;
+  }
+  return result;
+}
 
-	std::vector< std::pair< DAGHashType, PhaseShiftIdType > >
-	DAG::other_hash_values_with_phase_shift_id() const {
-		assert(hash_value_valid_);
-		return other_hash_values_;
-	}
+std::vector<std::pair<DAGHashType, PhaseShiftIdType> >
+DAG::other_hash_values_with_phase_shift_id() const {
+  assert(hash_value_valid_);
+  return other_hash_values_;
+}
 
-	bool DAG::remove_unused_qubits(std::vector< int > unused_qubits) {
-		if (unused_qubits.empty()) {
-			return true;
-		}
-		std::sort(unused_qubits.begin(), unused_qubits.end(), std::greater<>());
-		for (auto &id : unused_qubits) {
-			if (id >= get_num_qubits()) {
-				return false;
-			}
-			if (nodes[id]->type != DAGNode::input_qubit) {
-				return false;
-			}
-			if (nodes[id]->index != id) {
-				return false;
-			}
-			if (!nodes[id]->output_edges.empty()) {
-				// used
-				return false;
-			}
-			nodes.erase(nodes.begin() + id);
-			outputs.erase(outputs.begin() + id);
-			num_qubits--;
-			for (auto &node : nodes) {
-				if (node->is_qubit() && node->index > id) {
-					node->index--;
-				}
-			}
-		}
-		hash_value_valid_ = false;
-		return true;
-	}
+bool DAG::remove_unused_qubits(std::vector<int> unused_qubits) {
+  if (unused_qubits.empty()) {
+    return true;
+  }
+  std::sort(unused_qubits.begin(), unused_qubits.end(), std::greater<>());
+  for (auto &id : unused_qubits) {
+    if (id >= get_num_qubits()) {
+      return false;
+    }
+    if (nodes[id]->type != DAGNode::input_qubit) {
+      return false;
+    }
+    if (nodes[id]->index != id) {
+      return false;
+    }
+    if (!nodes[id]->output_edges.empty()) {
+      // used
+      return false;
+    }
+    nodes.erase(nodes.begin() + id);
+    outputs.erase(outputs.begin() + id);
+    num_qubits--;
+    for (auto &node : nodes) {
+      if (node->is_qubit() && node->index > id) {
+        node->index--;
+      }
+    }
+  }
+  hash_value_valid_ = false;
+  return true;
+}
 
-	bool
-	DAG::remove_unused_input_params(std::vector< int > unused_input_params) {
-		if (unused_input_params.empty()) {
-			return true;
-		}
-		std::sort(unused_input_params.begin(), unused_input_params.end(),
-		          std::greater<>());
-		for (auto &id : unused_input_params) {
-			if (id >= get_num_input_parameters()) {
-				return false;
-			}
-			if (nodes[get_num_qubits() + id]->type != DAGNode::input_param) {
-				return false;
-			}
-			if (nodes[get_num_qubits() + id]->index != id) {
-				return false;
-			}
-			if (!nodes[get_num_qubits() + id]->output_edges.empty()) {
-				// used
-				return false;
-			}
-			nodes.erase(nodes.begin() + get_num_qubits() + id);
-			parameters.erase(parameters.begin() + id);
-			num_input_parameters--;
-			for (auto &node : nodes) {
-				if (node->is_parameter() && node->index > id) {
-					node->index--;
-				}
-			}
-		}
-		hash_value_valid_ = false;
-		return true;
-	}
+bool
+DAG::remove_unused_input_params(std::vector<int> unused_input_params) {
+  if (unused_input_params.empty()) {
+    return true;
+  }
+  std::sort(unused_input_params.begin(), unused_input_params.end(),
+            std::greater<>());
+  for (auto &id : unused_input_params) {
+    if (id >= get_num_input_parameters()) {
+      return false;
+    }
+    if (nodes[get_num_qubits() + id]->type != DAGNode::input_param) {
+      return false;
+    }
+    if (nodes[get_num_qubits() + id]->index != id) {
+      return false;
+    }
+    if (!nodes[get_num_qubits() + id]->output_edges.empty()) {
+      // used
+      return false;
+    }
+    nodes.erase(nodes.begin() + get_num_qubits() + id);
+    parameters.erase(parameters.begin() + id);
+    num_input_parameters--;
+    for (auto &node : nodes) {
+      if (node->is_parameter() && node->index > id) {
+        node->index--;
+      }
+    }
+  }
+  hash_value_valid_ = false;
+  return true;
+}
 
-	DAG &DAG::shrink_unused_input_parameters() {
-		// Warning: the hash function should be designed such that this function
-		// doesn't change the hash value.
-		if (get_num_input_parameters() == 0) {
-			return *this;
-		}
-		int last_unused_input_param_index = get_num_input_parameters();
-		while (last_unused_input_param_index > 0 &&
-		       nodes[get_num_qubits() + last_unused_input_param_index - 1]
-		           ->output_edges.empty()) {
-			last_unused_input_param_index--;
-		}
-		if (last_unused_input_param_index == get_num_input_parameters()) {
-			// no need to shrink
-			return *this;
-		}
-		int num_parameters_shrinked =
-		    get_num_input_parameters() - last_unused_input_param_index;
+DAG &DAG::shrink_unused_input_parameters() {
+  // Warning: the hash function should be designed such that this function
+  // doesn't change the hash value.
+  if (get_num_input_parameters() == 0) {
+    return *this;
+  }
+  int last_unused_input_param_index = get_num_input_parameters();
+  while (last_unused_input_param_index > 0 &&
+      nodes[get_num_qubits() + last_unused_input_param_index - 1]
+          ->output_edges.empty()) {
+    last_unused_input_param_index--;
+  }
+  if (last_unused_input_param_index == get_num_input_parameters()) {
+    // no need to shrink
+    return *this;
+  }
+  int num_parameters_shrinked =
+      get_num_input_parameters() - last_unused_input_param_index;
 
-		// Erase the parameters and the nodes
-		parameters.erase(parameters.begin() + last_unused_input_param_index,
-		                 parameters.begin() + get_num_input_parameters());
-		nodes.erase(
-		    nodes.begin() + get_num_qubits() + last_unused_input_param_index,
-		    nodes.begin() + get_num_qubits() + get_num_input_parameters());
+  // Erase the parameters and the nodes
+  parameters.erase(parameters.begin() + last_unused_input_param_index,
+                   parameters.begin() + get_num_input_parameters());
+  nodes.erase(
+      nodes.begin() + get_num_qubits() + last_unused_input_param_index,
+      nodes.begin() + get_num_qubits() + get_num_input_parameters());
 
-		// Update the parameter indices
-		for (auto &node : nodes) {
-			if (node->is_parameter() &&
-			    node->index >= get_num_input_parameters()) {
-				// An internal parameter
-				node->index -= num_parameters_shrinked;
-			}
-		}
+  // Update the parameter indices
+  for (auto &node : nodes) {
+    if (node->is_parameter() &&
+        node->index >= get_num_input_parameters()) {
+      // An internal parameter
+      node->index -= num_parameters_shrinked;
+    }
+  }
 
-		// Update num_input_parameters
-		num_input_parameters -= num_parameters_shrinked;
-		return *this;
-	}
+  // Update num_input_parameters
+  num_input_parameters -= num_parameters_shrinked;
+  return *this;
+}
 
-	std::unique_ptr< DAG >
-	DAG::clone_and_shrink_unused_input_parameters() const {
-		auto cloned_dag = std::make_unique< DAG >(*this);
-		cloned_dag->shrink_unused_input_parameters();
-		return cloned_dag;
-	}
+std::unique_ptr<DAG>
+DAG::clone_and_shrink_unused_input_parameters() const {
+  auto cloned_dag = std::make_unique<DAG>(*this);
+  cloned_dag->shrink_unused_input_parameters();
+  return cloned_dag;
+}
 
-	bool DAG::has_unused_parameter() const {
-		for (auto &node : nodes) {
-			if (node->is_parameter() && node->output_edges.empty()) {
-				return true;
-			}
-		}
-		return false;
-	}
+bool DAG::has_unused_parameter() const {
+  for (auto &node : nodes) {
+    if (node->is_parameter() && node->output_edges.empty()) {
+      return true;
+    }
+  }
+  return false;
+}
 
-	int DAG::remove_unused_internal_parameters() {
-		int num_removed = 0;
-		int edge_id = (int)edges.size() - 1;
-		while (edge_id >= 0) {
-			if (edges[edge_id]->gate->is_parameter_gate()) {
-				assert(edges[edge_id]->output_nodes.size() == 1);
-				if (edges[edge_id]->output_nodes[0]->output_edges.empty()) {
-					num_removed += remove_gate(edges[edge_id].get());
-				}
-			}
-			edge_id--;
-		}
-		return num_removed;
-	}
+int DAG::remove_unused_internal_parameters() {
+  int num_removed = 0;
+  int edge_id = (int) edges.size() - 1;
+  while (edge_id >= 0) {
+    if (edges[edge_id]->gate->is_parameter_gate()) {
+      assert(edges[edge_id]->output_nodes.size() == 1);
+      if (edges[edge_id]->output_nodes[0]->output_edges.empty()) {
+        num_removed += remove_gate(edges[edge_id].get());
+      }
+    }
+    edge_id--;
+  }
+  return num_removed;
+}
 
-	void DAG::print(Context *ctx) const {
-		for (size_t i = 0; i < edges.size(); i++) {
-			DAGHyperEdge *edge = edges[i].get();
-			printf("gate[%zu] type(%d)\n", i, edge->gate->tp);
-			for (size_t j = 0; j < edge->input_nodes.size(); j++) {
-				DAGNode *node = edge->input_nodes[j];
-				if (node->is_qubit()) {
-					printf("    inputs[%zu]: qubit(%d)\n", j, node->index);
-				}
-				else {
-					printf("    inputs[%zu]: param(%d)\n", j, node->index);
-				}
-			}
-		}
-	}
+void DAG::print(Context *ctx) const {
+  for (size_t i = 0; i < edges.size(); i++) {
+    DAGHyperEdge *edge = edges[i].get();
+    printf("gate[%zu] type(%d)\n", i, edge->gate->tp);
+    for (size_t j = 0; j < edge->input_nodes.size(); j++) {
+      DAGNode *node = edge->input_nodes[j];
+      if (node->is_qubit()) {
+        printf("    inputs[%zu]: qubit(%d)\n", j, node->index);
+      } else {
+        printf("    inputs[%zu]: param(%d)\n", j, node->index);
+      }
+    }
+  }
+}
 
-	std::string DAG::to_string() const {
-		std::string result;
-		result += "DAG {\n";
-		const int num_edges = (int)edges.size();
-		for (int i = 0; i < num_edges; i++) {
-			result += "  ";
-			if (edges[i]->output_nodes.size() == 1) {
-				result += edges[i]->output_nodes[0]->to_string();
-			}
-			else if (edges[i]->output_nodes.size() == 2) {
-				result += "[" + edges[i]->output_nodes[0]->to_string();
-				result += ", " + edges[i]->output_nodes[1]->to_string();
-				result += "]";
-			}
-			else {
-				assert(false && "A hyperedge should have 1 or 2 outputs.");
-			}
-			result += " = ";
-			result += gate_type_name(edges[i]->gate->tp);
-			result += "(";
-			for (int j = 0; j < (int)edges[i]->input_nodes.size(); j++) {
-				result += edges[i]->input_nodes[j]->to_string();
-				if (j != (int)edges[i]->input_nodes.size() - 1) {
-					result += ", ";
-				}
-			}
-			result += ")";
-			result += "\n";
-		}
-		result += "}\n";
-		return result;
-	}
+std::string DAG::to_string() const {
+  std::string result;
+  result += "DAG {\n";
+  const int num_edges = (int) edges.size();
+  for (int i = 0; i < num_edges; i++) {
+    result += "  ";
+    if (edges[i]->output_nodes.size() == 1) {
+      result += edges[i]->output_nodes[0]->to_string();
+    } else if (edges[i]->output_nodes.size() == 2) {
+      result += "[" + edges[i]->output_nodes[0]->to_string();
+      result += ", " + edges[i]->output_nodes[1]->to_string();
+      result += "]";
+    } else {
+      assert(false && "A hyperedge should have 1 or 2 outputs.");
+    }
+    result += " = ";
+    result += gate_type_name(edges[i]->gate->tp);
+    result += "(";
+    for (int j = 0; j < (int) edges[i]->input_nodes.size(); j++) {
+      result += edges[i]->input_nodes[j]->to_string();
+      if (j != (int) edges[i]->input_nodes.size() - 1) {
+        result += ", ";
+      }
+    }
+    result += ")";
+    result += "\n";
+  }
+  result += "}\n";
+  return result;
+}
 
-	std::string DAG::to_json() const {
-		std::string result;
-		result += "[";
+std::string DAG::to_json() const {
+  std::string result;
+  result += "[";
 
-		// basic info
-		result += "[";
-		result += std::to_string(get_num_qubits());
-		result += ",";
-		result += std::to_string(get_num_input_parameters());
-		result += ",";
-		result += std::to_string(get_num_total_parameters());
-		result += ",";
-		result += std::to_string(get_num_gates());
-		result += ",";
+  // basic info
+  result += "[";
+  result += std::to_string(get_num_qubits());
+  result += ",";
+  result += std::to_string(get_num_input_parameters());
+  result += ",";
+  result += std::to_string(get_num_total_parameters());
+  result += ",";
+  result += std::to_string(get_num_gates());
+  result += ",";
 
-		result += "[";
-		if (hash_value_valid_) {
-			bool first_other_hash_value = true;
-			for (const auto &val : other_hash_values_with_phase_shift_id()) {
-				if (first_other_hash_value) {
-					first_other_hash_value = false;
-				}
-				else {
-					result += ",";
-				}
-				static char buffer[64];
-				auto [ptr, ec] = std::to_chars(buffer, buffer + sizeof(buffer),
-				                               val.first, /*base=*/
-				                               16);
-				assert(ec == std::errc());
-				auto hash_value = std::string(buffer, ptr);
-				if (kCheckPhaseShiftInGenerator &&
-				    val.second != kNoPhaseShift) {
-					// hash value and phase shift id
-					result += "[\"" + hash_value + "\"," +
-					          std::to_string(val.second) + "]";
-				}
-				else {
-					// hash value only
-					result += "\"" + hash_value + "\"";
-				}
-			}
-		}
-		result += "]";
+  result += "[";
+  if (hash_value_valid_) {
+    bool first_other_hash_value = true;
+    for (const auto &val : other_hash_values_with_phase_shift_id()) {
+      if (first_other_hash_value) {
+        first_other_hash_value = false;
+      } else {
+        result += ",";
+      }
+      static char buffer[64];
+      auto[ptr, ec] = std::to_chars(buffer, buffer + sizeof(buffer),
+                                    val.first, /*base=*/
+                                    16);
+      assert(ec == std::errc());
+      auto hash_value = std::string(buffer, ptr);
+      if (kCheckPhaseShiftInGenerator &&
+          val.second != kNoPhaseShift) {
+        // hash value and phase shift id
+        result += "[\"" + hash_value + "\"," +
+            std::to_string(val.second) + "]";
+      } else {
+        // hash value only
+        result += "\"" + hash_value + "\"";
+      }
+    }
+  }
+  result += "]";
 
-		result += ",";
-		result += "[";
-		// std::to_chars for floating-point numbers is not supported by some
-		// compilers, including GCC with version < 11.
-		result += to_string_with_precision(original_fingerprint_.real(),
-		                                   /*precision=*/17);
-		result += ",";
-		result += to_string_with_precision(original_fingerprint_.imag(),
-		                                   /*precision=*/17);
-		result += "]";
+  result += ",";
+  result += "[";
+  // std::to_chars for floating-point numbers is not supported by some
+  // compilers, including GCC with version < 11.
+  result += to_string_with_precision(original_fingerprint_.real(),
+      /*precision=*/17);
+  result += ",";
+  result += to_string_with_precision(original_fingerprint_.imag(),
+      /*precision=*/17);
+  result += "]";
 
-		result += "],";
+  result += "],";
 
-		// gates
-		const int num_edges = (int)edges.size();
-		result += "[";
-		for (int i = 0; i < num_edges; i++) {
-			result += "[";
-			result += "\"" + gate_type_name(edges[i]->gate->tp) + "\", ";
-			if (edges[i]->output_nodes.size() == 1) {
-				result +=
-				    "[\"" + edges[i]->output_nodes[0]->to_string() + "\"],";
-			}
-			else if (edges[i]->output_nodes.size() == 2) {
-				result += "[\"" + edges[i]->output_nodes[0]->to_string();
-				result += "\", \"" + edges[i]->output_nodes[1]->to_string();
-				result += "\"],";
-			}
-			else {
-				assert(false && "A hyperedge should have 1 or 2 outputs.");
-			}
-			result += "[";
-			for (int j = 0; j < (int)edges[i]->input_nodes.size(); j++) {
-				result += "\"" + edges[i]->input_nodes[j]->to_string() + "\"";
-				if (j != (int)edges[i]->input_nodes.size() - 1) {
-					result += ", ";
-				}
-			}
-			result += "]]";
-			if (i + 1 != num_edges)
-				result += ",";
-		}
-		result += "]";
+  // gates
+  const int num_edges = (int) edges.size();
+  result += "[";
+  for (int i = 0; i < num_edges; i++) {
+    result += "[";
+    result += "\"" + gate_type_name(edges[i]->gate->tp) + "\", ";
+    if (edges[i]->output_nodes.size() == 1) {
+      result +=
+          "[\"" + edges[i]->output_nodes[0]->to_string() + "\"],";
+    } else if (edges[i]->output_nodes.size() == 2) {
+      result += "[\"" + edges[i]->output_nodes[0]->to_string();
+      result += "\", \"" + edges[i]->output_nodes[1]->to_string();
+      result += "\"],";
+    } else {
+      assert(false && "A hyperedge should have 1 or 2 outputs.");
+    }
+    result += "[";
+    for (int j = 0; j < (int) edges[i]->input_nodes.size(); j++) {
+      result += "\"" + edges[i]->input_nodes[j]->to_string() + "\"";
+      if (j != (int) edges[i]->input_nodes.size() - 1) {
+        result += ", ";
+      }
+    }
+    result += "]]";
+    if (i + 1 != num_edges)
+      result += ",";
+  }
+  result += "]";
 
-		result += "]\n";
-		return result;
-	}
+  result += "]\n";
+  return result;
+}
 
-	std::unique_ptr< DAG > DAG::read_json(Context *ctx, std::istream &fin) {
-		fin.ignore(std::numeric_limits< std::streamsize >::max(), '[');
+std::unique_ptr<DAG> DAG::read_json(Context *ctx, std::istream &fin) {
+  fin.ignore(std::numeric_limits<std::streamsize>::max(), '[');
 
-		// basic info
-		int num_dag_qubits, num_input_params, num_total_params, num_gates;
-		fin.ignore(std::numeric_limits< std::streamsize >::max(), '[');
-		fin >> num_dag_qubits;
-		fin.ignore(std::numeric_limits< std::streamsize >::max(), ',');
-		fin >> num_input_params;
-		fin.ignore(std::numeric_limits< std::streamsize >::max(), ',');
-		fin >> num_total_params;
-		fin.ignore(std::numeric_limits< std::streamsize >::max(), ',');
-		fin >> num_gates;
+  // basic info
+  int num_dag_qubits, num_input_params, num_total_params, num_gates;
+  fin.ignore(std::numeric_limits<std::streamsize>::max(), '[');
+  fin >> num_dag_qubits;
+  fin.ignore(std::numeric_limits<std::streamsize>::max(), ',');
+  fin >> num_input_params;
+  fin.ignore(std::numeric_limits<std::streamsize>::max(), ',');
+  fin >> num_total_params;
+  fin.ignore(std::numeric_limits<std::streamsize>::max(), ',');
+  fin >> num_gates;
 
-		// TODO: Do not generate the distribution here -- we should generate
-		//  earlier to make the result more deterministic.
-        ctx->get_and_gen_hashing_dis(num_dag_qubits);
-        ctx->get_and_gen_input_dis(num_dag_qubits);
-        ctx->get_and_gen_parameters(num_input_params);
+  // TODO: Do not generate the distribution here -- we should generate
+  //  earlier to make the result more deterministic.
+  ctx->get_and_gen_hashing_dis(num_dag_qubits);
+  ctx->get_and_gen_input_dis(num_dag_qubits);
+  ctx->get_and_gen_parameters(num_input_params);
 
-		// ignore other hash values
-		fin.ignore(std::numeric_limits< std::streamsize >::max(), '[');
-		while (true) {
-			char ch;
-			fin.get(ch);
-			while (ch != '[' && ch != ']') {
-				fin.get(ch);
-			}
-			if (ch == '[') {
-				// A hash value with a phase shift id.
-				fin.ignore(std::numeric_limits< std::streamsize >::max(), ']');
-			}
-			else {
-				// ch == ']'
-				break;
-			}
-		}
+  // ignore other hash values
+  fin.ignore(std::numeric_limits<std::streamsize>::max(), '[');
+  while (true) {
+    char ch;
+    fin.get(ch);
+    while (ch != '[' && ch != ']') {
+      fin.get(ch);
+    }
+    if (ch == '[') {
+      // A hash value with a phase shift id.
+      fin.ignore(std::numeric_limits<std::streamsize>::max(), ']');
+    } else {
+      // ch == ']'
+      break;
+    }
+  }
 
-		fin.ignore(std::numeric_limits< std::streamsize >::max(), ']');
-		fin.ignore(std::numeric_limits< std::streamsize >::max(), ',');
+  fin.ignore(std::numeric_limits<std::streamsize>::max(), ']');
+  fin.ignore(std::numeric_limits<std::streamsize>::max(), ',');
 
-		auto result = std::make_unique< DAG >(num_dag_qubits, num_input_params);
+  auto result = std::make_unique<DAG>(num_dag_qubits, num_input_params);
 
-		// gates
-		fin.ignore(std::numeric_limits< std::streamsize >::max(), '[');
-		while (true) {
-			char ch;
-			fin.get(ch);
-			while (ch != '[' && ch != ']') {
-				fin.get(ch);
-			}
-			if (ch == ']') {
-				break;
-			}
+  // gates
+  fin.ignore(std::numeric_limits<std::streamsize>::max(), '[');
+  while (true) {
+    char ch;
+    fin.get(ch);
+    while (ch != '[' && ch != ']') {
+      fin.get(ch);
+    }
+    if (ch == ']') {
+      break;
+    }
 
-			// New gate
-			fin.ignore(std::numeric_limits< std::streamsize >::max(), '\"');
-			std::string name;
-			std::getline(fin, name, '\"');
-			auto gate_type = to_gate_type(name);
-			Gate *gate = ctx->get_gate(gate_type);
+    // New gate
+    fin.ignore(std::numeric_limits<std::streamsize>::max(), '\"');
+    std::string name;
+    std::getline(fin, name, '\"');
+    auto gate_type = to_gate_type(name);
+    Gate *gate = ctx->get_gate(gate_type);
 
-			std::vector< int > input_qubits, input_params, output_qubits,
-			    output_params;
-			auto read_indices = [&](std::vector< int > &qubit_indices,
-			                        std::vector< int > &param_indices) {
-				fin.ignore(std::numeric_limits< std::streamsize >::max(), '[');
-				while (true) {
-					fin.get(ch);
-					while (ch != '\"' && ch != ']') {
-						fin.get(ch);
-					}
-					if (ch == ']') {
-						break;
-					}
+    std::vector<int> input_qubits, input_params, output_qubits,
+        output_params;
+    auto read_indices = [&](std::vector<int> &qubit_indices,
+                            std::vector<int> &param_indices) {
+      fin.ignore(std::numeric_limits<std::streamsize>::max(), '[');
+      while (true) {
+        fin.get(ch);
+        while (ch != '\"' && ch != ']') {
+          fin.get(ch);
+        }
+        if (ch == ']') {
+          break;
+        }
 
-					// New index
-					fin.get(ch);
-					assert(ch == 'P' || ch == 'Q');
-					int index;
-					fin >> index;
-					fin.ignore(); // '\"'
-					if (ch == 'Q') {
-						qubit_indices.push_back(index);
-					}
-					else {
-						param_indices.push_back(index);
-					}
-				}
-			};
-			read_indices(output_qubits, output_params);
-			read_indices(input_qubits, input_params);
-			fin.ignore(std::numeric_limits< std::streamsize >::max(), ']');
+        // New index
+        fin.get(ch);
+        assert(ch == 'P' || ch == 'Q');
+        int index;
+        fin >> index;
+        fin.ignore(); // '\"'
+        if (ch == 'Q') {
+          qubit_indices.push_back(index);
+        } else {
+          param_indices.push_back(index);
+        }
+      }
+    };
+    read_indices(output_qubits, output_params);
+    read_indices(input_qubits, input_params);
+    fin.ignore(std::numeric_limits<std::streamsize>::max(), ']');
 
-			int output_param_index;
-			result->add_gate(input_qubits, input_params, gate,
-			                 &output_param_index);
-			if (gate->is_parameter_gate()) {
-				assert(output_param_index == output_params[0]);
-			}
-		}
+    int output_param_index;
+    result->add_gate(input_qubits, input_params, gate,
+                     &output_param_index);
+    if (gate->is_parameter_gate()) {
+      assert(output_param_index == output_params[0]);
+    }
+  }
 
-		fin.ignore(std::numeric_limits< std::streamsize >::max(), ']');
+  fin.ignore(std::numeric_limits<std::streamsize>::max(), ']');
 
-		return result;
-	}
+  return result;
+}
 
 bool DAG::canonical_representation(std::unique_ptr<DAG> *output_dag,
                                    bool output) const {
@@ -1205,9 +1189,9 @@ bool DAG::canonical_representation(std::unique_ptr<DAG> *output_dag,
   return this_is_canonical_representation;
 }
 
-	bool DAG::is_canonical_representation() const {
-		return canonical_representation(nullptr, false);
-	}
+bool DAG::is_canonical_representation() const {
+  return canonical_representation(nullptr, false);
+}
 
 bool DAG::to_canonical_representation() {
   std::unique_ptr<DAG> output_dag;
@@ -1218,200 +1202,199 @@ bool DAG::to_canonical_representation() {
   return false;
 }
 
-	std::unique_ptr< DAG >
-	DAG::get_permuted_dag(const std::vector< int > &qubit_permutation,
-	                      const std::vector< int > &param_permutation) const {
-		auto result = std::make_unique< DAG >(0, 0);
-		result->clone_from(*this, qubit_permutation, param_permutation);
-		return result;
-	}
+std::unique_ptr<DAG>
+DAG::get_permuted_dag(const std::vector<int> &qubit_permutation,
+                      const std::vector<int> &param_permutation) const {
+  auto result = std::make_unique<DAG>(0, 0);
+  result->clone_from(*this, qubit_permutation, param_permutation);
+  return result;
+}
 
-	void DAG::clone_from(const DAG &other,
-	                     const std::vector< int > &qubit_permutation,
-	                     const std::vector< int > &param_permutation) {
-		num_qubits = other.num_qubits;
-		num_input_parameters = other.num_input_parameters;
-		hash_value_ = other.hash_value_;
-		other_hash_values_ = other.other_hash_values_;
-		hash_value_valid_ = other.hash_value_valid_;
-		original_fingerprint_ = other.original_fingerprint_;
-		std::unordered_map< DAGNode *, DAGNode * > nodes_mapping;
-		std::unordered_map< DAGHyperEdge *, DAGHyperEdge * > edges_mapping;
-		nodes.clear();
-		nodes.reserve(other.nodes.size());
-		edges.clear();
-		edges.reserve(other.edges.size());
-		outputs.clear();
-		outputs.reserve(other.outputs.size());
-		parameters.clear();
-		parameters.reserve(other.parameters.size());
-		if (qubit_permutation.empty() && param_permutation.empty()) {
-			for (int i = 0; i < (int)other.nodes.size(); i++) {
-				nodes.emplace_back(
-				    std::make_unique< DAGNode >(*(other.nodes[i])));
-				assert(nodes[i].get() !=
-				       other.nodes[i].get()); // make sure we make a copy
-				nodes_mapping[other.nodes[i].get()] = nodes[i].get();
-			}
-		}
-		else {
-			assert(qubit_permutation.size() == num_qubits);
-			nodes.resize(other.nodes.size());
-			for (int i = 0; i < num_qubits; i++) {
-				assert(qubit_permutation[i] >= 0 &&
-				       qubit_permutation[i] < num_qubits);
-				nodes[qubit_permutation[i]] =
-				    std::make_unique< DAGNode >(*(other.nodes[i]));
-				nodes[qubit_permutation[i]]->index =
-				    qubit_permutation[i]; // update index
-				assert(nodes[qubit_permutation[i]].get() !=
-				       other.nodes[i].get());
-				nodes_mapping[other.nodes[i].get()] =
-				    nodes[qubit_permutation[i]].get();
-			}
-			const int num_permuted_parameters =
-			    std::min(num_input_parameters, (int)param_permutation.size());
-			for (int i_inc = 0; i_inc < num_permuted_parameters; i_inc++) {
-				assert(param_permutation[i_inc] >= 0 &&
-				       param_permutation[i_inc] < num_input_parameters);
-				const int i = num_qubits + i_inc;
-				nodes[num_qubits + param_permutation[i_inc]] =
-				    std::make_unique< DAGNode >(*(other.nodes[i]));
-				nodes[num_qubits + param_permutation[i_inc]]->index =
-				    param_permutation[i_inc]; // update index
-				assert(nodes[num_qubits + param_permutation[i_inc]].get() !=
-				       other.nodes[i].get());
-				nodes_mapping[other.nodes[i].get()] =
-				    nodes[num_qubits + param_permutation[i_inc]].get();
-			}
-			for (int i = num_qubits + num_permuted_parameters;
-			     i < (int)other.nodes.size(); i++) {
-				nodes[i] = std::make_unique< DAGNode >(*(other.nodes[i]));
-				if (nodes[i]->is_qubit()) {
-					nodes[i]->index =
-					    qubit_permutation[nodes[i]->index]; // update index
-				}
-				assert(nodes[i].get() != other.nodes[i].get());
-				nodes_mapping[other.nodes[i].get()] = nodes[i].get();
-			}
-		}
-		for (int i = 0; i < (int)other.edges.size(); i++) {
-			edges.emplace_back(
-			    std::make_unique< DAGHyperEdge >(*(other.edges[i])));
-			assert(edges[i].get() != other.edges[i].get());
-			edges_mapping[other.edges[i].get()] = edges[i].get();
-		}
-		for (auto &node : nodes) {
-			for (auto &edge : node->input_edges) {
-				edge = edges_mapping[edge];
-			}
-			for (auto &edge : node->output_edges) {
-				edge = edges_mapping[edge];
-			}
-		}
-		for (auto &edge : edges) {
-			for (auto &node : edge->input_nodes) {
-				node = nodes_mapping[node];
-			}
-			for (auto &node : edge->output_nodes) {
-				node = nodes_mapping[node];
-			}
-		}
-		for (auto &node : other.outputs) {
-			outputs.emplace_back(nodes_mapping[node]);
-		}
-		for (auto &node : other.parameters) {
-			parameters.emplace_back(nodes_mapping[node]);
-		}
-	}
+void DAG::clone_from(const DAG &other,
+                     const std::vector<int> &qubit_permutation,
+                     const std::vector<int> &param_permutation) {
+  num_qubits = other.num_qubits;
+  num_input_parameters = other.num_input_parameters;
+  hash_value_ = other.hash_value_;
+  other_hash_values_ = other.other_hash_values_;
+  hash_value_valid_ = other.hash_value_valid_;
+  original_fingerprint_ = other.original_fingerprint_;
+  std::unordered_map<DAGNode *, DAGNode *> nodes_mapping;
+  std::unordered_map<DAGHyperEdge *, DAGHyperEdge *> edges_mapping;
+  nodes.clear();
+  nodes.reserve(other.nodes.size());
+  edges.clear();
+  edges.reserve(other.edges.size());
+  outputs.clear();
+  outputs.reserve(other.outputs.size());
+  parameters.clear();
+  parameters.reserve(other.parameters.size());
+  if (qubit_permutation.empty() && param_permutation.empty()) {
+    for (int i = 0; i < (int) other.nodes.size(); i++) {
+      nodes.emplace_back(
+          std::make_unique<DAGNode>(*(other.nodes[i])));
+      assert(nodes[i].get() !=
+          other.nodes[i].get()); // make sure we make a copy
+      nodes_mapping[other.nodes[i].get()] = nodes[i].get();
+    }
+  } else {
+    assert(qubit_permutation.size() == num_qubits);
+    nodes.resize(other.nodes.size());
+    for (int i = 0; i < num_qubits; i++) {
+      assert(qubit_permutation[i] >= 0 &&
+          qubit_permutation[i] < num_qubits);
+      nodes[qubit_permutation[i]] =
+          std::make_unique<DAGNode>(*(other.nodes[i]));
+      nodes[qubit_permutation[i]]->index =
+          qubit_permutation[i]; // update index
+      assert(nodes[qubit_permutation[i]].get() !=
+          other.nodes[i].get());
+      nodes_mapping[other.nodes[i].get()] =
+          nodes[qubit_permutation[i]].get();
+    }
+    const int num_permuted_parameters =
+        std::min(num_input_parameters, (int) param_permutation.size());
+    for (int i_inc = 0; i_inc < num_permuted_parameters; i_inc++) {
+      assert(param_permutation[i_inc] >= 0 &&
+          param_permutation[i_inc] < num_input_parameters);
+      const int i = num_qubits + i_inc;
+      nodes[num_qubits + param_permutation[i_inc]] =
+          std::make_unique<DAGNode>(*(other.nodes[i]));
+      nodes[num_qubits + param_permutation[i_inc]]->index =
+          param_permutation[i_inc]; // update index
+      assert(nodes[num_qubits + param_permutation[i_inc]].get() !=
+          other.nodes[i].get());
+      nodes_mapping[other.nodes[i].get()] =
+          nodes[num_qubits + param_permutation[i_inc]].get();
+    }
+    for (int i = num_qubits + num_permuted_parameters;
+         i < (int) other.nodes.size(); i++) {
+      nodes[i] = std::make_unique<DAGNode>(*(other.nodes[i]));
+      if (nodes[i]->is_qubit()) {
+        nodes[i]->index =
+            qubit_permutation[nodes[i]->index]; // update index
+      }
+      assert(nodes[i].get() != other.nodes[i].get());
+      nodes_mapping[other.nodes[i].get()] = nodes[i].get();
+    }
+  }
+  for (int i = 0; i < (int) other.edges.size(); i++) {
+    edges.emplace_back(
+        std::make_unique<DAGHyperEdge>(*(other.edges[i])));
+    assert(edges[i].get() != other.edges[i].get());
+    edges_mapping[other.edges[i].get()] = edges[i].get();
+  }
+  for (auto &node : nodes) {
+    for (auto &edge : node->input_edges) {
+      edge = edges_mapping[edge];
+    }
+    for (auto &edge : node->output_edges) {
+      edge = edges_mapping[edge];
+    }
+  }
+  for (auto &edge : edges) {
+    for (auto &node : edge->input_nodes) {
+      node = nodes_mapping[node];
+    }
+    for (auto &node : edge->output_nodes) {
+      node = nodes_mapping[node];
+    }
+  }
+  for (auto &node : other.outputs) {
+    outputs.emplace_back(nodes_mapping[node]);
+  }
+  for (auto &node : other.parameters) {
+    parameters.emplace_back(nodes_mapping[node]);
+  }
+}
 
-	std::vector< DAGHyperEdge * > DAG::first_quantum_gates() const {
-		std::vector< DAGHyperEdge * > result;
-		std::unordered_set< DAGHyperEdge * > depend_on_other_gates;
-		depend_on_other_gates.reserve(edges.size());
-		for (const auto &edge : edges) {
-			if (edge->gate->is_parameter_gate()) {
-				continue;
-			}
-			if (depend_on_other_gates.find(edge.get()) ==
-			    depend_on_other_gates.end()) {
-				result.push_back(edge.get());
-			}
-			for (const auto &output_node : edge->output_nodes) {
-				for (const auto &output_edge : output_node->output_edges) {
-					depend_on_other_gates.insert(output_edge);
-				}
-			}
-		}
-		return result;
-	}
+std::vector<DAGHyperEdge *> DAG::first_quantum_gates() const {
+  std::vector<DAGHyperEdge *> result;
+  std::unordered_set<DAGHyperEdge *> depend_on_other_gates;
+  depend_on_other_gates.reserve(edges.size());
+  for (const auto &edge : edges) {
+    if (edge->gate->is_parameter_gate()) {
+      continue;
+    }
+    if (depend_on_other_gates.find(edge.get()) ==
+        depend_on_other_gates.end()) {
+      result.push_back(edge.get());
+    }
+    for (const auto &output_node : edge->output_nodes) {
+      for (const auto &output_edge : output_node->output_edges) {
+        depend_on_other_gates.insert(output_edge);
+      }
+    }
+  }
+  return result;
+}
 
-	std::vector< DAGHyperEdge * > DAG::last_quantum_gates() const {
-		std::vector< DAGHyperEdge * > result;
-		for (const auto &edge : edges) {
-			if (edge->gate->is_parameter_gate()) {
-				continue;
-			}
-			bool all_output = true;
-			for (const auto &output_node : edge->output_nodes) {
-				if (outputs[output_node->index] != output_node) {
-					all_output = false;
-					break;
-				}
-			}
-			if (all_output) {
-				result.push_back(edge.get());
-			}
-		}
-		return result;
-	}
+std::vector<DAGHyperEdge *> DAG::last_quantum_gates() const {
+  std::vector<DAGHyperEdge *> result;
+  for (const auto &edge : edges) {
+    if (edge->gate->is_parameter_gate()) {
+      continue;
+    }
+    bool all_output = true;
+    for (const auto &output_node : edge->output_nodes) {
+      if (outputs[output_node->index] != output_node) {
+        all_output = false;
+        break;
+      }
+    }
+    if (all_output) {
+      result.push_back(edge.get());
+    }
+  }
+  return result;
+}
 
-	bool DAG::same_gate(const DAG &dag1, int index1, const DAG &dag2,
-	                    int index2) {
-		assert(dag1.get_num_gates() > index1);
-		assert(dag2.get_num_gates() > index2);
-		return same_gate(dag1.edges[index1].get(), dag2.edges[index2].get());
-	}
+bool DAG::same_gate(const DAG &dag1, int index1, const DAG &dag2,
+                    int index2) {
+  assert(dag1.get_num_gates() > index1);
+  assert(dag2.get_num_gates() > index2);
+  return same_gate(dag1.edges[index1].get(), dag2.edges[index2].get());
+}
 
-	bool DAG::same_gate(DAGHyperEdge *edge1, DAGHyperEdge *edge2) {
-		if (edge1->gate != edge2->gate) {
-			return false;
-		}
-		if (edge1->input_nodes.size() != edge2->input_nodes.size()) {
-			return false;
-		}
-		if (edge1->output_nodes.size() != edge2->output_nodes.size()) {
-			return false;
-		}
-		for (int i = 0; i < (int)edge1->output_nodes.size(); i++) {
-			if (edge1->output_nodes[i]->type != edge2->output_nodes[i]->type) {
-				return false;
-			}
-			if (edge1->output_nodes[i]->index !=
-			        edge2->output_nodes[i]->index &&
-			    edge1->output_nodes[i]->type != DAGNode::internal_param) {
-				return false;
-			}
-		}
-		for (int i = 0; i < (int)edge1->input_nodes.size(); i++) {
-			if (edge1->input_nodes[i]->type != edge2->input_nodes[i]->type) {
-				return false;
-			}
-			if (edge1->input_nodes[i]->index != edge2->input_nodes[i]->index &&
-			    edge1->input_nodes[i]->type != DAGNode::internal_param) {
-				return false;
-			}
-			if (edge1->input_nodes[i]->type == DAGNode::internal_param) {
-				// Internal parameters are checked recursively.
-				assert(edge1->input_nodes[i]->input_edges.size() == 1);
-				assert(edge2->input_nodes[i]->input_edges.size() == 1);
-				if (!same_gate(edge1->input_nodes[i]->input_edges[0],
-				               edge2->input_nodes[i]->input_edges[0])) {
-					return false;
-				}
-			}
-		}
-		return true;
-	}
+bool DAG::same_gate(DAGHyperEdge *edge1, DAGHyperEdge *edge2) {
+  if (edge1->gate != edge2->gate) {
+    return false;
+  }
+  if (edge1->input_nodes.size() != edge2->input_nodes.size()) {
+    return false;
+  }
+  if (edge1->output_nodes.size() != edge2->output_nodes.size()) {
+    return false;
+  }
+  for (int i = 0; i < (int) edge1->output_nodes.size(); i++) {
+    if (edge1->output_nodes[i]->type != edge2->output_nodes[i]->type) {
+      return false;
+    }
+    if (edge1->output_nodes[i]->index !=
+        edge2->output_nodes[i]->index &&
+        edge1->output_nodes[i]->type != DAGNode::internal_param) {
+      return false;
+    }
+  }
+  for (int i = 0; i < (int) edge1->input_nodes.size(); i++) {
+    if (edge1->input_nodes[i]->type != edge2->input_nodes[i]->type) {
+      return false;
+    }
+    if (edge1->input_nodes[i]->index != edge2->input_nodes[i]->index &&
+        edge1->input_nodes[i]->type != DAGNode::internal_param) {
+      return false;
+    }
+    if (edge1->input_nodes[i]->type == DAGNode::internal_param) {
+      // Internal parameters are checked recursively.
+      assert(edge1->input_nodes[i]->input_edges.size() == 1);
+      assert(edge2->input_nodes[i]->input_edges.size() == 1);
+      if (!same_gate(edge1->input_nodes[i]->input_edges[0],
+                     edge2->input_nodes[i]->input_edges[0])) {
+        return false;
+      }
+    }
+  }
+  return true;
+}
 
 } // namespace quartz

--- a/src/quartz/dag/dag.h
+++ b/src/quartz/dag/dag.h
@@ -11,186 +11,186 @@
 
 namespace quartz {
 
-	class Context;
+class Context;
 
-	class DAG {
-	public:
-		DAG(int num_qubits, int num_input_parameters);
-		DAG(const DAG &other); // clone a DAG
-		[[nodiscard]] std::unique_ptr< DAG > clone() const;
-		[[nodiscard]] bool fully_equivalent(const DAG &other) const;
-		[[nodiscard]] bool fully_equivalent(Context *ctx, DAG &other);
-		[[nodiscard]] bool less_than(const DAG &other) const;
+class DAG {
+ public:
+  DAG(int num_qubits, int num_input_parameters);
+  DAG(const DAG &other); // clone a DAG
+  [[nodiscard]] std::unique_ptr<DAG> clone() const;
+  [[nodiscard]] bool fully_equivalent(const DAG &other) const;
+  [[nodiscard]] bool fully_equivalent(Context *ctx, DAG &other);
+  [[nodiscard]] bool less_than(const DAG &other) const;
 
-		bool add_gate(const std::vector< int > &qubit_indices,
-		              const std::vector< int > &parameter_indices, Gate *gate,
-		              int *output_para_index);
-		void add_input_parameter();
-		bool remove_last_gate();
+  bool add_gate(const std::vector<int> &qubit_indices,
+                const std::vector<int> &parameter_indices, Gate *gate,
+                int *output_para_index);
+  void add_input_parameter();
+  bool remove_last_gate();
 
-		// Generate all possible parameter gates at the beginning.
-		// TODO: Currently we only support |max_recursion_depth == 1|.
-		void generate_parameter_gates(Context *ctx,
-		                              int max_recursion_depth = 1);
+  // Generate all possible parameter gates at the beginning.
+  // TODO: Currently we only support |max_recursion_depth == 1|.
+  void generate_parameter_gates(Context *ctx,
+                                int max_recursion_depth = 1);
 
-		// Return the total number of gates removed.
-		// The time complexity is O((number of gates removed) *
-		// ((total number of nodes) + (total number of edges))).
-		int remove_gate(DAGHyperEdge *edge);
-		int remove_first_quantum_gate();
-		// Evaluate the output distribution given input distribution and
-		// input parameters. Also output all parameter values (including input
-		// and internal parameters) when |parameter_values| is not nullptr.
-		bool
-		evaluate(const Vector &input_dis,
-		         const std::vector< ParamType > &input_parameters,
-		         Vector &output_dis,
-		         std::vector< ParamType > *parameter_values = nullptr) const;
-		[[nodiscard]] int get_num_qubits() const;
-		[[nodiscard]] int get_num_input_parameters() const;
-		[[nodiscard]] int get_num_total_parameters() const;
-		[[nodiscard]] int get_num_internal_parameters() const;
-		[[nodiscard]] int get_num_gates() const;
-		[[nodiscard]] bool qubit_used(int qubit_index) const;
-		// Used by a parameter gate is considered as used here.
-		[[nodiscard]] bool input_param_used(int param_index) const;
-		// Returns a pair. The first component denotes the input parameters
-		// already used in this DAG. The second component denotes the input
-		// parameters used in each of the parameters in this DAG.
-        [[nodiscard]] std::pair<InputParamMaskType,
-                                std::vector<InputParamMaskType>> get_input_param_mask() const;
-		DAGHashType hash(Context *ctx);
-        // Evaluate the output distribution 2^|num_qubits| times, with the i-th
-        // time the input distribution being a vector with only the i-th entry
-        // equals to 1 and all other entries equal to 0.
-        [[nodiscard]] std::vector<Vector> get_matrix(Context *ctx) const;
-		[[nodiscard]] bool hash_value_valid() const;
-		[[nodiscard]] DAGHashType cached_hash_value() const;
-		[[nodiscard]] std::vector< DAGHashType > other_hash_values() const;
-		[[nodiscard]] std::vector< std::pair< DAGHashType, PhaseShiftIdType > >
-		other_hash_values_with_phase_shift_id() const;
+  // Return the total number of gates removed.
+  // The time complexity is O((number of gates removed) *
+  // ((total number of nodes) + (total number of edges))).
+  int remove_gate(DAGHyperEdge *edge);
+  int remove_first_quantum_gate();
+  // Evaluate the output distribution given input distribution and
+  // input parameters. Also output all parameter values (including input
+  // and internal parameters) when |parameter_values| is not nullptr.
+  bool
+  evaluate(const Vector &input_dis,
+           const std::vector<ParamType> &input_parameters,
+           Vector &output_dis,
+           std::vector<ParamType> *parameter_values = nullptr) const;
+  [[nodiscard]] int get_num_qubits() const;
+  [[nodiscard]] int get_num_input_parameters() const;
+  [[nodiscard]] int get_num_total_parameters() const;
+  [[nodiscard]] int get_num_internal_parameters() const;
+  [[nodiscard]] int get_num_gates() const;
+  [[nodiscard]] bool qubit_used(int qubit_index) const;
+  // Used by a parameter gate is considered as used here.
+  [[nodiscard]] bool input_param_used(int param_index) const;
+  // Returns a pair. The first component denotes the input parameters
+  // already used in this DAG. The second component denotes the input
+  // parameters used in each of the parameters in this DAG.
+  [[nodiscard]] std::pair<InputParamMaskType,
+                          std::vector<InputParamMaskType>> get_input_param_mask() const;
+  DAGHashType hash(Context *ctx);
+  // Evaluate the output distribution 2^|num_qubits| times, with the i-th
+  // time the input distribution being a vector with only the i-th entry
+  // equals to 1 and all other entries equal to 0.
+  [[nodiscard]] std::vector<Vector> get_matrix(Context *ctx) const;
+  [[nodiscard]] bool hash_value_valid() const;
+  [[nodiscard]] DAGHashType cached_hash_value() const;
+  [[nodiscard]] std::vector<DAGHashType> other_hash_values() const;
+  [[nodiscard]] std::vector<std::pair<DAGHashType, PhaseShiftIdType> >
+  other_hash_values_with_phase_shift_id() const;
 
-		// Remove the qubit set of |unused_qubits|, given that they are unused.
-		// Returns false iff an error occurs.
-		bool remove_unused_qubits(std::vector< int > unused_qubits);
+  // Remove the qubit set of |unused_qubits|, given that they are unused.
+  // Returns false iff an error occurs.
+  bool remove_unused_qubits(std::vector<int> unused_qubits);
 
-		// Remove the parameter set of |unused_input_params|, given that they
-		// are unused input parameters Returns false iff an error occurs.
-		bool remove_unused_input_params(std::vector< int > unused_input_params);
+  // Remove the parameter set of |unused_input_params|, given that they
+  // are unused input parameters Returns false iff an error occurs.
+  bool remove_unused_input_params(std::vector<int> unused_input_params);
 
-		// Remove a suffix of unused input parameters.
-		DAG &shrink_unused_input_parameters();
-		[[nodiscard]] std::unique_ptr< DAG >
-		clone_and_shrink_unused_input_parameters() const;
-		[[nodiscard]] bool has_unused_parameter() const;
-		// Returns the number of internal parameters removed.
-		int remove_unused_internal_parameters();
-		void print(Context *ctx) const;
-		[[nodiscard]] std::string to_string() const;
-		[[nodiscard]] std::string to_json() const;
-		static std::unique_ptr< DAG > read_json(Context *ctx,
-		                                        std::istream &fin);
+  // Remove a suffix of unused input parameters.
+  DAG &shrink_unused_input_parameters();
+  [[nodiscard]] std::unique_ptr<DAG>
+  clone_and_shrink_unused_input_parameters() const;
+  [[nodiscard]] bool has_unused_parameter() const;
+  // Returns the number of internal parameters removed.
+  int remove_unused_internal_parameters();
+  void print(Context *ctx) const;
+  [[nodiscard]] std::string to_string() const;
+  [[nodiscard]] std::string to_json() const;
+  static std::unique_ptr<DAG> read_json(Context *ctx,
+                                        std::istream &fin);
 
-		// Returns true iff the DAG is already under the canonical
-		// representation.
-		// Canonical representation is a sequence representation of a
-		// circuit such that the sequence is the lexicographically smallest
-        // topological order of the circuit, where the gates are compared by:
-		// 1. The qubit indices in lexicographical order.
-        //    If the smallest qubit indices two gates operate on
-        //    are different, the gate with the smaller one is considered
-        //    smaller. For example,
-        //      (q1, q4) < (q2, q3);
-        //      (q1, q3) < (q1, q4);
-        //      (q1, q3) < (q2);
-        //      (q1) < (q1, q3).
-        //    Note that two gates operating on the same qubit is impossible
-        //    for the topological order of one circuit, but we still define it
-        //    for the completeness of comparing different circuits.
-        // 2. If the qubit indices are all the same, compare the gate type.
-        //
-		// The parameter "gates" are placed at the beginning.
-        //
-		// If |output| is true, store the canonical representation into
-		// |output_dag|.
-		// The parameter |output_dag| should be a pointer containing nullptr
-		// (otherwise its content will be deleted).
-		// This functions guarantees that if and only if two sequence
-        // representations share the same canonical representation, they have
-        // the same circuit representation.
-		bool canonical_representation(std::unique_ptr<DAG > *output_dag,
-                                      bool output = true) const;
-		[[nodiscard]] bool is_canonical_representation() const;
-		// Returns true iff this is NOT canonical representation
-		// (so the function changes this DAG to canonical representation).
-		bool to_canonical_representation();
-		[[nodiscard]] std::unique_ptr< DAG >
-		get_permuted_dag(const std::vector< int > &qubit_permutation,
-		                 const std::vector< int > &param_permutation) const;
+  // Returns true iff the DAG is already under the canonical
+  // representation.
+  // Canonical representation is a sequence representation of a
+  // circuit such that the sequence is the lexicographically smallest
+  // topological order of the circuit, where the gates are compared by:
+  // 1. The qubit indices in lexicographical order.
+  //    If the smallest qubit indices two gates operate on
+  //    are different, the gate with the smaller one is considered
+  //    smaller. For example,
+  //      (q1, q4) < (q2, q3);
+  //      (q1, q3) < (q1, q4);
+  //      (q1, q3) < (q2);
+  //      (q1) < (q1, q3).
+  //    Note that two gates operating on the same qubit is impossible
+  //    for the topological order of one circuit, but we still define it
+  //    for the completeness of comparing different circuits.
+  // 2. If the qubit indices are all the same, compare the gate type.
+  //
+  // The parameter "gates" are placed at the beginning.
+  //
+  // If |output| is true, store the canonical representation into
+  // |output_dag|.
+  // The parameter |output_dag| should be a pointer containing nullptr
+  // (otherwise its content will be deleted).
+  // This functions guarantees that if and only if two sequence
+  // representations share the same canonical representation, they have
+  // the same circuit representation.
+  bool canonical_representation(std::unique_ptr<DAG> *output_dag,
+                                bool output = true) const;
+  [[nodiscard]] bool is_canonical_representation() const;
+  // Returns true iff this is NOT canonical representation
+  // (so the function changes this DAG to canonical representation).
+  bool to_canonical_representation();
+  [[nodiscard]] std::unique_ptr<DAG>
+  get_permuted_dag(const std::vector<int> &qubit_permutation,
+                   const std::vector<int> &param_permutation) const;
 
-		// Returns quantum gates which do not topologically depend on any other
-		// quantum gates.
-		std::vector< DAGHyperEdge * > first_quantum_gates() const;
-		// Returns quantum gates which can appear at last in some topological
-		// order of the DAG.
-		std::vector< DAGHyperEdge * > last_quantum_gates() const;
+  // Returns quantum gates which do not topologically depend on any other
+  // quantum gates.
+  std::vector<DAGHyperEdge *> first_quantum_gates() const;
+  // Returns quantum gates which can appear at last in some topological
+  // order of the DAG.
+  std::vector<DAGHyperEdge *> last_quantum_gates() const;
 
-		static bool same_gate(const DAG &dag1, int index1, const DAG &dag2,
-		                      int index2);
+  static bool same_gate(const DAG &dag1, int index1, const DAG &dag2,
+                        int index2);
 
-		static bool same_gate(DAGHyperEdge *edge1, DAGHyperEdge *edge2);
+  static bool same_gate(DAGHyperEdge *edge1, DAGHyperEdge *edge2);
 
-	private:
-		void clone_from(const DAG &other,
-		                const std::vector< int > &qubit_permutation,
-		                const std::vector< int > &param_permutation);
+ private:
+  void clone_from(const DAG &other,
+                  const std::vector<int> &qubit_permutation,
+                  const std::vector<int> &param_permutation);
 
-		// A helper function used by |DAGHashType hash(Context *ctx)|.
-		static void generate_hash_values(
-		    Context *ctx, const ComplexType &hash_value,
-		    const PhaseShiftIdType &phase_shift_id,
-		    const std::vector< ParamType > &param_values,
-		    DAGHashType *main_hash,
-		    std::vector< std::pair< DAGHashType, PhaseShiftIdType > >
-		        *other_hash);
+  // A helper function used by |DAGHashType hash(Context *ctx)|.
+  static void generate_hash_values(
+      Context *ctx, const ComplexType &hash_value,
+      const PhaseShiftIdType &phase_shift_id,
+      const std::vector<ParamType> &param_values,
+      DAGHashType *main_hash,
+      std::vector<std::pair<DAGHashType, PhaseShiftIdType> >
+      *other_hash);
 
-	public:
-		std::vector< std::unique_ptr< DAGNode > > nodes;
-		std::vector< std::unique_ptr< DAGHyperEdge > > edges;
-		// The gates' information is owned by edges.
-		std::vector< DAGNode * > outputs;
-		std::vector< DAGNode * > parameters;
+ public:
+  std::vector<std::unique_ptr<DAGNode> > nodes;
+  std::vector<std::unique_ptr<DAGHyperEdge> > edges;
+  // The gates' information is owned by edges.
+  std::vector<DAGNode *> outputs;
+  std::vector<DAGNode *> parameters;
 
-	private:
-		int num_qubits, num_input_parameters;
-		DAGHashType hash_value_;
-		// For both floating-point error tolerance
-		// and equivalences under a phase shift.
-		// The first component of the pair is the hash value,
-		// and the second component is the id of the phase shifted.
-		// For now, the id is hard-coded as follows:
-		//   - |kNoPhaseShift|: no shift
-		//   - p \in [0, get_num_total_parameters()):
-		//       shifted by e^(i * (p-th parameter))
-		//   - p \in [get_num_total_parameters(), 2 *
-		//   get_num_total_parameters()):
-		//       shifted by e^(-i * ((p - get_num_total_parameters())-th
-		//       parameter))
-		std::vector< std::pair< DAGHashType, PhaseShiftIdType > >
-		    other_hash_values_;
-		ComplexType original_fingerprint_;
-		bool hash_value_valid_;
-	};
+ private:
+  int num_qubits, num_input_parameters;
+  DAGHashType hash_value_;
+  // For both floating-point error tolerance
+  // and equivalences under a phase shift.
+  // The first component of the pair is the hash value,
+  // and the second component is the id of the phase shifted.
+  // For now, the id is hard-coded as follows:
+  //   - |kNoPhaseShift|: no shift
+  //   - p \in [0, get_num_total_parameters()):
+  //       shifted by e^(i * (p-th parameter))
+  //   - p \in [get_num_total_parameters(), 2 *
+  //   get_num_total_parameters()):
+  //       shifted by e^(-i * ((p - get_num_total_parameters())-th
+  //       parameter))
+  std::vector<std::pair<DAGHashType, PhaseShiftIdType> >
+      other_hash_values_;
+  ComplexType original_fingerprint_;
+  bool hash_value_valid_;
+};
 
-	class UniquePtrDAGComparator {
-	public:
-		bool operator()(const std::unique_ptr< DAG > &dag1,
-		                const std::unique_ptr< DAG > &dag2) const {
-			if (!dag1 || !dag2) {
-				// nullptr
-				return !dag2;
-			}
-			return dag1->less_than(*dag2);
-		}
-	};
+class UniquePtrDAGComparator {
+ public:
+  bool operator()(const std::unique_ptr<DAG> &dag1,
+                  const std::unique_ptr<DAG> &dag2) const {
+    if (!dag1 || !dag2) {
+      // nullptr
+      return !dag2;
+    }
+    return dag1->less_than(*dag2);
+  }
+};
 } // namespace quartz

--- a/src/quartz/dag/dag.h
+++ b/src/quartz/dag/dag.h
@@ -104,6 +104,9 @@ namespace quartz {
         //      (q1, q3) < (q1, q4);
         //      (q1, q3) < (q2);
         //      (q1) < (q1, q3).
+        //    Note that two gates operating on the same qubit is impossible
+        //    for the topological order of one circuit, but we still define it
+        //    for the completeness of comparing different circuits.
         // 2. If the qubit indices are all the same, compare the gate type.
         //
 		// The parameter "gates" are placed at the beginning.

--- a/src/quartz/dag/dag.h
+++ b/src/quartz/dag/dag.h
@@ -121,6 +121,9 @@ namespace quartz {
 		bool canonical_representation(std::unique_ptr<DAG > *output_dag,
                                       bool output = true) const;
 		[[nodiscard]] bool is_canonical_representation() const;
+		// Returns true iff this is NOT canonical representation
+		// (so the function changes this DAG to canonical representation).
+		bool to_canonical_representation();
 		[[nodiscard]] std::unique_ptr< DAG >
 		get_permuted_dag(const std::vector< int > &qubit_permutation,
 		                 const std::vector< int > &param_permutation) const;

--- a/src/quartz/dag/dag.h
+++ b/src/quartz/dag/dag.h
@@ -91,27 +91,33 @@ namespace quartz {
 		static std::unique_ptr< DAG > read_json(Context *ctx,
 		                                        std::istream &fin);
 
-		// Returns true iff the DAG is already under the minimal circuit
+		// Returns true iff the DAG is already under the canonical
 		// representation.
-		// Minimal circuit representation is a sequence representation of a
-		// circuit such that:
-		// 1. The gates are ordered column by column. If we see each circuit as
-		//    a grid of gates such that each row represents a qubit, and put
-		//    each gate at the leftmost possible position, gate A is placed
-		//    before gate B iff A is in a column before B or they are in the
-		//    same column and the smallest qubit index of A is smaller than the
-		//    smallest qubit index of B.
-		// 2. The parameter "gates" are placed at the beginning.
-		// If |output| is true, store the minimal circuit representation into
+		// Canonical representation is a sequence representation of a
+		// circuit such that the sequence is the lexicographically smallest
+        // topological order of the circuit, where the gates are compared by:
+		// 1. The qubit indices in lexicographical order.
+        //    If the smallest qubit indices two gates operate on
+        //    are different, the gate with the smaller one is considered
+        //    smaller. For example,
+        //      (q1, q4) < (q2, q3);
+        //      (q1, q3) < (q1, q4);
+        //      (q1, q3) < (q2);
+        //      (q1) < (q1, q3).
+        // 2. If the qubit indices are all the same, compare the gate type.
+        //
+		// The parameter "gates" are placed at the beginning.
+        //
+		// If |output| is true, store the canonical representation into
 		// |output_dag|.
 		// The parameter |output_dag| should be a pointer containing nullptr
 		// (otherwise its content will be deleted).
-		// This functions guarantees that if two sequence representations
-		// share the same "minimal_circuit_representation", they have the same
-		// circuit representation.
-		bool minimal_circuit_representation(std::unique_ptr< DAG > *output_dag,
-		                                    bool output = true) const;
-		[[nodiscard]] bool is_minimal_circuit_representation() const;
+		// This functions guarantees that if and only if two sequence
+        // representations share the same canonical representation, they have
+        // the same circuit representation.
+		bool canonical_representation(std::unique_ptr<DAG > *output_dag,
+                                      bool output = true) const;
+		[[nodiscard]] bool is_canonical_representation() const;
 		[[nodiscard]] std::unique_ptr< DAG >
 		get_permuted_dag(const std::vector< int > &qubit_permutation,
 		                 const std::vector< int > &param_permutation) const;

--- a/src/quartz/dataset/dataset.cpp
+++ b/src/quartz/dataset/dataset.cpp
@@ -108,7 +108,7 @@ int Dataset::remove_singletons(Context *ctx) {
   return num_removed;
 }
 
-int Dataset::normalize_to_minimal_circuit_representations(Context *ctx) {
+int Dataset::normalize_to_canonical_representations(Context *ctx) {
   int num_removed = 0;
   std::vector<std::unique_ptr<DAG> > dags_to_insert_afterwards;
   auto dag_already_exists =
@@ -130,8 +130,8 @@ int Dataset::normalize_to_minimal_circuit_representations(Context *ctx) {
     std::unique_ptr<DAG> new_dag;
 
     for (auto &dag : dags) {
-      bool is_minimal = dag->minimal_circuit_representation(&new_dag);
-      if (!is_minimal) {
+      bool is_canonical = dag->canonical_representation(&new_dag);
+      if (!is_canonical) {
         if (!dag_already_exists(*new_dag, new_dags)) {
           new_dags.push_back(std::move(new_dag));
         }

--- a/src/quartz/dataset/dataset.h
+++ b/src/quartz/dataset/dataset.h
@@ -14,9 +14,9 @@ namespace quartz {
 		// Return the number of DAGs removed.
 		int remove_singletons(Context *ctx);
 
-		// Normalize each DAG to have the minimal circuit representation.
+		// Normalize each DAG to have the canonical representation.
 		// Return the number of DAGs removed.
-		int normalize_to_minimal_circuit_representations(Context *ctx);
+		int normalize_to_canonical_representations(Context *ctx);
 
 		// This function runs in O(1).
 		[[nodiscard]] int num_hash_values() const;

--- a/src/quartz/dataset/equivalence_set.cpp
+++ b/src/quartz/dataset/equivalence_set.cpp
@@ -461,7 +461,7 @@ namespace quartz {
 				break;
 			}
 			if (normalize_to_minimal_circuit_representation &&
-			    normalize_to_minimal_circuit_representations(ctx, verbose)) {
+                normalize_to_canonical_representations(ctx, verbose)) {
 				remaining_optimizations = kNumOptimizationsToPerform;
 				ever_simplified = true;
 			}
@@ -549,7 +549,7 @@ namespace quartz {
 	}
 
 	int
-	EquivalenceSet::normalize_to_minimal_circuit_representations(Context *ctx, bool verbose) {
+	EquivalenceSet::normalize_to_canonical_representations(Context *ctx, bool verbose) {
 		int num_class_modified = 0;
 		for (auto &item : classes_) {
 			auto dags = item->extract();
@@ -558,7 +558,7 @@ namespace quartz {
 			std::unordered_set< DAGHashType > hash_values_to_remove;
 			int class_modified = 0;
 			for (auto &dag : dags) {
-				bool is_minimal = dag->minimal_circuit_representation(&new_dag);
+				bool is_minimal = dag->canonical_representation(&new_dag);
 				if (!is_minimal) {
 					class_modified++;
 					new_dags.push_back(std::move(new_dag));

--- a/src/quartz/dataset/equivalence_set.h
+++ b/src/quartz/dataset/equivalence_set.h
@@ -105,9 +105,9 @@ namespace quartz {
 		// Return the number of equivalent classes removed.
 		int remove_singletons(Context *ctx, bool verbose = false);
 
-		// Normalize each DAG to have the minimal circuit representation.
+		// Normalize each DAG to have the canonical representation.
 		// Return the number of equivalent classes modified.
-		int normalize_to_minimal_circuit_representations(Context *ctx, bool verbose = false);
+		int normalize_to_canonical_representations(Context *ctx, bool verbose = false);
 
 		// Remove unused internal parameters.
 		// Return the number of equivalent classes modified.

--- a/src/quartz/gate/gate.cpp
+++ b/src/quartz/gate/gate.cpp
@@ -21,6 +21,8 @@ namespace quartz {
 
 	bool Gate::is_commutative() const { return false; }
 
+    bool Gate::is_symmetric() const { return false; }
+
 	int Gate::get_num_qubits() const { return num_qubits; }
 
 	int Gate::get_num_parameters() const { return num_parameters; }

--- a/src/quartz/gate/gate.h
+++ b/src/quartz/gate/gate.h
@@ -17,6 +17,8 @@ namespace quartz {
 		virtual ParamType compute(const std::vector< ParamType > &input_params);
 		[[nodiscard]] virtual bool
 		is_commutative() const; // for traditional gates
+        [[nodiscard]] virtual bool
+        is_symmetric() const; // for 2-qubit gates; currently unused (always false)
 		[[nodiscard]] int get_num_qubits() const;
 		[[nodiscard]] int get_num_parameters() const;
 		[[nodiscard]] bool is_parameter_gate() const;

--- a/src/quartz/generator/generator.cpp
+++ b/src/quartz/generator/generator.cpp
@@ -4,637 +4,624 @@
 #include <cassert>
 
 namespace quartz {
-	void Generator::generate_dfs(int num_qubits, int max_num_input_parameters,
-	                             int max_num_quantum_gates,
-	                             int max_num_param_gates, Dataset &dataset,
-	                             bool restrict_search_space,
-	                             bool unique_parameters) {
-		DAG *dag = new DAG(num_qubits, max_num_input_parameters);
-		// Generate all possible parameter gates at the beginning.
-		assert(max_num_param_gates == 1);
-		dag->generate_parameter_gates(context);
-		// We need a large vector for both input and internal parameters.
-		// std::vector<int> used_parameters(max_num_input_parameters +
-		// max_num_param_gates, 0);
-		std::vector< int > used_parameters(dag->get_num_total_parameters(), 0);
-		dfs(0, max_num_quantum_gates, max_num_param_gates, dag, used_parameters,
-		    dataset, restrict_search_space, unique_parameters);
-		delete dag;
-	}
+void Generator::generate_dfs(int num_qubits, int max_num_input_parameters,
+                             int max_num_quantum_gates,
+                             int max_num_param_gates, Dataset &dataset,
+                             bool restrict_search_space,
+                             bool unique_parameters) {
+  DAG *dag = new DAG(num_qubits, max_num_input_parameters);
+  // Generate all possible parameter gates at the beginning.
+  assert(max_num_param_gates == 1);
+  dag->generate_parameter_gates(context);
+  // We need a large vector for both input and internal parameters.
+  // std::vector<int> used_parameters(max_num_input_parameters +
+  // max_num_param_gates, 0);
+  std::vector<int> used_parameters(dag->get_num_total_parameters(), 0);
+  dfs(0, max_num_quantum_gates, max_num_param_gates, dag, used_parameters,
+      dataset, restrict_search_space, unique_parameters);
+  delete dag;
+}
 
-	void Generator::generate(int num_qubits, int num_input_parameters,
-	                         int max_num_quantum_gates, int max_num_param_gates,
-	                         Dataset *dataset, bool verify_equivalences,
-                             EquivalenceSet *equiv_set, bool unique_parameters,
-                             bool verbose, decltype(std::chrono::steady_clock::now()
-        - std::chrono::steady_clock::now()) *record_verification_time) {
-		auto empty_dag =
-		    std::make_unique< DAG >(num_qubits, num_input_parameters);
-		// Generate all possible parameter gates at the beginning.
-		assert(max_num_param_gates == 1);
-		empty_dag->generate_parameter_gates(context);
-		empty_dag->hash(context); // generate other hash values
-		std::vector< DAG * > dags_to_search(1, empty_dag.get());
-		if (verify_equivalences) {
-			assert(equiv_set);
-			auto equiv_class = std::make_unique< EquivalenceClass >();
-			equiv_class->insert(std::make_unique< DAG >(*empty_dag));
-			equiv_set->insert_class(context, std::move(equiv_class));
-		}
-		else {
-			context->set_representative(std::make_unique< DAG >(*empty_dag));
-		}
-		dataset->insert(context, std::move(empty_dag));
-		std::vector< std::vector< DAG * > > dags(1, dags_to_search);
+void Generator::generate(int num_qubits, int num_input_parameters,
+                         int max_num_quantum_gates, int max_num_param_gates,
+                         Dataset *dataset, bool verify_equivalences,
+                         EquivalenceSet *equiv_set, bool unique_parameters,
+                         bool verbose, decltype(std::chrono::steady_clock::now()
+    - std::chrono::steady_clock::now()) *record_verification_time) {
+  auto empty_dag =
+      std::make_unique<DAG>(num_qubits, num_input_parameters);
+  // Generate all possible parameter gates at the beginning.
+  assert(max_num_param_gates == 1);
+  empty_dag->generate_parameter_gates(context);
+  empty_dag->hash(context); // generate other hash values
+  std::vector<DAG *> dags_to_search(1, empty_dag.get());
+  if (verify_equivalences) {
+    assert(equiv_set);
+    auto equiv_class = std::make_unique<EquivalenceClass>();
+    equiv_class->insert(std::make_unique<DAG>(*empty_dag));
+    equiv_set->insert_class(context, std::move(equiv_class));
+  } else {
+    context->set_representative(std::make_unique<DAG>(*empty_dag));
+  }
+  dataset->insert(context, std::move(empty_dag));
+  std::vector<std::vector<DAG *> > dags(1, dags_to_search);
 
-		// To avoid EquivalenceSet deleting the DAGs in |dags| when calling
-		// clear().
-		std::vector< std::unique_ptr< DAG > > dag_holder;
+  // To avoid EquivalenceSet deleting the DAGs in |dags| when calling
+  // clear().
+  std::vector<std::unique_ptr<DAG> > dag_holder;
 
-		for (int num_gates = 1; num_gates <= max_num_quantum_gates;
-		     num_gates++) {
-			if (verbose) {
-				std::cout << "BFS: " << dags_to_search.size()
-				          << " representative DAGs to search with "
-				          << num_gates - 1 << " gates." << std::endl;
-			}
-			if (!verify_equivalences) {
-				assert(dataset);
-				dags_to_search.clear();
-				bfs(dags, max_num_param_gates, *dataset, &dags_to_search,
-				    verify_equivalences, nullptr, unique_parameters);
-				dags.push_back(dags_to_search);
-			}
-			else {
-				assert(dataset);
-				assert(equiv_set);
-				bfs(dags, max_num_param_gates, *dataset, nullptr,
-				    verify_equivalences, equiv_set, unique_parameters);
-				// Do not verify when |num_gates == max_num_quantum_gates|.
-				// This is to make the behavior the same when
-				// |verify_equivalences| is true or false.
-				if (num_gates == max_num_quantum_gates) {
-					break;
-				}
-				bool ret =
-				    dataset->save_json(context, "tmp_before_verify.json");
-				assert(ret);
+  for (int num_gates = 1; num_gates <= max_num_quantum_gates;
+       num_gates++) {
+    if (verbose) {
+      std::cout << "BFS: " << dags_to_search.size()
+                << " representative DAGs to search with "
+                << num_gates - 1 << " gates." << std::endl;
+    }
+    if (!verify_equivalences) {
+      assert(dataset);
+      dags_to_search.clear();
+      bfs(dags, max_num_param_gates, *dataset, &dags_to_search,
+          verify_equivalences, nullptr, unique_parameters);
+      dags.push_back(dags_to_search);
+    } else {
+      assert(dataset);
+      assert(equiv_set);
+      bfs(dags, max_num_param_gates, *dataset, nullptr,
+          verify_equivalences, equiv_set, unique_parameters);
+      // Do not verify when |num_gates == max_num_quantum_gates|.
+      // This is to make the behavior the same when
+      // |verify_equivalences| is true or false.
+      if (num_gates == max_num_quantum_gates) {
+        break;
+      }
+      bool ret =
+          dataset->save_json(context, "tmp_before_verify.json");
+      assert(ret);
 
-				decltype(std::chrono::steady_clock::now()) start;
-				if (record_verification_time) {
-				  start = std::chrono::steady_clock::now();
-				}
-				// Assume working directory is cmake-build-debug/ here.
-				system("python src/python/verifier/verify_equivalences.py "
-				       "tmp_before_verify.json tmp_after_verify.json");
-                if (record_verification_time) {
-                  auto end = std::chrono::steady_clock::now();
-                  *record_verification_time += end - start;
-                }
+      decltype(std::chrono::steady_clock::now()) start;
+      if (record_verification_time) {
+        start = std::chrono::steady_clock::now();
+      }
+      // Assume working directory is cmake-build-debug/ here.
+      system("python src/python/verifier/verify_equivalences.py "
+             "tmp_before_verify.json tmp_after_verify.json");
+      if (record_verification_time) {
+        auto end = std::chrono::steady_clock::now();
+        *record_verification_time += end - start;
+      }
 
-				dags_to_search.clear();
-				ret = equiv_set->load_json(context, "tmp_after_verify.json",
-				                           &dags_to_search);
-				assert(ret);
-				for (auto &dag : dags_to_search) {
-					auto new_dag = std::make_unique< DAG >(*dag);
-					dag = new_dag.get();
-					dag_holder.push_back(std::move(new_dag));
-				}
+      dags_to_search.clear();
+      ret = equiv_set->load_json(context, "tmp_after_verify.json",
+                                 &dags_to_search);
+      assert(ret);
+      for (auto &dag : dags_to_search) {
+        auto new_dag = std::make_unique<DAG>(*dag);
+        dag = new_dag.get();
+        dag_holder.push_back(std::move(new_dag));
+      }
 
-				dags.push_back(dags_to_search);
-				/* Seems problematic
-				equiv_set->remove_common_first_or_last_gates(context);
-				std::vector<DAG *> simplified_dags_to_search;
-				simplified_dags_to_search.reserve(dags_to_search.size());
-				for (auto &dag : dags_to_search) {
-				  if (equiv_set->contains(context, dag)) {
-				    simplified_dags_to_search.push_back(dag);
-				  }
-				}
-				dags.push_back(simplified_dags_to_search);
-				*/
-			}
-		}
-	}
-
-	void Generator::dfs(int gate_idx, int max_num_gates,
-	                    int max_remaining_param_gates, DAG *dag,
-	                    std::vector< int > &used_parameters, Dataset &dataset,
-	                    bool restrict_search_space, bool unique_parameters) {
-		if (restrict_search_space) {
-			// An optimization to restrict the search space, but may also cause
-			// the equivalences found to be incomplete.
-			bool pass_checks = true;
-			// check that qubits are used in an increasing order
-			for (int i = 1; i < dag->get_num_qubits(); i++)
-				if (dag->outputs[i] != dag->nodes[i].get() &&
-				    dag->outputs[i - 1] == dag->nodes[i - 1].get())
-					pass_checks = false;
-			// check that input parameters are used in an increasing order
-			for (int i = 1; i < dag->get_num_input_parameters(); i++)
-				if (used_parameters[i] > 0 && used_parameters[i - 1] == 0)
-					pass_checks = false;
-			// Note that we do not check that internal parameters are used in an
-			// increasing order here.
-			// Return if we fail any checks
-			if (!pass_checks)
-				return;
-		}
-
-		static int tmp = 0;
-		tmp++;
-		if (tmp == (tmp & (-tmp))) {
-			std::cout << "DFS " << tmp << " " << dataset.num_hash_values()
-			          << std::endl;
-		}
-
-		/*int num_unused_internal_parameter = 0;
-		for (int i = dag->get_num_input_parameters();
-		     i < dag->get_num_total_parameters(); i++) {
-		  if (used_parameters[i] == 0)
-		    num_unused_internal_parameter++;
-		}
-
-		bool save_into_dataset = (num_unused_internal_parameter == 0);
-		if (save_into_dataset) {
-		  // save a clone of dag to |dataset|
-		  dataset.insert(context,
-		dag->clone_and_shrink_unused_input_parameters());
-		}*/
-		dataset.insert(context, dag->clone());
-
-		// Check that this circuit is different with any other circuits in the
-		// |dataset|.
-		// Optimization disabled.
-		/*for (auto &other_dag : dataset[dag->hash(context)]) {
-		  // we could use BFS to avoid searching DAGs with more gates at first
-		  if (dag->get_num_gates() >= other_dag->get_num_gates()
-		      && verifier_.equivalent_on_the_fly(context, dag, other_dag.get()))
-		{ return;
-		  }
-		}*/
-
-		if (gate_idx >= max_num_gates)
-			return;
-		std::vector< int > qubit_indices;
-		std::vector< int > parameter_indices;
-        InputParamMaskType input_param_usage_mask;
-        std::vector<InputParamMaskType> input_param_masks;
-        if (unique_parameters) {
-          std::tie(input_param_usage_mask, input_param_masks) =
-              dag->get_input_param_mask();
+      dags.push_back(dags_to_search);
+      /* Seems problematic
+      equiv_set->remove_common_first_or_last_gates(context);
+      std::vector<DAG *> simplified_dags_to_search;
+      simplified_dags_to_search.reserve(dags_to_search.size());
+      for (auto &dag : dags_to_search) {
+        if (equiv_set->contains(context, dag)) {
+          simplified_dags_to_search.push_back(dag);
         }
-		for (const auto &idx : context->get_supported_quantum_gates()) {
-			Gate *gate = context->get_gate(idx);
-			if (gate->get_num_qubits() == 0) {
-				assert(false); // We only search for quantum gates here.
-				if (!max_remaining_param_gates) {
-					// We can't add more parameter gates.
-					continue;
-				}
-				if (gate->get_num_parameters() == 1) {
-					for (int p = 0; p < dag->get_num_total_parameters(); p++) {
-						parameter_indices.push_back(p);
-						used_parameters[p] += 1;
-						int output_param_index;
-						bool ret =
-						    dag->add_gate(qubit_indices, parameter_indices,
-						                  gate, &output_param_index);
-						assert(ret);
-						dfs(gate_idx + 1, max_num_gates,
-						    max_remaining_param_gates - 1, dag, used_parameters,
-						    dataset, restrict_search_space, unique_parameters);
-						ret = dag->remove_last_gate();
-						assert(ret);
-						used_parameters[p] -= 1;
-						parameter_indices.pop_back();
-					}
-				}
-				else if (gate->get_num_parameters() == 2) {
-					// Case: 0-qubit operators with 2 parameters
-					bool new_input_parameter_searched = false;
-					for (int p1 = 0; p1 < dag->get_num_total_parameters();
-					     p1++) {
-						if (restrict_search_space) {
-							if (p1 < dag->get_num_input_parameters() &&
-							    !used_parameters[p1]) {
-								// We should use the new (unused) input
-								// parameter with smallest index as the first
-								// input if there are more than one of them.
-								if (new_input_parameter_searched) {
-									continue;
-								}
-								else {
-									new_input_parameter_searched = true;
-								}
-							}
-						}
-						parameter_indices.push_back(p1);
-						used_parameters[p1] += 1;
-						for (int p2 = 0; p2 < dag->get_num_total_parameters();
-						     p2++) {
-							if (gate->is_commutative() && p1 > p2) {
-								// For commutative gates, enforce p1 <= p2
-								continue;
-							}
-							parameter_indices.push_back(p2);
-							used_parameters[p2] += 1;
-							int output_param_index;
-							bool ret =
-							    dag->add_gate(qubit_indices, parameter_indices,
-							                  gate, &output_param_index);
-							assert(ret);
-							dfs(gate_idx + 1, max_num_gates,
-							    max_remaining_param_gates - 1, dag,
-							    used_parameters, dataset,
-							    restrict_search_space, unique_parameters);
-							ret = dag->remove_last_gate();
-							assert(ret);
-							used_parameters[p2] -= 1;
-							parameter_indices.pop_back();
-						}
-						used_parameters[p1] -= 1;
-						parameter_indices.pop_back();
-					}
-				}
-				else {
-					assert(false && "Unsupported gate type");
-				}
-			}
-			else if (gate->get_num_qubits() == 1) {
-				for (int i = 0; i < dag->get_num_qubits(); i++) {
-					qubit_indices.push_back(i);
-					auto search_parameters = [&](int num_remaining_parameters,
-                                                 const InputParamMaskType &current_usage_mask,
-					                             auto &search_parameters_ref /*feed in the lambda implementation to itself as a parameter*/) {
-						if (num_remaining_parameters == 0) {
-							bool ret =
-							    dag->add_gate(qubit_indices, parameter_indices,
-							                  gate, nullptr);
-							assert(ret);
-							dfs(gate_idx + 1, max_num_gates,
-							    max_remaining_param_gates, dag, used_parameters,
-							    dataset, restrict_search_space, unique_parameters);
-							ret = dag->remove_last_gate();
-							assert(ret);
-							return;
-						}
+      }
+      dags.push_back(simplified_dags_to_search);
+      */
+    }
+  }
+}
 
-						for (int p1 = 0; p1 < dag->get_num_total_parameters();
-						     p1++) {
-                            if (unique_parameters) {
-                              if (current_usage_mask & input_param_masks[p1]) {
-                                // p1 contains an already used input parameter.
-                                continue;
-                              }
-                              parameter_indices.push_back(p1);
-                              used_parameters[p1] += 1;
-                              search_parameters_ref(
-                                  num_remaining_parameters - 1,
-                                  current_usage_mask | input_param_masks[p1],
-                                  search_parameters_ref);
-                              used_parameters[p1] -= 1;
-                              parameter_indices.pop_back();
-                            } else {
-                              parameter_indices.push_back(p1);
-                              used_parameters[p1] += 1;
-                              search_parameters_ref(
-                                  num_remaining_parameters - 1,
-                                  /*unused*/0,
-                                  search_parameters_ref);
-                              used_parameters[p1] -= 1;
-                              parameter_indices.pop_back();
-                            }
-						}
-					};
-					search_parameters(gate->get_num_parameters(),
-                                      input_param_usage_mask,
-					                  search_parameters);
+void Generator::dfs(int gate_idx, int max_num_gates,
+                    int max_remaining_param_gates, DAG *dag,
+                    std::vector<int> &used_parameters, Dataset &dataset,
+                    bool restrict_search_space, bool unique_parameters) {
+  if (restrict_search_space) {
+    // An optimization to restrict the search space, but may also cause
+    // the equivalences found to be incomplete.
+    bool pass_checks = true;
+    // check that qubits are used in an increasing order
+    for (int i = 1; i < dag->get_num_qubits(); i++)
+      if (dag->outputs[i] != dag->nodes[i].get() &&
+          dag->outputs[i - 1] == dag->nodes[i - 1].get())
+        pass_checks = false;
+    // check that input parameters are used in an increasing order
+    for (int i = 1; i < dag->get_num_input_parameters(); i++)
+      if (used_parameters[i] > 0 && used_parameters[i - 1] == 0)
+        pass_checks = false;
+    // Note that we do not check that internal parameters are used in an
+    // increasing order here.
+    // Return if we fail any checks
+    if (!pass_checks)
+      return;
+  }
 
-					qubit_indices.pop_back();
-				}
-			}
-			else if (gate->get_num_qubits() == 2) {
-				if (gate->get_num_parameters() == 0) {
-					// Case: 2-qubit operators without parameters
-					bool new_qubit_searched = false;
-					for (int q1 = 0; q1 < dag->get_num_qubits(); q1++) {
-						if (restrict_search_space) {
-							if (q1 < dag->get_num_input_parameters() &&
-							    !dag->qubit_used(q1)) {
-								// We should use the new (unused) qubit with
-								// smallest index as the first input if there
-								// are more than one of them.
-								if (new_qubit_searched) {
-									continue;
-								}
-								else {
-									new_qubit_searched = true;
-								}
-							}
-						}
-						qubit_indices.push_back(q1);
-						for (int q2 = 0; q2 < dag->get_num_qubits(); q2++) {
-							if (q1 == q2)
-								continue;
-							qubit_indices.push_back(q2);
-							bool ret =
-							    dag->add_gate(qubit_indices, parameter_indices,
-							                  gate, nullptr);
-							assert(ret);
-							dfs(gate_idx + 1, max_num_gates,
-							    max_remaining_param_gates, dag, used_parameters,
-							    dataset, restrict_search_space, unique_parameters);
-							ret = dag->remove_last_gate();
-							assert(ret);
-							qubit_indices.pop_back();
-						}
-						qubit_indices.pop_back();
-					}
-				}
-				else {
-					assert(false && "To be implemented...");
-				}
-			}
-			else {
-				// Current only support 1- and 2-qubit gates
-				assert(false && "Unsupported gate");
-			}
-		}
-	}
+  static int tmp = 0;
+  tmp++;
+  if (tmp == (tmp & (-tmp))) {
+    std::cout << "DFS " << tmp << " " << dataset.num_hash_values()
+              << std::endl;
+  }
 
-	void Generator::bfs(const std::vector< std::vector< DAG * > > &dags,
-	                    int max_num_param_gates, Dataset &dataset,
-	                    std::vector< DAG * > *new_representatives,
-	                    bool verify_equivalences,
-	                    const EquivalenceSet *equiv_set,
-                        bool unique_parameters) {
-		auto try_to_add_to_result = [&](DAG *new_dag) {
-			// A new DAG with |current_max_num_gates| + 1 gates.
-			if (verify_equivalences) {
-				assert(equiv_set);
-				if (!verifier_.redundant(context, equiv_set, new_dag)) {
-					auto new_new_dag = std::make_unique< DAG >(*new_dag);
-					auto new_new_dag_ptr = new_new_dag.get();
-					dataset.insert(context, std::move(new_new_dag));
-					if (new_representatives) {
-						// Warning: this is not the new representatives -- only
-						// the new DAGs.
-						new_representatives->push_back(new_new_dag_ptr);
-					}
-				}
-			}
-			else {
-				// If we will not verify the equivalence later, we should update
-				// the representatives in the context now.
-				if (verifier_.redundant(context, new_dag)) {
-					return;
-				}
-				bool ret =
-				    dataset.insert(context, std::make_unique< DAG >(*new_dag));
-				// Presuming different hash values imply different DAGs.
-				if (ret) {
-					// The DAG's hash value is new to the dataset.
-					// Note: this is the second instance of DAG we create in
-					// this function.
-					auto rep = std::make_unique< DAG >(*new_dag);
-					auto rep_ptr = rep.get();
-					context->set_representative(std::move(rep));
-					if (new_representatives) {
-						new_representatives->push_back(rep_ptr);
-					}
-				}
-			}
-		};
-		for (auto &dag : dags.back()) {
-		    InputParamMaskType input_param_usage_mask;
-		    std::vector<InputParamMaskType> input_param_masks;
-            if (unique_parameters) {
-              std::tie(input_param_usage_mask, input_param_masks) =
-                  dag->get_input_param_mask();
-            }
-			std::vector< int > qubit_indices, parameter_indices;
-			// Add 1 quantum gate according to the qubit index order.
+  /*int num_unused_internal_parameter = 0;
+  for (int i = dag->get_num_input_parameters();
+       i < dag->get_num_total_parameters(); i++) {
+    if (used_parameters[i] == 0)
+      num_unused_internal_parameter++;
+  }
 
-              for (int q1 = 0; q1 < dag->get_num_qubits(); q1++) {
-                qubit_indices.push_back(q1);
-                // Case: 1-qubit operators
-                  for (const auto &idx : context->get_supported_quantum_gates()) {
-                    Gate *gate = context->get_gate(idx);
-                    if (gate->get_num_qubits() != 1) {
-                      assert(gate->get_num_qubits() == 2);
-                      continue;
-                    }
-                    auto
-                        search_parameters = [&](int num_remaining_parameters,
-                                                const InputParamMaskType &current_usage_mask,
-                                                auto &
-                                                search_parameters_ref /*feed in the lambda implementation to itself as a parameter*/) {
-                      if (num_remaining_parameters == 0) {
-                        bool ret = dag->add_gate(qubit_indices,
-                                                 parameter_indices,
-                                                 gate, nullptr);
-                        assert(ret);
-                        try_to_add_to_result(dag);
-                        ret = dag->remove_last_gate();
-                        assert(ret);
-                        return;
-                      }
+  bool save_into_dataset = (num_unused_internal_parameter == 0);
+  if (save_into_dataset) {
+    // save a clone of dag to |dataset|
+    dataset.insert(context,
+  dag->clone_and_shrink_unused_input_parameters());
+  }*/
+  dataset.insert(context, dag->clone());
 
-                      for (int p1 = 0;
-                           p1 < dag->get_num_total_parameters();
-                           p1++) {
-                        if (unique_parameters) {
-                          if (current_usage_mask & input_param_masks[p1]) {
-                            // p1 contains an already used input parameter.
-                            continue;
-                          }
-                          parameter_indices.push_back(p1);
-                          search_parameters_ref(
-                              num_remaining_parameters - 1,
-                              current_usage_mask | input_param_masks[p1],
-                              search_parameters_ref);
-                          parameter_indices.pop_back();
-                        } else {
-                          parameter_indices.push_back(p1);
-                          search_parameters_ref(
-                              num_remaining_parameters - 1,
-                              /*unused*/0,
-                              search_parameters_ref);
-                          parameter_indices.pop_back();
-                        }
-                      }
-                    };
-                    search_parameters(gate->get_num_parameters(),
-                                      input_param_usage_mask,
-                                      search_parameters);
-                }
-                // Case: 2-qubit operators without parameters
-                for (int q2 = q1 + 1; q2 < dag->get_num_qubits(); q2++) {
-                  qubit_indices.push_back(q2);
-                  for (const auto &idx : context->get_supported_quantum_gates()) {
-                    Gate *gate = context->get_gate(idx);
-                    if (gate->get_num_qubits() == 2) {
-                      assert(gate->get_num_parameters() == 0);
-                      bool ret = dag->add_gate(qubit_indices,
-                                               parameter_indices,
-                                               gate, nullptr);
-                      assert(ret);
-                      try_to_add_to_result(dag);
-                      ret = dag->remove_last_gate();
-                      assert(ret);
-                      if (!gate->is_commutative()) {
-                        std::swap(qubit_indices[0], qubit_indices[1]);
-                        ret = dag->add_gate(qubit_indices,
-                                            parameter_indices,
-                                            gate, nullptr);
-                        assert(ret);
-                        try_to_add_to_result(dag);
-                        ret = dag->remove_last_gate();
-                        assert(ret);
-                        std::swap(qubit_indices[0], qubit_indices[1]);
-                      }
-                    }
-                  }
-                  qubit_indices.pop_back();
-                }
-                qubit_indices.pop_back();
+  // Check that this circuit is different with any other circuits in the
+  // |dataset|.
+  // Optimization disabled.
+  /*for (auto &other_dag : dataset[dag->hash(context)]) {
+    // we could use BFS to avoid searching DAGs with more gates at first
+    if (dag->get_num_gates() >= other_dag->get_num_gates()
+        && verifier_.equivalent_on_the_fly(context, dag, other_dag.get()))
+  { return;
+    }
+  }*/
+
+  if (gate_idx >= max_num_gates)
+    return;
+  std::vector<int> qubit_indices;
+  std::vector<int> parameter_indices;
+  InputParamMaskType input_param_usage_mask;
+  std::vector<InputParamMaskType> input_param_masks;
+  if (unique_parameters) {
+    std::tie(input_param_usage_mask, input_param_masks) =
+        dag->get_input_param_mask();
+  }
+  for (const auto &idx : context->get_supported_quantum_gates()) {
+    Gate *gate = context->get_gate(idx);
+    if (gate->get_num_qubits() == 0) {
+      assert(false); // We only search for quantum gates here.
+      if (!max_remaining_param_gates) {
+        // We can't add more parameter gates.
+        continue;
+      }
+      if (gate->get_num_parameters() == 1) {
+        for (int p = 0; p < dag->get_num_total_parameters(); p++) {
+          parameter_indices.push_back(p);
+          used_parameters[p] += 1;
+          int output_param_index;
+          bool ret =
+              dag->add_gate(qubit_indices, parameter_indices,
+                            gate, &output_param_index);
+          assert(ret);
+          dfs(gate_idx + 1, max_num_gates,
+              max_remaining_param_gates - 1, dag, used_parameters,
+              dataset, restrict_search_space, unique_parameters);
+          ret = dag->remove_last_gate();
+          assert(ret);
+          used_parameters[p] -= 1;
+          parameter_indices.pop_back();
+        }
+      } else if (gate->get_num_parameters() == 2) {
+        // Case: 0-qubit operators with 2 parameters
+        bool new_input_parameter_searched = false;
+        for (int p1 = 0; p1 < dag->get_num_total_parameters();
+             p1++) {
+          if (restrict_search_space) {
+            if (p1 < dag->get_num_input_parameters() &&
+                !used_parameters[p1]) {
+              // We should use the new (unused) input
+              // parameter with smallest index as the first
+              // input if there are more than one of them.
+              if (new_input_parameter_searched) {
+                continue;
+              } else {
+                new_input_parameter_searched = true;
               }
-			dag->hash(context); // restore hash value
-		}
-	}
+            }
+          }
+          parameter_indices.push_back(p1);
+          used_parameters[p1] += 1;
+          for (int p2 = 0; p2 < dag->get_num_total_parameters();
+               p2++) {
+            if (gate->is_commutative() && p1 > p2) {
+              // For commutative gates, enforce p1 <= p2
+              continue;
+            }
+            parameter_indices.push_back(p2);
+            used_parameters[p2] += 1;
+            int output_param_index;
+            bool ret =
+                dag->add_gate(qubit_indices, parameter_indices,
+                              gate, &output_param_index);
+            assert(ret);
+            dfs(gate_idx + 1, max_num_gates,
+                max_remaining_param_gates - 1, dag,
+                used_parameters, dataset,
+                restrict_search_space, unique_parameters);
+            ret = dag->remove_last_gate();
+            assert(ret);
+            used_parameters[p2] -= 1;
+            parameter_indices.pop_back();
+          }
+          used_parameters[p1] -= 1;
+          parameter_indices.pop_back();
+        }
+      } else {
+        assert(false && "Unsupported gate type");
+      }
+    } else if (gate->get_num_qubits() == 1) {
+      for (int i = 0; i < dag->get_num_qubits(); i++) {
+        qubit_indices.push_back(i);
+        auto search_parameters = [&](int num_remaining_parameters,
+                                     const InputParamMaskType &current_usage_mask,
+                                     auto &search_parameters_ref /*feed in the lambda implementation to itself as a parameter*/) {
+          if (num_remaining_parameters == 0) {
+            bool ret =
+                dag->add_gate(qubit_indices, parameter_indices,
+                              gate, nullptr);
+            assert(ret);
+            dfs(gate_idx + 1, max_num_gates,
+                max_remaining_param_gates, dag, used_parameters,
+                dataset, restrict_search_space, unique_parameters);
+            ret = dag->remove_last_gate();
+            assert(ret);
+            return;
+          }
 
-	void Generator::dfs_parameter_gates(
-	    std::unique_ptr< DAG > dag, int remaining_gates, int max_unused_params,
-	    int current_unused_params, std::vector< int > &params_used_times,
-	    std::vector< std::unique_ptr< DAG > > &result) {
-		if (remaining_gates == 0) {
-			result.push_back(std::move(dag));
-			return;
-		}
-		for (const auto &idx : context->get_supported_parameter_gates()) {
-			Gate *gate = context->get_gate(idx);
-			if (gate->get_num_parameters() == 1) {
-				std::vector< int > param_indices(1);
-				for (param_indices[0] = 0;
-				     param_indices[0] < dag->get_num_total_parameters();
-				     param_indices[0]++) {
-					if (param_indices[0] >= dag->get_num_input_parameters()) {
-						if (!params_used_times[param_indices[0]])
-							current_unused_params--;
-						params_used_times[param_indices[0]]++;
-					}
-					if (current_unused_params + 1 /*new parameter*/
-					        - (remaining_gates - 1) *
-					              (kMaxParamInputPerParamGate - 1) >
-					    max_unused_params) {
-						// Too many unused parameters, prune it
-						// Restore |params_used_times[param_indices[1]]|
-						if (param_indices[0] >=
-						    dag->get_num_input_parameters()) {
-							params_used_times[param_indices[0]]--;
-							if (!params_used_times[param_indices[0]])
-								current_unused_params++;
-						}
-						continue;
-					}
-					int output_param_index;
-					auto new_dag = std::make_unique< DAG >(*dag);
-					bool ret = new_dag->add_gate({}, param_indices, gate,
-					                             &output_param_index);
-					assert(ret);
-					if (output_param_index >= params_used_times.size()) {
-						params_used_times.resize(output_param_index + 1);
-					}
-					params_used_times[output_param_index] = 0;
-					dfs_parameter_gates(std::move(new_dag), remaining_gates - 1,
-					                    max_unused_params,
-					                    current_unused_params +
-					                        1 /*new parameter*/,
-					                    params_used_times, result);
-					assert(ret);
-					if (param_indices[0] >= dag->get_num_input_parameters()) {
-						params_used_times[param_indices[0]]--;
-						if (!params_used_times[param_indices[0]])
-							current_unused_params++;
-					}
-				}
-			}
-			else if (gate->get_num_parameters() == 2) {
-				// Case: 0-qubit operators with 2 parameters
-				std::vector< int > param_indices(2);
-				for (param_indices[0] = 0;
-				     param_indices[0] < dag->get_num_total_parameters();
-				     param_indices[0]++) {
-					if (param_indices[0] >= dag->get_num_input_parameters()) {
-						// Only enforce all internal parameters are used
-						if (!params_used_times[param_indices[0]])
-							current_unused_params--;
-						params_used_times[param_indices[0]]++;
-					}
-					for (param_indices[1] = 0;
-					     param_indices[1] < dag->get_num_total_parameters();
-					     param_indices[1]++) {
-						if (gate->is_commutative() &&
-						    param_indices[0] > param_indices[1]) {
-							// For commutative gates, enforce param_indices[0]
-							// <= param_indices[1]
-							continue;
-						}
-						if (param_indices[1] >=
-						    dag->get_num_input_parameters()) {
-							if (!params_used_times[param_indices[1]])
-								current_unused_params--;
-							params_used_times[param_indices[1]]++;
-						}
-						if (current_unused_params + 1 /*new parameter*/
-						        - (remaining_gates - 1) *
-						              (kMaxParamInputPerParamGate - 1) >
-						    max_unused_params) {
-							// Too many unused parameters, prune it
-							// Restore |params_used_times[param_indices[1]]|
-							if (param_indices[1] >=
-							    dag->get_num_input_parameters()) {
-								params_used_times[param_indices[1]]--;
-								if (!params_used_times[param_indices[1]])
-									current_unused_params++;
-							}
-							continue;
-						}
-						int output_param_index;
-						auto new_dag = std::make_unique< DAG >(*dag);
-						bool ret = new_dag->add_gate({}, param_indices, gate,
-						                             &output_param_index);
-						assert(ret);
-						if (output_param_index >= params_used_times.size()) {
-							params_used_times.resize(output_param_index + 1);
-						}
-						params_used_times[output_param_index] = 0;
-						dfs_parameter_gates(
-						    std::move(new_dag), remaining_gates - 1,
-						    max_unused_params,
-						    current_unused_params + 1 /*new parameter*/,
-						    params_used_times, result);
-						assert(ret);
-						if (param_indices[1] >=
-						    dag->get_num_input_parameters()) {
-							params_used_times[param_indices[1]]--;
-							if (!params_used_times[param_indices[1]])
-								current_unused_params++;
-						}
-					}
-					if (param_indices[0] >= dag->get_num_input_parameters()) {
-						params_used_times[param_indices[0]]--;
-						if (!params_used_times[param_indices[0]])
-							current_unused_params++;
-					}
-				}
-			}
-			else {
-				assert(false && "Unsupported gate type");
-			}
-		}
-	}
+          for (int p1 = 0; p1 < dag->get_num_total_parameters();
+               p1++) {
+            if (unique_parameters) {
+              if (current_usage_mask & input_param_masks[p1]) {
+                // p1 contains an already used input parameter.
+                continue;
+              }
+              parameter_indices.push_back(p1);
+              used_parameters[p1] += 1;
+              search_parameters_ref(
+                  num_remaining_parameters - 1,
+                  current_usage_mask | input_param_masks[p1],
+                  search_parameters_ref);
+              used_parameters[p1] -= 1;
+              parameter_indices.pop_back();
+            } else {
+              parameter_indices.push_back(p1);
+              used_parameters[p1] += 1;
+              search_parameters_ref(
+                  num_remaining_parameters - 1,
+                  /*unused*/0,
+                  search_parameters_ref);
+              used_parameters[p1] -= 1;
+              parameter_indices.pop_back();
+            }
+          }
+        };
+        search_parameters(gate->get_num_parameters(),
+                          input_param_usage_mask,
+                          search_parameters);
+
+        qubit_indices.pop_back();
+      }
+    } else if (gate->get_num_qubits() == 2) {
+      if (gate->get_num_parameters() == 0) {
+        // Case: 2-qubit operators without parameters
+        bool new_qubit_searched = false;
+        for (int q1 = 0; q1 < dag->get_num_qubits(); q1++) {
+          if (restrict_search_space) {
+            if (q1 < dag->get_num_input_parameters() &&
+                !dag->qubit_used(q1)) {
+              // We should use the new (unused) qubit with
+              // smallest index as the first input if there
+              // are more than one of them.
+              if (new_qubit_searched) {
+                continue;
+              } else {
+                new_qubit_searched = true;
+              }
+            }
+          }
+          qubit_indices.push_back(q1);
+          for (int q2 = 0; q2 < dag->get_num_qubits(); q2++) {
+            if (q1 == q2)
+              continue;
+            qubit_indices.push_back(q2);
+            bool ret =
+                dag->add_gate(qubit_indices, parameter_indices,
+                              gate, nullptr);
+            assert(ret);
+            dfs(gate_idx + 1, max_num_gates,
+                max_remaining_param_gates, dag, used_parameters,
+                dataset, restrict_search_space, unique_parameters);
+            ret = dag->remove_last_gate();
+            assert(ret);
+            qubit_indices.pop_back();
+          }
+          qubit_indices.pop_back();
+        }
+      } else {
+        assert(false && "To be implemented...");
+      }
+    } else {
+      // Current only support 1- and 2-qubit gates
+      assert(false && "Unsupported gate");
+    }
+  }
+}
+
+void Generator::bfs(const std::vector<std::vector<DAG *> > &dags,
+                    int max_num_param_gates, Dataset &dataset,
+                    std::vector<DAG *> *new_representatives,
+                    bool verify_equivalences,
+                    const EquivalenceSet *equiv_set,
+                    bool unique_parameters) {
+  auto try_to_add_to_result = [&](DAG *new_dag) {
+    // A new DAG with |current_max_num_gates| + 1 gates.
+    if (verify_equivalences) {
+      assert(equiv_set);
+      if (!verifier_.redundant(context, equiv_set, new_dag)) {
+        auto new_new_dag = std::make_unique<DAG>(*new_dag);
+        auto new_new_dag_ptr = new_new_dag.get();
+        dataset.insert(context, std::move(new_new_dag));
+        if (new_representatives) {
+          // Warning: this is not the new representatives -- only
+          // the new DAGs.
+          new_representatives->push_back(new_new_dag_ptr);
+        }
+      }
+    } else {
+      // If we will not verify the equivalence later, we should update
+      // the representatives in the context now.
+      if (verifier_.redundant(context, new_dag)) {
+        return;
+      }
+      bool ret =
+          dataset.insert(context, std::make_unique<DAG>(*new_dag));
+      // Presuming different hash values imply different DAGs.
+      if (ret) {
+        // The DAG's hash value is new to the dataset.
+        // Note: this is the second instance of DAG we create in
+        // this function.
+        auto rep = std::make_unique<DAG>(*new_dag);
+        auto rep_ptr = rep.get();
+        context->set_representative(std::move(rep));
+        if (new_representatives) {
+          new_representatives->push_back(rep_ptr);
+        }
+      }
+    }
+  };
+  for (auto &dag : dags.back()) {
+    InputParamMaskType input_param_usage_mask;
+    std::vector<InputParamMaskType> input_param_masks;
+    if (unique_parameters) {
+      std::tie(input_param_usage_mask, input_param_masks) =
+          dag->get_input_param_mask();
+    }
+    std::vector<int> qubit_indices, parameter_indices;
+    // Add 1 quantum gate according to the qubit index order.
+
+    for (int q1 = 0; q1 < dag->get_num_qubits(); q1++) {
+      qubit_indices.push_back(q1);
+      // Case: 1-qubit operators
+      for (const auto &idx : context->get_supported_quantum_gates()) {
+        Gate *gate = context->get_gate(idx);
+        if (gate->get_num_qubits() != 1) {
+          assert(gate->get_num_qubits() == 2);
+          continue;
+        }
+        auto
+            search_parameters = [&](int num_remaining_parameters,
+                                    const InputParamMaskType &current_usage_mask,
+                                    auto &
+                                    search_parameters_ref /*feed in the lambda implementation to itself as a parameter*/) {
+          if (num_remaining_parameters == 0) {
+            bool ret = dag->add_gate(qubit_indices,
+                                     parameter_indices,
+                                     gate, nullptr);
+            assert(ret);
+            try_to_add_to_result(dag);
+            ret = dag->remove_last_gate();
+            assert(ret);
+            return;
+          }
+
+          for (int p1 = 0;
+               p1 < dag->get_num_total_parameters();
+               p1++) {
+            if (unique_parameters) {
+              if (current_usage_mask & input_param_masks[p1]) {
+                // p1 contains an already used input parameter.
+                continue;
+              }
+              parameter_indices.push_back(p1);
+              search_parameters_ref(
+                  num_remaining_parameters - 1,
+                  current_usage_mask | input_param_masks[p1],
+                  search_parameters_ref);
+              parameter_indices.pop_back();
+            } else {
+              parameter_indices.push_back(p1);
+              search_parameters_ref(
+                  num_remaining_parameters - 1,
+                  /*unused*/0,
+                  search_parameters_ref);
+              parameter_indices.pop_back();
+            }
+          }
+        };
+        search_parameters(gate->get_num_parameters(),
+                          input_param_usage_mask,
+                          search_parameters);
+      }
+      // Case: 2-qubit operators without parameters
+      for (int q2 = q1 + 1; q2 < dag->get_num_qubits(); q2++) {
+        qubit_indices.push_back(q2);
+        for (const auto &idx : context->get_supported_quantum_gates()) {
+          Gate *gate = context->get_gate(idx);
+          if (gate->get_num_qubits() == 2) {
+            assert(gate->get_num_parameters() == 0);
+            bool ret = dag->add_gate(qubit_indices,
+                                     parameter_indices,
+                                     gate, nullptr);
+            assert(ret);
+            try_to_add_to_result(dag);
+            ret = dag->remove_last_gate();
+            assert(ret);
+            if (!gate->is_commutative()) {
+              std::swap(qubit_indices[0], qubit_indices[1]);
+              ret = dag->add_gate(qubit_indices,
+                                  parameter_indices,
+                                  gate, nullptr);
+              assert(ret);
+              try_to_add_to_result(dag);
+              ret = dag->remove_last_gate();
+              assert(ret);
+              std::swap(qubit_indices[0], qubit_indices[1]);
+            }
+          }
+        }
+        qubit_indices.pop_back();
+      }
+      qubit_indices.pop_back();
+    }
+    dag->hash(context); // restore hash value
+  }
+}
+
+void Generator::dfs_parameter_gates(
+    std::unique_ptr<DAG> dag, int remaining_gates, int max_unused_params,
+    int current_unused_params, std::vector<int> &params_used_times,
+    std::vector<std::unique_ptr<DAG> > &result) {
+  if (remaining_gates == 0) {
+    result.push_back(std::move(dag));
+    return;
+  }
+  for (const auto &idx : context->get_supported_parameter_gates()) {
+    Gate *gate = context->get_gate(idx);
+    if (gate->get_num_parameters() == 1) {
+      std::vector<int> param_indices(1);
+      for (param_indices[0] = 0;
+           param_indices[0] < dag->get_num_total_parameters();
+           param_indices[0]++) {
+        if (param_indices[0] >= dag->get_num_input_parameters()) {
+          if (!params_used_times[param_indices[0]])
+            current_unused_params--;
+          params_used_times[param_indices[0]]++;
+        }
+        if (current_unused_params + 1 /*new parameter*/
+            - (remaining_gates - 1) *
+                (kMaxParamInputPerParamGate - 1) >
+            max_unused_params) {
+          // Too many unused parameters, prune it
+          // Restore |params_used_times[param_indices[1]]|
+          if (param_indices[0] >=
+              dag->get_num_input_parameters()) {
+            params_used_times[param_indices[0]]--;
+            if (!params_used_times[param_indices[0]])
+              current_unused_params++;
+          }
+          continue;
+        }
+        int output_param_index;
+        auto new_dag = std::make_unique<DAG>(*dag);
+        bool ret = new_dag->add_gate({}, param_indices, gate,
+                                     &output_param_index);
+        assert(ret);
+        if (output_param_index >= params_used_times.size()) {
+          params_used_times.resize(output_param_index + 1);
+        }
+        params_used_times[output_param_index] = 0;
+        dfs_parameter_gates(std::move(new_dag), remaining_gates - 1,
+                            max_unused_params,
+                            current_unused_params +
+                                1 /*new parameter*/,
+                            params_used_times, result);
+        assert(ret);
+        if (param_indices[0] >= dag->get_num_input_parameters()) {
+          params_used_times[param_indices[0]]--;
+          if (!params_used_times[param_indices[0]])
+            current_unused_params++;
+        }
+      }
+    } else if (gate->get_num_parameters() == 2) {
+      // Case: 0-qubit operators with 2 parameters
+      std::vector<int> param_indices(2);
+      for (param_indices[0] = 0;
+           param_indices[0] < dag->get_num_total_parameters();
+           param_indices[0]++) {
+        if (param_indices[0] >= dag->get_num_input_parameters()) {
+          // Only enforce all internal parameters are used
+          if (!params_used_times[param_indices[0]])
+            current_unused_params--;
+          params_used_times[param_indices[0]]++;
+        }
+        for (param_indices[1] = 0;
+             param_indices[1] < dag->get_num_total_parameters();
+             param_indices[1]++) {
+          if (gate->is_commutative() &&
+              param_indices[0] > param_indices[1]) {
+            // For commutative gates, enforce param_indices[0]
+            // <= param_indices[1]
+            continue;
+          }
+          if (param_indices[1] >=
+              dag->get_num_input_parameters()) {
+            if (!params_used_times[param_indices[1]])
+              current_unused_params--;
+            params_used_times[param_indices[1]]++;
+          }
+          if (current_unused_params + 1 /*new parameter*/
+              - (remaining_gates - 1) *
+                  (kMaxParamInputPerParamGate - 1) >
+              max_unused_params) {
+            // Too many unused parameters, prune it
+            // Restore |params_used_times[param_indices[1]]|
+            if (param_indices[1] >=
+                dag->get_num_input_parameters()) {
+              params_used_times[param_indices[1]]--;
+              if (!params_used_times[param_indices[1]])
+                current_unused_params++;
+            }
+            continue;
+          }
+          int output_param_index;
+          auto new_dag = std::make_unique<DAG>(*dag);
+          bool ret = new_dag->add_gate({}, param_indices, gate,
+                                       &output_param_index);
+          assert(ret);
+          if (output_param_index >= params_used_times.size()) {
+            params_used_times.resize(output_param_index + 1);
+          }
+          params_used_times[output_param_index] = 0;
+          dfs_parameter_gates(
+              std::move(new_dag), remaining_gates - 1,
+              max_unused_params,
+              current_unused_params + 1 /*new parameter*/,
+              params_used_times, result);
+          assert(ret);
+          if (param_indices[1] >=
+              dag->get_num_input_parameters()) {
+            params_used_times[param_indices[1]]--;
+            if (!params_used_times[param_indices[1]])
+              current_unused_params++;
+          }
+        }
+        if (param_indices[0] >= dag->get_num_input_parameters()) {
+          params_used_times[param_indices[0]]--;
+          if (!params_used_times[param_indices[0]])
+            current_unused_params++;
+        }
+      }
+    } else {
+      assert(false && "Unsupported gate type");
+    }
+  }
+}
 
 } // namespace quartz

--- a/src/quartz/generator/generator.h
+++ b/src/quartz/generator/generator.h
@@ -10,70 +10,70 @@
 #include <unordered_set>
 
 namespace quartz {
-	class Generator {
-	public:
-		explicit Generator(Context *ctx) : context(ctx) {}
+class Generator {
+ public:
+  explicit Generator(Context *ctx) : context(ctx) {}
 
-		// Use DFS to generate all equivalent DAGs with |num_qubits| qubits,
-		// <= |max_num_input_parameters| input parameters,
-		// and <= |max_num_quantum_gates| gates.
-		// If |restrict_search_space| is false, we search for all possible DAGs
-		// with no unused internal parameters.
-		// If |restrict_search_space| is true, we only search for DAGs which:
-		//   - Use qubits in an increasing order;
-		//   - Use input parameters in an increasing order;
-		//   - When a gate uses more than one fresh new qubits or fresh new
-		//   input
-		//     parameters, restrict the order (for example, if a CX gate uses
-		//     two fresh new qubits, the control qubit must have the smaller
-		//     index).
-        // If |unique_parameters| is true, we only search for DAGs that use
-        // each input parameters only once (note: use a doubled parameter, i.e.,
-        // Rx(2theta) is considered using the parameter theta once).
-		void generate_dfs(int num_qubits, int max_num_input_parameters,
-		                  int max_num_quantum_gates, int max_num_param_gates,
-		                  Dataset &dataset, bool restrict_search_space,
-                          bool unique_parameters);
+  // Use DFS to generate all equivalent DAGs with |num_qubits| qubits,
+  // <= |max_num_input_parameters| input parameters,
+  // and <= |max_num_quantum_gates| gates.
+  // If |restrict_search_space| is false, we search for all possible DAGs
+  // with no unused internal parameters.
+  // If |restrict_search_space| is true, we only search for DAGs which:
+  //   - Use qubits in an increasing order;
+  //   - Use input parameters in an increasing order;
+  //   - When a gate uses more than one fresh new qubits or fresh new
+  //   input
+  //     parameters, restrict the order (for example, if a CX gate uses
+  //     two fresh new qubits, the control qubit must have the smaller
+  //     index).
+  // If |unique_parameters| is true, we only search for DAGs that use
+  // each input parameters only once (note: use a doubled parameter, i.e.,
+  // Rx(2theta) is considered using the parameter theta once).
+  void generate_dfs(int num_qubits, int max_num_input_parameters,
+                    int max_num_quantum_gates, int max_num_param_gates,
+                    Dataset &dataset, bool restrict_search_space,
+                    bool unique_parameters);
 
-		// Use BFS to generate all equivalent DAGs with |num_qubits| qubits,
-		// |num_input_parameters| input parameters (probably with some unused),
-		// and <= |max_num_quantum_gates| gates.
-		// If |unique_parameters| is true, we only search for DAGs that use
-		// each input parameters only once (note: use a doubled parameter, i.e.,
-		// Rx(2theta) is considered using the parameter theta once).
-        void generate(int num_qubits,
-                      int num_input_parameters,
-                      int max_num_quantum_gates,
-                      int max_num_param_gates,
-                      Dataset *dataset,
-                      bool verify_equivalences,
-                      EquivalenceSet *equiv_set,
-                      bool unique_parameters,
-                      bool verbose = false,
-                      decltype(std::chrono::steady_clock::now()
-                          - std::chrono::steady_clock::now()) *record_verification_time = nullptr);
+  // Use BFS to generate all equivalent DAGs with |num_qubits| qubits,
+  // |num_input_parameters| input parameters (probably with some unused),
+  // and <= |max_num_quantum_gates| gates.
+  // If |unique_parameters| is true, we only search for DAGs that use
+  // each input parameters only once (note: use a doubled parameter, i.e.,
+  // Rx(2theta) is considered using the parameter theta once).
+  void generate(int num_qubits,
+                int num_input_parameters,
+                int max_num_quantum_gates,
+                int max_num_param_gates,
+                Dataset *dataset,
+                bool verify_equivalences,
+                EquivalenceSet *equiv_set,
+                bool unique_parameters,
+                bool verbose = false,
+                decltype(std::chrono::steady_clock::now()
+                    - std::chrono::steady_clock::now()) *record_verification_time = nullptr);
 
-	private:
-		void dfs(int gate_idx, int max_num_gates, int max_remaining_param_gates,
-		         DAG *dag, std::vector< int > &used_parameters,
-		         Dataset &dataset, bool restrict_search_space,
-                 bool unique_parameters);
+ private:
+  void dfs(int gate_idx, int max_num_gates, int max_remaining_param_gates,
+           DAG *dag, std::vector<int> &used_parameters,
+           Dataset &dataset, bool restrict_search_space,
+           bool unique_parameters);
 
-		// |dags[i]| is the DAGs with |i| gates.
-		void bfs(const std::vector< std::vector< DAG * > > &dags,
-		         int max_num_param_gates, Dataset &dataset,
-		         std::vector< DAG * > *new_representatives,
-		         bool verify_equivalences, const EquivalenceSet *equiv_set,
-                 bool unique_parameters);
+  // |dags[i]| is the DAGs with |i| gates.
+  void bfs(const std::vector<std::vector<DAG *> > &dags,
+           int max_num_param_gates, Dataset &dataset,
+           std::vector<DAG *> *new_representatives,
+           bool verify_equivalences, const EquivalenceSet *equiv_set,
+           bool unique_parameters);
 
-		void dfs_parameter_gates(std::unique_ptr< DAG > dag,
-		                         int remaining_gates, int max_unused_params,
-		                         int current_unused_params,
-		                         std::vector< int > &params_used_times,
-		                         std::vector< std::unique_ptr< DAG > > &result);
+  void dfs_parameter_gates(std::unique_ptr<DAG> dag,
+                           int remaining_gates, int max_unused_params,
+                           int current_unused_params,
+                           std::vector<int> &params_used_times,
+                           std::vector<std::unique_ptr<DAG> > &result);
 
-		Context *context;
-		Verifier verifier_;
-	};
+  Context *context;
+  Verifier verifier_;
+};
 
 } // namespace quartz

--- a/src/quartz/verifier/verifier.cpp
+++ b/src/quartz/verifier/verifier.cpp
@@ -3,78 +3,73 @@
 #include <algorithm>
 
 namespace quartz {
-	bool Verifier::equivalent_on_the_fly(Context *ctx, DAG *circuit1,
-	                                     DAG *circuit2) {
-		// Disable the verifier.
-		return false;
-		// Aggressively assume circuits with the same hash values are
-		// equivalent.
-		return circuit1->hash(ctx) == circuit2->hash(ctx);
-	}
+bool Verifier::equivalent_on_the_fly(Context *ctx, DAG *circuit1,
+                                     DAG *circuit2) {
+  // Disable the verifier.
+  return false;
+  // Aggressively assume circuits with the same hash values are
+  // equivalent.
+  return circuit1->hash(ctx) == circuit2->hash(ctx);
+}
 
-	bool Verifier::redundant(Context *ctx, DAG *dag) {
-		// Check if any suffix already exists.
-		// This function assumes that two DAGs are equivalent iff they share the
-		// same hash value.
-		auto subgraph = std::make_unique< DAG >(*dag);
-		while (subgraph->get_num_gates() > 0) {
-			subgraph->remove_gate(subgraph->edges[0].get());
-			if (subgraph->get_num_gates() == 0) {
-				break;
-			}
-			subgraph->hash(ctx);
-			const auto &rep = ctx->get_possible_representative(subgraph.get());
-			if (rep && !subgraph->fully_equivalent(*rep)) {
-				// |subgraph| already exists and is not the representative.
-				return true;
-			}
-		}
-		return false;
-	}
+bool Verifier::redundant(Context *ctx, DAG *dag) {
+  // Check if any suffix already exists.
+  // This function assumes that two DAGs are equivalent iff they share the
+  // same hash value.
+  auto subgraph = std::make_unique<DAG>(*dag);
+  while (subgraph->get_num_gates() > 0) {
+    subgraph->remove_gate(subgraph->edges[0].get());
+    if (subgraph->get_num_gates() == 0) {
+      break;
+    }
+    subgraph->hash(ctx);
+    const auto &rep = ctx->get_possible_representative(subgraph.get());
+    if (rep && !subgraph->fully_equivalent(*rep)) {
+      // |subgraph| already exists and is not the representative.
+      return true;
+    }
+  }
+  return false;
+}
 
-	bool Verifier::redundant(Context *ctx, const EquivalenceSet *eqs,
-	                         DAG *dag) {
-		// Representative pruning.
-		// Check if any suffix already exists.
-		auto subgraph = std::make_unique< DAG >(*dag);
-		while (subgraph->get_num_gates() > 0) {
-			if (subgraph->remove_first_quantum_gate() == 0) {
-				// Already no quantum gates
-				break;
-			}
-			if (subgraph->get_num_gates() == 0) {
-				break;
-			}
-			DAGHashType hash_value = subgraph->hash(ctx);
-			auto possible_classes = eqs->get_possible_classes(hash_value);
-			for (const auto &other_hash : subgraph->other_hash_values()) {
-				auto more_possible_classes =
-				    eqs->get_possible_classes(other_hash);
-				possible_classes.insert(possible_classes.end(),
-				                        more_possible_classes.begin(),
-				                        more_possible_classes.end());
-			}
-			std::sort(possible_classes.begin(), possible_classes.end());
-			auto last =
-			    std::unique(possible_classes.begin(), possible_classes.end());
-			possible_classes.erase(last, possible_classes.end());
-			for (const auto &equiv_class : possible_classes) {
-				if (equiv_class->contains(*subgraph)) {
-					if (!subgraph->fully_equivalent(
-					        *equiv_class->get_representative())) {
-						// |subgraph| already exists and is not the
-						// representative. So the whole |dag| is redundant.
-						return true;
-					}
-					else {
-						// |subgraph| already exists and is the representative.
-						// So we need to check other subgraphs.
-						break;
-					}
-				}
-			}
-		}
-		return false;
-	}
+bool Verifier::redundant(Context *ctx, const EquivalenceSet *eqs,
+                         DAG *dag) {
+  // Representative pruning.
+  // Check if DAG is in canonical representation.
+  if (!dag->is_canonical_representation()) {
+    return true;
+  }
+  // Check if canonicalize(dropfirst) already exists.
+  auto dropfirst = std::make_unique<DAG>(*dag);
+  dropfirst->remove_first_quantum_gate();
+  dropfirst->to_canonical_representation();
+  DAGHashType hash_value = dropfirst->hash(ctx);
+  auto possible_classes = eqs->get_possible_classes(hash_value);
+  for (const auto &other_hash : dropfirst->other_hash_values()) {
+    auto more_possible_classes =
+        eqs->get_possible_classes(other_hash);
+    possible_classes.insert(possible_classes.end(),
+                            more_possible_classes.begin(),
+                            more_possible_classes.end());
+  }
+  std::sort(possible_classes.begin(), possible_classes.end());
+  auto last =
+      std::unique(possible_classes.begin(), possible_classes.end());
+  possible_classes.erase(last, possible_classes.end());
+  for (const auto &equiv_class : possible_classes) {
+    if (equiv_class->contains(*dropfirst)) {
+      if (!dropfirst->fully_equivalent(
+          *equiv_class->get_representative())) {
+        // |dropfirst| already exists and is not the
+        // representative. So the whole |dag| is redundant.
+        return true;
+      } else {
+        // |dropfirst| already exists and is the representative.
+        break;
+      }
+    }
+  }
+  return false;
+}
 
 } // namespace quartz

--- a/src/quartz/verifier/verifier.cpp
+++ b/src/quartz/verifier/verifier.cpp
@@ -65,11 +65,12 @@ bool Verifier::redundant(Context *ctx, const EquivalenceSet *eqs,
         return true;
       } else {
         // |dropfirst| already exists and is the representative.
-        break;
+        return false;
       }
     }
   }
-  return false;
+  // |dropfirst| is not found and therefore is not a representative.
+  return true;
 }
 
 } // namespace quartz

--- a/src/test/test_all.cpp
+++ b/src/test/test_all.cpp
@@ -20,7 +20,7 @@ int main() {
 
 	DAG dag(2, 0);
 	dag.add_gate({0}, {}, y, nullptr);
-	std::cout << "Is_minimal=" << dag.is_minimal_circuit_representation()
+	std::cout << "Is_canonical=" << dag.is_canonical_representation()
 	          << std::endl;
 
 	Vector input_dis = Vector::random_generate(2);

--- a/src/test/test_generator.h
+++ b/src/test/test_generator.h
@@ -56,7 +56,7 @@ void test_generator(const std::vector< GateType > &support_gates,
 		for (auto &it : dataset.dataset) {
 			bool has_minimal_representation = false;
 			for (auto &dag : it.second) {
-				bool result = dag->minimal_circuit_representation(&tmp_dag);
+				bool result = dag->canonical_representation(&tmp_dag);
 				if (result) {
 					has_minimal_representation = true;
 				}

--- a/src/test/test_sparsity.cpp
+++ b/src/test/test_sparsity.cpp
@@ -71,7 +71,7 @@ void test_sparsity(const std::vector<GateType> &supported_gates,
              .c_str());
   equiv_set.clear();
   equiv_set.load_json(&ctx, file_prefix + "verified.json");
-  equiv_set.normalize_to_minimal_circuit_representations(&ctx);
+  equiv_set.normalize_to_canonical_representations(&ctx);
   end = std::chrono::steady_clock::now();
   std::cout
       << std::dec << "There are "


### PR DESCRIPTION
This PR changes the `generator.cpp` to generate the gates in the order of qubit indices, and the `verifier.cpp` to check if canonicalize(dropfirst) is a representative.

It also changes the code format of several relevant files to make the tab size to be 2 spaces so each line will not be too long.

The size of ECC sets, including the number of ECCs, the number of circuits, and the number of transformations, will be slightly changed due to a different selection of representatives.