### PR TITLE
[Generator] Minor optimization on generator based on canonical representation

### DIFF
--- a/src/quartz/dag/dag.cpp
+++ b/src/quartz/dag/dag.cpp
@@ -1084,19 +1084,9 @@ bool DAG::canonical_representation(std::unique_ptr<DAG> *output_dag,
   class CompareByMinQubitIndex {
    public:
     bool operator()(DAGHyperEdge *edge1, DAGHyperEdge *edge2) const {
-      auto get_min_qubit_index = [&](DAGHyperEdge *edge) {
-        int result = -1;
-        for (auto &input_node : edge->input_nodes) {
-          if (result == -1
-              || (input_node->is_qubit() && input_node->index < result)) {
-            result = input_node->index;
-          }
-        }
-        return result;
-      };
       // std::priority_queue maintains the largest element,
       // so we use ">" to get the gate with minimum qubit index.
-      return get_min_qubit_index(edge1) > get_min_qubit_index(edge2);
+      return edge1->get_min_qubit_index() > edge2->get_min_qubit_index();
     }
   };
 

--- a/src/quartz/dag/daghyperedge.cpp
+++ b/src/quartz/dag/daghyperedge.cpp
@@ -1,0 +1,16 @@
+#include "daghyperedge.h"
+#include "dagnode.h"
+
+namespace quartz {
+int DAGHyperEdge::get_min_qubit_index() const {
+  int result = -1;
+  for (auto &input_node : input_nodes) {
+    if (result == -1
+        || (input_node->is_qubit() && input_node->index < result)) {
+      result = input_node->index;
+    }
+  }
+  return result;
+}
+
+}

--- a/src/quartz/dag/daghyperedge.cpp
+++ b/src/quartz/dag/daghyperedge.cpp
@@ -5,8 +5,8 @@ namespace quartz {
 int DAGHyperEdge::get_min_qubit_index() const {
   int result = -1;
   for (auto &input_node : input_nodes) {
-    if (result == -1
-        || (input_node->is_qubit() && input_node->index < result)) {
+    if (input_node->is_qubit()
+        && (result == -1 || input_node->index < result)) {
       result = input_node->index;
     }
   }

--- a/src/quartz/dag/daghyperedge.h
+++ b/src/quartz/dag/daghyperedge.h
@@ -7,14 +7,15 @@
 
 namespace quartz {
 
-	class DAGNode;
+class DAGNode;
 
-	// A hyperedge in DAG corresponds to a gate in the circuit.
-	class DAGHyperEdge {
-	public:
-		std::vector< DAGNode * > input_nodes; // Nodes including parameters!
-		std::vector< DAGNode * > output_nodes;
+// A hyperedge in DAG corresponds to a gate in the circuit.
+class DAGHyperEdge {
+ public:
+  int get_min_qubit_index() const;
+  std::vector<DAGNode *> input_nodes; // Nodes including parameters!
+  std::vector<DAGNode *> output_nodes;
 
-		Gate *gate;
-	};
+  Gate *gate;
+};
 } // namespace quartz

--- a/src/quartz/verifier/verifier.cpp
+++ b/src/quartz/verifier/verifier.cpp
@@ -34,12 +34,10 @@ bool Verifier::redundant(Context *ctx, DAG *dag) {
 
 bool Verifier::redundant(Context *ctx, const EquivalenceSet *eqs,
                          DAG *dag) {
-  // Representative pruning.
-  // Check if DAG is in canonical representation.
-  if (!dag->is_canonical_representation()) {
-    return true;
-  }
-  // Check if canonicalize(dropfirst) already exists.
+  // RepGen.
+  // We have already known that |dag| is a canonical sequence and DropLast(dag)
+  // is a representative.
+  // Check if canonicalize(DropFirst(dag)) is a representative.
   auto dropfirst = std::make_unique<DAG>(*dag);
   dropfirst->remove_first_quantum_gate();
   dropfirst->to_canonical_representation();

--- a/src/quartz/verifier/verifier.cpp
+++ b/src/quartz/verifier/verifier.cpp
@@ -35,8 +35,11 @@ bool Verifier::redundant(Context *ctx, DAG *dag) {
 bool Verifier::redundant(Context *ctx, const EquivalenceSet *eqs,
                          DAG *dag) {
   // RepGen.
-  // We have already known that |dag| is a canonical sequence and DropLast(dag)
-  // is a representative.
+  // Check if |dag| is a canonical sequence.
+  if (!dag->is_canonical_representation()) {
+    return true;
+  }
+  // We have already known that DropLast(dag) is a representative.
   // Check if canonicalize(DropFirst(dag)) is a representative.
   auto dropfirst = std::make_unique<DAG>(*dag);
   dropfirst->remove_first_quantum_gate();


### PR DESCRIPTION
Logs when generating (3,3)- and (4,3)-complete ECC sets for the Nam gate set on an Ubuntu workstation:
```
Nam_3_3 generated. Running Time (s): 5.301
Pruning Time (s): 0.054
Verification Time (s): 4.461
Num_total_dags = 193, num_equivalence_classes = 81
*** Number of transformations of Nam_3_3 = 224

Nam_4_3 generated. Running Time (s): 41.493
Pruning Time (s): 0.453
Verification Time (s): 32.829
Num_total_dags = 1294, num_equivalence_classes = 588
*** Number of transformations of Nam_4_3 = 1412
```