### PR TITLE
[Optimizer] Add an option to optimize for circuit depth

### DIFF
--- a/src/benchmark/nam_small_circuits.cpp
+++ b/src/benchmark/nam_small_circuits.cpp
@@ -50,6 +50,7 @@ void benchmark_nam(const std::string &circuit_name) {
                 .count() /
                 1000.0
             << " seconds: gate count = " << graph_before_search->gate_count()
+            << ", circuit depth = " << graph_before_search->circuit_depth()
             << ", cost = " << graph_before_search->total_cost() << std::endl;
 
   start = std::chrono::steady_clock::now();
@@ -75,6 +76,7 @@ void benchmark_nam(const std::string &circuit_name) {
                 .count() /
                 1000.0
             << " seconds: gate count = " << graph_after_search->gate_count()
+            << ", circuit depth = " << graph_after_search->circuit_depth()
             << ", cost = " << graph_after_search->total_cost() << std::endl;
 
   geomean_gate_count /= graph_after_search->gate_count();

--- a/src/quartz/tasograph/tasograph.cpp
+++ b/src/quartz/tasograph/tasograph.cpp
@@ -376,6 +376,8 @@ std::shared_ptr<Graph> Graph::context_shift(Context *src_ctx, Context *dst_ctx,
 }
 
 float Graph::total_cost(void) const {
+  // Uncomment to use circuit depth as the cost
+  // return circuit_depth();
   size_t cnt = 0;
   for (const auto &it : inEdges) {
     if (it.first.ptr->is_quantum_gate())
@@ -392,6 +394,49 @@ int Graph::gate_count() const {
       cnt++;
   }
   return cnt;
+}
+
+int Graph::circuit_depth() const {
+  std::unordered_map<Op, std::vector<int>, OpHash> op_2_qubit_idx;
+  std::vector<int> depth(get_num_qubits(), 0);
+  std::queue<Op> gates;
+  std::unordered_map<Op, int, OpHash> gate_indegree;
+  for (const auto &it: outEdges) {
+    if (it.first.ptr->tp == GateType::input_qubit) {
+      auto idx = input_qubit_op_2_qubit_idx.find(it.first);
+      op_2_qubit_idx[it.first] = std::vector<int>(1, idx->second);
+      gates.push(it.first);
+    }
+  }
+  while (!gates.empty()) {
+    const auto &gate = gates.front();
+    gates.pop();
+    if (outEdges.count(gate) == 0) {
+      continue;
+    }
+    for (auto &edge : outEdges.find(gate)->second) {
+      if (gate_indegree.count(edge.dstOp) == 0) {
+        gate_indegree[edge.dstOp] = edge.dstOp.ptr->num_qubits;
+        op_2_qubit_idx[edge.dstOp] = std::vector<int>(edge.dstOp.ptr->num_qubits, 0);
+      }
+      gate_indegree[edge.dstOp]--;
+      op_2_qubit_idx[edge.dstOp][edge.dstIdx] = op_2_qubit_idx[edge.srcOp][edge.srcIdx];
+      if (!gate_indegree[edge.dstOp]) {
+        // Append the gate
+        int max_previous_depth = 0;
+        for (auto &idx: op_2_qubit_idx[edge.dstOp]) {
+          max_previous_depth = std::max(max_previous_depth, depth[idx]);
+        }
+        // Update the depth
+        for (auto &idx: op_2_qubit_idx[edge.dstOp]) {
+          depth[idx] = max_previous_depth + 1;
+        }
+        gates.push(edge.dstOp);
+      }
+    }
+  }
+  int max_depth = *std::max_element(depth.begin(), depth.end());
+  return max_depth;
 }
 
 void Graph::remove_node(Op oldOp) {

--- a/src/quartz/tasograph/tasograph.cpp
+++ b/src/quartz/tasograph/tasograph.cpp
@@ -1541,7 +1541,7 @@ std::shared_ptr<Graph> Graph::optimize(
                   .count() /
               1000.0 >
           timeout) {
-        std::cout << "Timeout. Program terminated. Best gate count is "
+        std::cout << "Timeout. Program terminated. Best cost is "
                   << bestCost << std::endl;
         bestGraph->constant_and_rotation_elimination();
         return bestGraph;

--- a/src/quartz/tasograph/tasograph.h
+++ b/src/quartz/tasograph/tasograph.h
@@ -181,8 +181,9 @@ public:
   size_t hash();
   bool equal(const Graph &other) const;
   bool check_correctness();
-  float total_cost() const;
-  int gate_count() const;
+  [[nodiscard]] float total_cost() const;
+  [[nodiscard]] int gate_count() const;
+  [[nodiscard]] int circuit_depth() const;
   size_t get_next_special_op_guid();
   size_t get_special_op_guid();
   void set_special_op_guid(size_t _special_op_guid);


### PR DESCRIPTION
This PR mainly adds a function to compute the circuit depth. @zikun-li Please review it :)

This PR doesn't change the default cost function (which is gate count).

Benchmark `nam_small_circuits`:

If we use gate count as the cost function:
```
tof_3 after toffoli flip in 0.04 seconds: gate count = 39, circuit depth = 31, cost = 39
tof_3: bestCost(39.0000) candidates(0) after 0.0000 seconds
tof_3: bestCost(37.0000) candidates(1) after 3.8360 seconds
tof_3: bestCost(35.0000) candidates(1) after 6.1590 seconds
tof_3: bestCost(35.0000) candidates(0) after 7.9390 seconds
tof_3 optimization result in 11.051 seconds: gate count = 35, circuit depth = 31, cost = 35
barenco_tof_3 after toffoli flip in 0.043 seconds: gate count = 46, circuit depth = 41, cost = 46
barenco_tof_3: bestCost(46.0000) candidates(0) after 0.0000 seconds
barenco_tof_3: bestCost(44.0000) candidates(3) after 3.4950 seconds
barenco_tof_3: bestCost(42.0000) candidates(5) after 7.0360 seconds
barenco_tof_3: bestCost(41.0000) candidates(6) after 9.8090 seconds
barenco_tof_3: Timeout. Program terminated. Best cost is 40
barenco_tof_3 optimization result in 13.318 seconds: gate count = 40, circuit depth = 37, cost = 40
mod_mult_55 after toffoli flip in 0.168 seconds: gate count = 105, circuit depth = 49, cost = 105
mod_mult_55: bestCost(105.0000) candidates(0) after 0.0000 seconds
mod_mult_55: Timeout. Program terminated. Best cost is 103
mod_mult_55 optimization result in 23.818 seconds: gate count = 103, circuit depth = 49, cost = 103
vbe_adder_3 after toffoli flip in 0.287 seconds: gate count = 115, circuit depth = 78, cost = 115
vbe_adder_3: bestCost(115.0000) candidates(0) after 0.0000 seconds
vbe_adder_3: Timeout. Program terminated. Best cost is 113
vbe_adder_3 optimization result in 30.22 seconds: gate count = 113, circuit depth = 76, cost = 113
gf2^4_mult after toffoli flip in 0.796 seconds: gate count = 186, circuit depth = 102, cost = 186
gf2^4_mult: bestCost(186.0000) candidates(0) after 0.0020 seconds
gf2^4_mult: Timeout. Program terminated. Best cost is 184
gf2^4_mult optimization result in 104.515 seconds: gate count = 184, circuit depth = 102, cost = 184
5 circuits, gate count optimized by 1.06089 times on average.
```

If we use circuit depth instead as the cost function:
```
tof_3 after toffoli flip in 0.032 seconds: gate count = 39, circuit depth = 31, cost = 31
tof_3: bestCost(31.0000) candidates(0) after 0.0000 seconds
tof_3: bestCost(29.0000) candidates(1) after 2.1680 seconds
tof_3: bestCost(29.0000) candidates(0) after 4.1600 seconds
tof_3 optimization result in 7.121 seconds: gate count = 39, circuit depth = 29, cost = 29
barenco_tof_3 after toffoli flip in 0.038 seconds: gate count = 46, circuit depth = 41, cost = 41
barenco_tof_3: bestCost(41.0000) candidates(0) after 0.0000 seconds
barenco_tof_3: bestCost(39.0000) candidates(5) after 3.3090 seconds
barenco_tof_3: bestCost(37.0000) candidates(7) after 6.4210 seconds
barenco_tof_3: bestCost(37.0000) candidates(6) after 9.9350 seconds
barenco_tof_3: Timeout. Program terminated. Best cost is 36
barenco_tof_3 optimization result in 13.814 seconds: gate count = 44, circuit depth = 36, cost = 36
mod_mult_55 after toffoli flip in 0.138 seconds: gate count = 105, circuit depth = 49, cost = 49
mod_mult_55: bestCost(49.0000) candidates(0) after 0.0010 seconds
mod_mult_55: Timeout. Program terminated. Best cost is 47
mod_mult_55 optimization result in 26.387 seconds: gate count = 105, circuit depth = 47, cost = 47
vbe_adder_3 after toffoli flip in 0.224 seconds: gate count = 115, circuit depth = 78, cost = 78
vbe_adder_3: bestCost(78.0000) candidates(0) after 0.0020 seconds
vbe_adder_3: Timeout. Program terminated. Best cost is 74
vbe_adder_3 optimization result in 44.427 seconds: gate count = 113, circuit depth = 74, cost = 74
gf2^4_mult after toffoli flip in 0.861 seconds: gate count = 186, circuit depth = 102, cost = 102
gf2^4_mult: bestCost(102.0000) candidates(0) after 0.0030 seconds
gf2^4_mult: Timeout. Program terminated. Best cost is 98
gf2^4_mult optimization result in 104.987 seconds: gate count = 186, circuit depth = 98, cost = 98
5 circuits, gate count optimized by 1.01248 times on average.
```

If we use 0.1 * `gate count` + `circuit depth` instead as the cost function:
```
tof_3 after toffoli flip in 0.038 seconds: gate count = 39, circuit depth = 31, cost = 34.9
tof_3: bestCost(34.9000) candidates(0) after 0.0000 seconds
tof_3: bestCost(32.9000) candidates(3) after 2.9040 seconds
tof_3: bestCost(32.7000) candidates(4) after 5.5020 seconds
tof_3: bestCost(32.5000) candidates(4) after 7.9800 seconds
tof_3: Timeout. Program terminated. Best cost is 32.5
tof_3 optimization result in 11.623 seconds: gate count = 35, circuit depth = 29, cost = 32.5
barenco_tof_3 after toffoli flip in 0.088 seconds: gate count = 46, circuit depth = 41, cost = 45.6
barenco_tof_3: bestCost(45.6000) candidates(0) after 0.0000 seconds
barenco_tof_3: bestCost(43.5000) candidates(7) after 3.9340 seconds
barenco_tof_3: bestCost(41.4000) candidates(11) after 7.3270 seconds
barenco_tof_3: Timeout. Program terminated. Best cost is 41.2
barenco_tof_3 optimization result in 12.603 seconds: gate count = 42, circuit depth = 37, cost = 41.2
mod_mult_55 after toffoli flip in 0.169 seconds: gate count = 105, circuit depth = 49, cost = 59.5
mod_mult_55: bestCost(59.5000) candidates(0) after 0.0010 seconds
mod_mult_55: Timeout. Program terminated. Best cost is 57.3
mod_mult_55 optimization result in 22.54 seconds: gate count = 103, circuit depth = 47, cost = 57.3
vbe_adder_3 after toffoli flip in 0.539 seconds: gate count = 115, circuit depth = 77, cost = 88.5
vbe_adder_3: bestCost(88.5000) candidates(0) after 0.0030 seconds
vbe_adder_3: Timeout. Program terminated. Best cost is 84.3
vbe_adder_3 optimization result in 42.01 seconds: gate count = 113, circuit depth = 73, cost = 84.3
gf2^4_mult after toffoli flip in 0.553 seconds: gate count = 186, circuit depth = 102, cost = 120.6
gf2^4_mult: bestCost(120.6000) candidates(0) after 0.0050 seconds
gf2^4_mult: Timeout. Program terminated. Best cost is 116.6
gf2^4_mult optimization result in 99.578 seconds: gate count = 186, circuit depth = 98, cost = 116.6
5 circuits, gate count optimized by 1.04832 times on average.
```
I feel like this "mixed" one would probably work the best when optimizing for circuit depth because it breaks ties better.