### PR TITLE
[Benchmark] Change alpha from 0.999 to 1.0001 in the benchmark

### DIFF
--- a/src/benchmark/nam_small_circuits.cpp
+++ b/src/benchmark/nam_small_circuits.cpp
@@ -55,7 +55,7 @@ void benchmark_nam(const std::string &circuit_name) {
   start = std::chrono::steady_clock::now();
   // Optimization
   auto graph_after_search = graph_before_search->optimize(
-      0.999,
+      1.0001,
       0,
       false,
       &dst_ctx,


### PR DESCRIPTION
This PR is to make the small benchmark more consistent with the paper. The results do not change.

Before (on an Ubuntu workstation):
```
tof_3 after toffoli flip in 0.004 seconds: gate count = 39, cost = 39
tof_3: bestCost(39.0000) candidates(0) after 0.0000 seconds
tof_3: bestCost(37.0000) candidates(1) after 0.3010 seconds
tof_3: bestCost(35.0000) candidates(1) after 0.5530 seconds
tof_3: bestCost(35.0000) candidates(0) after 0.7500 seconds
tof_3 optimization result in 1.113 seconds: gate count = 35, cost = 35
barenco_tof_3 after toffoli flip in 0.006 seconds: gate count = 46, cost = 46
barenco_tof_3: bestCost(46.0000) candidates(0) after 0.0000 seconds
barenco_tof_3: bestCost(44.0000) candidates(3) after 0.4730 seconds
barenco_tof_3: bestCost(42.0000) candidates(5) after 0.8790 seconds
barenco_tof_3: bestCost(41.0000) candidates(6) after 1.2290 seconds
barenco_tof_3: bestCost(40.0000) candidates(6) after 1.5540 seconds
barenco_tof_3: bestCost(40.0000) candidates(5) after 1.8500 seconds
barenco_tof_3: bestCost(40.0000) candidates(4) after 2.1740 seconds
barenco_tof_3: bestCost(40.0000) candidates(3) after 2.5620 seconds
barenco_tof_3: bestCost(40.0000) candidates(2) after 2.9520 seconds
barenco_tof_3: bestCost(40.0000) candidates(1) after 3.3610 seconds
barenco_tof_3: bestCost(40.0000) candidates(0) after 3.8030 seconds
barenco_tof_3 optimization result in 4.362 seconds: gate count = 40, cost = 40
mod_mult_55 after toffoli flip in 0.023 seconds: gate count = 105, cost = 105
mod_mult_55: bestCost(105.0000) candidates(0) after 0.0000 seconds
mod_mult_55: bestCost(103.0000) candidates(4) after 2.4920 seconds
mod_mult_55: bestCost(101.0000) candidates(6) after 4.8220 seconds
mod_mult_55: bestCost(99.0000) candidates(7) after 6.9930 seconds
mod_mult_55: bestCost(97.0000) candidates(7) after 9.0110 seconds
mod_mult_55: Timeout. Program terminated. Best gate count is 97
mod_mult_55 optimization result in 10.972 seconds: gate count = 97, cost = 97
vbe_adder_3 after toffoli flip in 0.044 seconds: gate count = 115, cost = 115
vbe_adder_3: bestCost(115.0000) candidates(0) after 0.0000 seconds
vbe_adder_3: bestCost(113.0000) candidates(10) after 3.8250 seconds
vbe_adder_3: bestCost(111.0000) candidates(19) after 7.4970 seconds
vbe_adder_3: Timeout. Program terminated. Best gate count is 109
vbe_adder_3 optimization result in 11.036 seconds: gate count = 109, cost = 109
gf2^4_mult after toffoli flip in 0.091 seconds: gate count = 186, cost = 186
gf2^4_mult: bestCost(186.0000) candidates(0) after 0.0000 seconds
gf2^4_mult: bestCost(184.0000) candidates(1) after 9.6470 seconds
gf2^4_mult: Timeout. Program terminated. Best gate count is 182
gf2^4_mult optimization result in 19.383 seconds: gate count = 182, cost = 182
5 circuits, gate count optimized by 1.08384 times on average.
```

After:
```
tof_3 after toffoli flip in 0.004 seconds: gate count = 39, cost = 39
tof_3: bestCost(39.0000) candidates(0) after 0.0000 seconds
tof_3: bestCost(37.0000) candidates(8) after 0.3020 seconds
tof_3: bestCost(35.0000) candidates(14) after 0.5500 seconds
tof_3: bestCost(35.0000) candidates(18) after 0.7480 seconds
tof_3: bestCost(35.0000) candidates(21) after 0.9410 seconds
tof_3: bestCost(35.0000) candidates(24) after 1.1340 seconds
tof_3: bestCost(35.0000) candidates(27) after 1.3310 seconds
tof_3: bestCost(35.0000) candidates(32) after 1.5260 seconds
tof_3: bestCost(35.0000) candidates(35) after 1.7210 seconds
tof_3: bestCost(35.0000) candidates(40) after 1.9200 seconds
tof_3: bestCost(35.0000) candidates(44) after 2.1130 seconds
tof_3: bestCost(35.0000) candidates(47) after 2.3110 seconds
tof_3: bestCost(35.0000) candidates(49) after 2.5030 seconds
tof_3: bestCost(35.0000) candidates(51) after 2.6920 seconds
tof_3: bestCost(35.0000) candidates(55) after 2.8920 seconds
tof_3: bestCost(35.0000) candidates(59) after 3.0850 seconds
tof_3: bestCost(35.0000) candidates(60) after 3.2760 seconds
tof_3: bestCost(35.0000) candidates(64) after 3.4750 seconds
tof_3: bestCost(35.0000) candidates(68) after 3.6630 seconds
tof_3: bestCost(35.0000) candidates(72) after 3.8570 seconds
tof_3: bestCost(35.0000) candidates(74) after 4.0520 seconds
tof_3: bestCost(35.0000) candidates(77) after 4.2490 seconds
tof_3: bestCost(35.0000) candidates(82) after 4.4430 seconds
tof_3: bestCost(35.0000) candidates(85) after 4.6390 seconds
tof_3: bestCost(35.0000) candidates(88) after 4.8390 seconds
tof_3: bestCost(35.0000) candidates(91) after 5.0270 seconds
tof_3: bestCost(35.0000) candidates(95) after 5.2260 seconds
tof_3: bestCost(35.0000) candidates(98) after 5.4210 seconds
tof_3: bestCost(35.0000) candidates(102) after 5.6200 seconds
tof_3: bestCost(35.0000) candidates(108) after 5.8170 seconds
tof_3: bestCost(35.0000) candidates(112) after 6.0150 seconds
tof_3: bestCost(35.0000) candidates(114) after 6.2150 seconds
tof_3: bestCost(35.0000) candidates(117) after 6.4050 seconds
tof_3: bestCost(35.0000) candidates(121) after 6.6000 seconds
tof_3: bestCost(35.0000) candidates(123) after 6.8010 seconds
tof_3: bestCost(35.0000) candidates(127) after 6.9990 seconds
tof_3: bestCost(35.0000) candidates(129) after 7.1950 seconds
tof_3: bestCost(35.0000) candidates(130) after 7.3930 seconds
tof_3: bestCost(35.0000) candidates(133) after 7.5880 seconds
tof_3: bestCost(35.0000) candidates(137) after 7.7870 seconds
tof_3: bestCost(35.0000) candidates(143) after 7.9830 seconds
tof_3: bestCost(35.0000) candidates(145) after 8.1840 seconds
tof_3: bestCost(35.0000) candidates(147) after 8.3810 seconds
tof_3: bestCost(35.0000) candidates(151) after 8.5800 seconds
tof_3: bestCost(35.0000) candidates(153) after 8.7780 seconds
tof_3: bestCost(35.0000) candidates(155) after 8.9740 seconds
tof_3: bestCost(35.0000) candidates(158) after 9.1710 seconds
tof_3: bestCost(35.0000) candidates(162) after 9.3650 seconds
tof_3: bestCost(35.0000) candidates(162) after 9.5630 seconds
tof_3: bestCost(35.0000) candidates(166) after 9.7570 seconds
tof_3: bestCost(35.0000) candidates(169) after 9.9560 seconds
tof_3: Timeout. Program terminated. Best gate count is 35
tof_3 optimization result in 10.277 seconds: gate count = 35, cost = 35
barenco_tof_3 after toffoli flip in 0.006 seconds: gate count = 46, cost = 46
barenco_tof_3: bestCost(46.0000) candidates(0) after 0.0000 seconds
barenco_tof_3: bestCost(44.0000) candidates(15) after 0.4740 seconds
barenco_tof_3: bestCost(42.0000) candidates(28) after 0.8840 seconds
barenco_tof_3: bestCost(41.0000) candidates(39) after 1.2320 seconds
barenco_tof_3: bestCost(40.0000) candidates(47) after 1.5530 seconds
barenco_tof_3: bestCost(40.0000) candidates(52) after 1.8480 seconds
barenco_tof_3: bestCost(40.0000) candidates(56) after 2.1360 seconds
barenco_tof_3: bestCost(40.0000) candidates(59) after 2.4240 seconds
barenco_tof_3: bestCost(40.0000) candidates(64) after 2.7180 seconds
barenco_tof_3: bestCost(40.0000) candidates(68) after 3.0100 seconds
barenco_tof_3: bestCost(40.0000) candidates(70) after 3.2950 seconds
barenco_tof_3: bestCost(40.0000) candidates(73) after 3.5850 seconds
barenco_tof_3: bestCost(40.0000) candidates(76) after 3.8710 seconds
barenco_tof_3: bestCost(40.0000) candidates(82) after 4.1670 seconds
barenco_tof_3: bestCost(40.0000) candidates(85) after 4.4620 seconds
barenco_tof_3: bestCost(40.0000) candidates(89) after 4.7520 seconds
barenco_tof_3: bestCost(40.0000) candidates(92) after 5.0410 seconds
barenco_tof_3: bestCost(40.0000) candidates(94) after 5.3330 seconds
barenco_tof_3: bestCost(40.0000) candidates(94) after 5.6210 seconds
barenco_tof_3: bestCost(40.0000) candidates(94) after 5.9090 seconds
barenco_tof_3: bestCost(40.0000) candidates(96) after 6.2020 seconds
barenco_tof_3: bestCost(40.0000) candidates(96) after 6.4920 seconds
barenco_tof_3: bestCost(40.0000) candidates(97) after 6.7850 seconds
barenco_tof_3: bestCost(40.0000) candidates(100) after 7.0740 seconds
barenco_tof_3: bestCost(40.0000) candidates(102) after 7.3670 seconds
barenco_tof_3: bestCost(40.0000) candidates(106) after 7.6510 seconds
barenco_tof_3: bestCost(40.0000) candidates(108) after 7.9410 seconds
barenco_tof_3: bestCost(40.0000) candidates(110) after 8.2330 seconds
barenco_tof_3: bestCost(40.0000) candidates(109) after 8.5170 seconds
barenco_tof_3: bestCost(40.0000) candidates(112) after 8.8110 seconds
barenco_tof_3: bestCost(40.0000) candidates(116) after 9.1020 seconds
barenco_tof_3: bestCost(40.0000) candidates(119) after 9.3940 seconds
barenco_tof_3: bestCost(40.0000) candidates(123) after 9.6900 seconds
barenco_tof_3: bestCost(40.0000) candidates(124) after 9.9820 seconds
barenco_tof_3: Timeout. Program terminated. Best gate count is 40
barenco_tof_3 optimization result in 10.381 seconds: gate count = 40, cost = 40
mod_mult_55 after toffoli flip in 0.023 seconds: gate count = 105, cost = 105
mod_mult_55: bestCost(105.0000) candidates(0) after 0.0000 seconds
mod_mult_55: bestCost(103.0000) candidates(34) after 2.4560 seconds
mod_mult_55: bestCost(101.0000) candidates(65) after 4.7540 seconds
mod_mult_55: bestCost(99.0000) candidates(94) after 6.8970 seconds
mod_mult_55: bestCost(97.0000) candidates(122) after 8.8850 seconds
mod_mult_55: Timeout. Program terminated. Best gate count is 97
mod_mult_55 optimization result in 10.849 seconds: gate count = 97, cost = 97
vbe_adder_3 after toffoli flip in 0.041 seconds: gate count = 115, cost = 115
vbe_adder_3: bestCost(115.0000) candidates(0) after 0.0000 seconds
vbe_adder_3: bestCost(113.0000) candidates(48) after 3.8070 seconds
vbe_adder_3: bestCost(111.0000) candidates(93) after 7.4080 seconds
vbe_adder_3: Timeout. Program terminated. Best gate count is 109
vbe_adder_3 optimization result in 10.977 seconds: gate count = 109, cost = 109
gf2^4_mult after toffoli flip in 0.092 seconds: gate count = 186, cost = 186
gf2^4_mult: bestCost(186.0000) candidates(0) after 0.0000 seconds
gf2^4_mult: bestCost(184.0000) candidates(74) after 9.5770 seconds
gf2^4_mult: Timeout. Program terminated. Best gate count is 182
gf2^4_mult optimization result in 19.473 seconds: gate count = 182, cost = 182
5 circuits, gate count optimized by 1.08384 times on average.
```