### PR TITLE
[Refactor] Use the new optimize function

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,18 +114,35 @@ As shown in the example above, the grammar for the rules are simple. Also, if a 
 #### Optimization
 
 You can use the API:
+```cpp
+std::shared_ptr<Graph> optimize(Context *ctx,
+                                const std::string &equiv_file_name,
+                                const std::string &circuit_name,
+                                bool print_message,
+                                double cost_upper_bound = -1 /*default = current cost * 1.05*/,
+                                int timeout = 3600 /*1 hour*/);
+```
+
+Explanation for some of the parameters:
+- `equiv_file_name`: The file name of the ECC set.
+- `circuit_name`: The name of the circuit, which will be printed with the intermediate result.
+- `print_message`: Print debug message to the console.
+- `cost_upper_bound`: Maximum circuit cost to be searched during optimization.
+- `timeout`: Timeout for optimization in seconds.
+
+You can also use the deprecated API for now:
 ``` cpp
-Graph::optimize(float alpha, int budget, bool print_subst, Context *ctx,
-           const std::string &equiv_file_name, bool use_simulated_annealing,
-           bool enable_early_stop, bool use_rotation_merging_in_searching,
-           GateType target_rotation, std::string circuit_name = "",
-           int timeout = 86400 /*1 day*/);
+Graph::optimize_legacy(float alpha, int budget, bool print_subst, Context *ctx,
+                       const std::string &equiv_file_name, bool use_simulated_annealing,
+                       bool enable_early_stop, bool use_rotation_merging_in_searching,
+                       GateType target_rotation, std::string circuit_name = "",
+                       int timeout = 86400 /*1 day*/);
 ```
 
 Explanation for some of the parameters:
 
 - `print_subst`: Deprecated will be removed in future version.
-- `equiv_file_name`: The filename of the file that stores the ECC set. 
+- `equiv_file_name`: The file name of the ECC set. 
 - `use_simulated_annealing`: Use simulated annealing in searching.
 - `use_rotation_merging_in_searching`: Enable rotation merging in each iteration of the back-track searching.
 - `target_rotation`: The target rotation used if you enable rotation merging in search.

--- a/src/benchmark/nam_small_circuits.cpp
+++ b/src/benchmark/nam_small_circuits.cpp
@@ -3,6 +3,7 @@
 #include "quartz/tasograph/substitution.h"
 #include <cmath>
 #include <filesystem>
+#include <sstream>
 
 using namespace quartz;
 
@@ -12,6 +13,7 @@ static const std::string
 
 static int num_benchmark = 0;
 static double geomean_gate_count = 1;
+static std::stringstream summary_result;
 
 void benchmark_nam(const std::string &circuit_name) {
   std::string circuit_path = "circuit/nam-benchmarks/" + circuit_name + ".qasm";
@@ -55,19 +57,12 @@ void benchmark_nam(const std::string &circuit_name) {
 
   start = std::chrono::steady_clock::now();
   // Optimization
-  auto graph_after_search = graph_before_search->optimize(
-      1.0001,
-      0,
-      false,
-      &dst_ctx,
-      ecc_set_name, /*use_simulated_annealing=*/
-      false, /*enable_early_stop=*/
-      false,
-      /*use_rotation_merging_in_searching=*/
-      false,
-      GateType::rz,
-      circuit_name, /*timeout=*/
-      10);
+  auto graph_after_search = graph_before_search->optimize(&dst_ctx,
+                                                          ecc_set_name,
+                                                          circuit_name, /*print_message=*/
+                                                          true, /*cost_upper_bound=*/
+                                                          -1, /*timeout=*/
+                                                          10);
   end = std::chrono::steady_clock::now();
 
   std::cout << circuit_name << " optimization result in "
@@ -78,6 +73,15 @@ void benchmark_nam(const std::string &circuit_name) {
             << " seconds: gate count = " << graph_after_search->gate_count()
             << ", circuit depth = " << graph_after_search->circuit_depth()
             << ", cost = " << graph_after_search->total_cost() << std::endl;
+
+  summary_result << circuit_name << " optimization result in "
+                 << (double) std::chrono::duration_cast<std::chrono::milliseconds>(
+                     end - start)
+                     .count() /
+                     1000.0
+                 << " seconds: gate count = " << graph_after_search->gate_count()
+                 << ", circuit depth = " << graph_after_search->circuit_depth()
+                 << ", cost = " << graph_after_search->total_cost() << std::endl;
 
   geomean_gate_count /= graph_after_search->gate_count();
   // graph_after_search->to_qasm(output_fn, false, false);
@@ -97,6 +101,8 @@ int main() {
   benchmark_nam("vbe_adder_3");  // 150 gates
   benchmark_nam("gf2^4_mult");  // 225 gates
   if (num_benchmark > 0) {
+    std::cout << "Summary:" << std::endl;
+    std::cout << summary_result.str();
     std::cout << num_benchmark << " circuits, gate count optimized by "
               << std::pow(geomean_gate_count, 1.0 / num_benchmark)
               << " times on average."

--- a/src/quartz/tasograph/tasograph.h
+++ b/src/quartz/tasograph/tasograph.h
@@ -201,15 +201,28 @@ public:
                                        RuleParser *rule_parser,
                                        bool ignore_toffoli = false);
   std::shared_ptr<Graph>
-  optimize(float alpha, int budget, bool print_subst, Context *ctx,
-           const std::string &equiv_file_name, bool use_simulated_annealing,
-           bool enable_early_stop, bool use_rotation_merging_in_searching,
-           GateType target_rotation, std::string circuit_name = "",
-           int timeout = 86400 /*1 day*/);
-  std::shared_ptr<Graph> optimize(std::vector<GraphXfer *> xfers,
-                                  double gate_count_upper_bound,
-                                  std::string circuit_name, bool print_message,
-                                  int timeout = 86400 /*1 day*/);
+  optimize_legacy(float alpha,
+                  int budget,
+                  bool print_subst,
+                  Context *ctx,
+                  const std::string &equiv_file_name,
+                  bool use_simulated_annealing,
+                  bool enable_early_stop,
+                  bool use_rotation_merging_in_searching,
+                  GateType target_rotation,
+                  std::string circuit_name = "",
+                  int timeout = 86400 /*1 day*/);
+  std::shared_ptr<Graph> optimize(Context *ctx,
+                                  const std::string &equiv_file_name,
+                                  const std::string &circuit_name,
+                                  bool print_message,
+                                  double cost_upper_bound = -1 /*default = current cost * 1.05*/,
+                                  int timeout = 3600 /*1 hour*/);
+  std::shared_ptr<Graph> optimize(const std::vector<GraphXfer *> &xfers,
+                                  double cost_upper_bound,
+                                  const std::string &circuit_name,
+                                  bool print_message,
+                                  int timeout = 3600 /*1 hour*/);
   void constant_and_rotation_elimination();
   void rotation_merging(GateType target_rotation);
   std::string to_qasm(bool print_result, bool print_id) const;

--- a/src/test/test_ibmq.cpp
+++ b/src/test/test_ibmq.cpp
@@ -81,13 +81,10 @@ int main(int argc, char **argv) {
   }
 
   // Optimization
-  auto graph_after_search = graph_before_search->optimize(
-      0.999, 0, false, &dst_ctx, eqset_fn, simulated_annealing, early_stop,
-      /*rotation_merging_in_searching*/ false, GateType::u1);
-  //  eqset_fn = "../IBM_with_U3_2_1_complete_ECC_set.json";
-  //  Graph *graph_after_u3_pass = graph_after_search->optimize(
-  //      0.999, 0, false, &dst_ctx, eqset_fn, simulated_annealing, early_stop,
-  //      /*rotation_merging_in_searching*/ false, GateType::u1);
+  auto graph_after_search = graph_before_search->optimize(&dst_ctx,
+                                                          eqset_fn,
+                                                          fn, /*print_message=*/
+                                                          true);
   end = std::chrono::steady_clock::now();
   std::cout << "Optimization results of Quartz for " << fn
             << " on IBMQ gate set." << std::endl

--- a/src/test/test_ibmq_td_disabled.cpp
+++ b/src/test/test_ibmq_td_disabled.cpp
@@ -57,16 +57,13 @@ int main(int argc, char **argv) {
   auto graph_before_search = graph_new_ctx->toffoli_flip_by_instruction(
       GateType::u1, xfer_pair.first, xfer_pair.second, trace);
 
-  // Optimization
-  auto graph_after_search = graph_before_search->optimize(
-      0.999, 0, false, &dst_ctx, eqset_fn, simulated_annealing, early_stop,
-      /*rotation_merging_in_searching*/ false, GateType::u1);
-  //  eqset_fn = "../IBM_with_U3_2_1_complete_ECC_set.json";
-  //  Graph *graph_after_u3_pass = graph_after_search->optimize(
-  //      0.999, 0, false, &dst_ctx, eqset_fn, simulated_annealing, early_stop,
-  //      /*rotation_merging_in_searching*/ false, GateType::u1);
-  auto end = std::chrono::steady_clock::now();
   auto fn = input_fn.substr(input_fn.rfind('/') + 1);
+  // Optimization
+  auto graph_after_search = graph_before_search->optimize(&dst_ctx,
+                                                          eqset_fn,
+                                                          fn, /*print_message=*/
+                                                          true);
+  auto end = std::chrono::steady_clock::now();
   std::cout << "Optimization results of Quartz for " << fn
             << " on IBMQ gate set." << std::endl
             << "Gate count after optimization: "

--- a/src/test/test_nam.cpp
+++ b/src/test/test_nam.cpp
@@ -75,9 +75,10 @@ int main(int argc, char **argv) {
   }
 
   // Optimization
-  auto graph_after_search = graph_before_search->optimize(
-      0.999, 0, false, &dst_ctx, eqset_fn, simulated_annealing, early_stop,
-      /*rotation_merging_in_searching*/ false, GateType::rz, fn);
+  auto graph_after_search = graph_before_search->optimize(&dst_ctx,
+                                                          eqset_fn,
+                                                          fn, /*print_message=*/
+                                                          true);
   end = std::chrono::steady_clock::now();
   std::cout << "Optimization results of Quartz for " << fn
             << " on Nam's gate set." << std::endl

--- a/src/test/test_nam_td_disabled.cpp
+++ b/src/test/test_nam_td_disabled.cpp
@@ -53,9 +53,10 @@ int main(int argc, char **argv) {
 
   // Optimization
   auto fn = input_fn.substr(input_fn.rfind('/') + 1);
-  auto graph_after_search = graph_before_search->optimize(
-      1.02, 0, false, &dst_ctx, eqset_fn, simulated_annealing, early_stop,
-      /*rotation_merging_in_searching*/ false, GateType::rz, fn);
+  auto graph_after_search = graph_before_search->optimize(&dst_ctx,
+                                                          eqset_fn,
+                                                          fn, /*print_message=*/
+                                                          true);
   auto end = std::chrono::steady_clock::now();
   std::cout << "Optimization results of Quartz for " << fn
             << " on Nam's gate set." << std::endl

--- a/src/test/test_optimization.h
+++ b/src/test/test_optimization.h
@@ -14,32 +14,32 @@ using namespace quartz;
 void test_optimization(Context *ctx, const std::string &file_name,
                        const std::string &equivalent_file_name,
                        bool use_simulated_annealing) {
-	QASMParser qasm_parser(ctx);
-	DAG *dag = nullptr;
-	if (!qasm_parser.load_qasm(file_name, dag)) {
-		std::cerr << "Parser failed" << std::endl;
-		return;
-	}
-    ctx->get_and_gen_input_dis(dag->get_num_qubits());
-    ctx->get_and_gen_hashing_dis(dag->get_num_qubits());
-    ctx->get_and_gen_parameters(dag->get_num_input_parameters());
+  QASMParser qasm_parser(ctx);
+  DAG *dag = nullptr;
+  if (!qasm_parser.load_qasm(file_name, dag)) {
+    std::cerr << "Parser failed" << std::endl;
+    return;
+  }
+  ctx->get_and_gen_input_dis(dag->get_num_qubits());
+  ctx->get_and_gen_hashing_dis(dag->get_num_qubits());
+  ctx->get_and_gen_parameters(dag->get_num_input_parameters());
 
-	quartz::Graph graph(ctx, dag);
-	std::cout << graph.total_cost() << " gates in circuit before optimizing."
-	          << std::endl;
-	auto start = std::chrono::steady_clock::now();
-	auto new_graph = graph.optimize(
-	    1.1, 0, false, ctx, equivalent_file_name, use_simulated_annealing,
-	    false /*early_stop*/, false /*rotation_merging*/,
-	    GateType::rz /*Just a placeholder*/);
-	auto end = std::chrono::steady_clock::now();
-	std::cout
-	    << "After optimizing graph in "
-	    << (double)std::chrono::duration_cast< std::chrono::milliseconds >(
-	           end - start)
-	               .count() /
-	           1000.0
-	    << " seconds, "
-	    << "total gate count becomes " << new_graph->total_cost() << "."
-	    << std::endl;
+  quartz::Graph graph(ctx, dag);
+  std::cout << graph.total_cost() << " gates in circuit before optimizing."
+            << std::endl;
+  auto start = std::chrono::steady_clock::now();
+  auto new_graph = graph.optimize(ctx,
+                                  equivalent_file_name,
+                                  file_name, /*print_message=*/
+                                  true);
+  auto end = std::chrono::steady_clock::now();
+  std::cout
+      << "After optimizing graph in "
+      << (double) std::chrono::duration_cast<std::chrono::milliseconds>(
+          end - start)
+          .count() /
+          1000.0
+      << " seconds, "
+      << "total gate count becomes " << new_graph->total_cost() << "."
+      << std::endl;
 }

--- a/src/test/test_quartz.cpp
+++ b/src/test/test_quartz.cpp
@@ -78,9 +78,10 @@ int main(int argc, char **argv) {
   graph_before_search->to_qasm(input_fn + ".toffoli_flip", false, false);
 
   // Optimization
-  auto graph_after_search = graph_before_search->optimize(
-      0.999, 0, false, &dst_ctx, eqset_fn, simulated_annealing, early_stop,
-      /*rotation_merging_in_searching*/ false, GateType::rz);
+  auto graph_after_search = graph_before_search->optimize(&dst_ctx,
+                                                          eqset_fn,
+                                                          input_fn, /*print_message=*/
+                                                          true);
   std::cout << "gate count after optimization: "
             << graph_after_search->total_cost() << std::endl;
   graph_after_search->to_qasm(output_fn, false, false);

--- a/src/test/test_rigetti.cpp
+++ b/src/test/test_rigetti.cpp
@@ -77,10 +77,10 @@ int main(int argc, char **argv) {
               << " on Rigetti gate set." << std::endl
               << "Gate count after optimization: "
               << graph_before_search->total_cost() << ", "
-              << (double)std::chrono::duration_cast<std::chrono::milliseconds>(
-                     end - start)
-                         .count() /
-                     1000.0
+              << (double) std::chrono::duration_cast<std::chrono::milliseconds>(
+                  end - start)
+                  .count() /
+                  1000.0
               << " seconds." << std::endl;
     return 0;
   }
@@ -91,10 +91,10 @@ int main(int argc, char **argv) {
   auto union_ctx_0 = union_contexts(&cz_ctx, &dst_ctx);
   auto graph_before_h_cz_merge = new_graph->context_shift(
       &dst_ctx, &cz_ctx, &union_ctx_0, &cx_2_cz, false);
-  auto graph_after_h_cz_merge = graph_before_h_cz_merge->optimize(
-      0.999, 0, false, &union_ctx_0, "../H_CZ_2_2_complete_ECC_set_modified.json",
-      simulated_annealing, false, /*rotation_merging_in_searching*/ true,
-      GateType::rz, fn);
+  auto graph_after_h_cz_merge = graph_before_h_cz_merge->optimize(&union_ctx_0,
+                                                                  "../H_CZ_2_2_complete_ECC_set_modified.json",
+                                                                  fn, /*print_message=*/
+                                                                  true);
   //   graph_after_h_cz_merge->to_qasm(
   //       "circuit/voqc-benchmarks/after_h_cz_merge.qasm", false, false);
 
@@ -108,18 +108,19 @@ int main(int argc, char **argv) {
       &cz_ctx, &rigetti_ctx, &union_ctx_1, &rules, false);
 
   // Optimization
-  auto graph_after_search = graph_rigetti->optimize(
-      0.999, 0, false, &union_ctx_1, eqset_fn, simulated_annealing, early_stop,
-      /*rotation_merging_in_searching*/ false, GateType::rz, fn);
+  auto graph_after_search = graph_rigetti->optimize(&union_ctx_1,
+                                                    eqset_fn,
+                                                    fn, /*print_message=*/
+                                                    true);
   end = std::chrono::steady_clock::now();
   std::cout << "Optimization results of Quartz for " << fn
             << " on Rigetti gate set." << std::endl
             << "Gate count after optimization: "
             << graph_after_search->total_cost() << ", "
-            << (double)std::chrono::duration_cast<std::chrono::milliseconds>(
-                   end - start)
-                       .count() /
-                   1000.0
+            << (double) std::chrono::duration_cast<std::chrono::milliseconds>(
+                end - start)
+                .count() /
+                1000.0
             << " seconds." << std::endl;
   graph_after_search->to_qasm(output_fn, false, false);
 }

--- a/src/test/test_rigetti_td_disabled.cpp
+++ b/src/test/test_rigetti_td_disabled.cpp
@@ -25,6 +25,7 @@ int main(int argc, char **argv) {
   bool early_stop = false;
   parse_args(argv, argc, simulated_annealing, early_stop, input_fn, output_fn,
              eqset_fn);
+  auto fn = input_fn.substr(input_fn.rfind('/') + 1);
 
   // Construct contexts
   Context src_ctx({GateType::h, GateType::ccz, GateType::cx, GateType::x,
@@ -58,10 +59,10 @@ int main(int argc, char **argv) {
   auto union_ctx_0 = union_contexts(&cz_ctx, &dst_ctx);
   auto graph_before_h_cz_merge = new_graph->context_shift(
       &dst_ctx, &cz_ctx, &union_ctx_0, &cx_2_cz, false);
-  auto graph_after_h_cz_merge = graph_before_h_cz_merge->optimize(
-      0.999, 0, false, &union_ctx_0, "../H_CZ_2_2_complete_ECC_set.json",
-      simulated_annealing, false, /*rotation_merging_in_searching*/ true,
-      GateType::rz);
+  auto graph_after_h_cz_merge = graph_before_h_cz_merge->optimize(&union_ctx_0,
+                                                                  "../H_CZ_2_2_complete_ECC_set_modified.json",
+                                                                  fn, /*print_message=*/
+                                                                  true);
   graph_after_h_cz_merge->to_qasm(
       "circuit/voqc-benchmarks/after_h_cz_merge.qasm", false, false);
 
@@ -75,19 +76,19 @@ int main(int argc, char **argv) {
       &cz_ctx, &rigetti_ctx, &union_ctx_1, &rules, false);
 
   // Optimization
-  auto graph_after_search = graph_rigetti->optimize(
-      0.999, 0, false, &union_ctx_1, eqset_fn, simulated_annealing, early_stop,
-      /*rotation_merging_in_searching*/ false, GateType::rz);
+  auto graph_after_search = graph_rigetti->optimize(&union_ctx_1,
+                                                    eqset_fn,
+                                                    fn, /*print_message=*/
+                                                    true);
   auto end = std::chrono::steady_clock::now();
-  auto fn = input_fn.substr(input_fn.rfind('/') + 1);
   std::cout << "Optimization results of Quartz for " << fn
             << " on Rigetti gate set." << std::endl
             << "Gate count after optimization: "
             << graph_after_search->total_cost() << ", "
-            << (double)std::chrono::duration_cast<std::chrono::milliseconds>(
-                   end - start)
-                       .count() /
-                   1000.0
+            << (double) std::chrono::duration_cast<std::chrono::milliseconds>(
+                end - start)
+                .count() /
+                1000.0
             << " seconds." << std::endl;
   graph_after_search->to_qasm(output_fn, false, false);
 }


### PR DESCRIPTION
This PR refactors the codebase to use the new `optimize` function in all cases, and rename the old one to be `optimize_legacy`.

It also creates a `optimize` function to take as input the ECC set file name and call the new `optimize` function for easier invocation.

It also adds a short summary for `src/benchmark/nam_small_circuits.cpp` for it to be easier to read.

It also changes the default timeout from 1 day to 1 hour.

Benchmark on Ubuntu workstation:
Before this PR:
```
tof_3 optimization result in 10.277 seconds: gate count = 35, cost = 35
barenco_tof_3 optimization result in 10.381 seconds: gate count = 40, cost = 40
mod_mult_55 optimization result in 10.849 seconds: gate count = 97, cost = 97
vbe_adder_3 optimization result in 10.977 seconds: gate count = 109, cost = 109
gf2^4_mult optimization result in 19.473 seconds: gate count = 182, cost = 182
5 circuits, gate count optimized by 1.08384 times on average.
```
After this PR:
```
tof_3 optimization result in 10.194 seconds: gate count = 35, circuit depth = 31, cost = 35
barenco_tof_3 optimization result in 10.497 seconds: gate count = 40, circuit depth = 37, cost = 40
mod_mult_55 optimization result in 10.717 seconds: gate count = 96, circuit depth = 46, cost = 96
vbe_adder_3 optimization result in 10.563 seconds: gate count = 92, circuit depth = 58, cost = 92
gf2^4_mult optimization result in 10.632 seconds: gate count = 184, circuit depth = 103, cost = 184
5 circuits, gate count optimized by 1.1211 times on average.
```