### PR TITLE
[Optimizer] Set the candidate queue capacity to 2000

### DIFF
--- a/src/benchmark/nam_small_circuits.cpp
+++ b/src/benchmark/nam_small_circuits.cpp
@@ -95,6 +95,7 @@ int main() {
          GateType::add}, ecc_set_prefix, true, 3, 2, 4);
     std::cout << "ECC set generated." << std::endl;
   }
+  // Logs are printed to Nam_4_3_tof_3.log, Nam_4_3_barenco_tof_3.log, ...
   benchmark_nam("tof_3");  // 45 gates
   benchmark_nam("barenco_tof_3");  // 58 gates
   benchmark_nam("mod_mult_55");  // 119 gates

--- a/src/quartz/tasograph/tasograph.cpp
+++ b/src/quartz/tasograph/tasograph.cpp
@@ -1748,10 +1748,8 @@ std::shared_ptr<Graph> Graph::optimize(Context *ctx,
   }
   auto log_file_name =
       equiv_file_name.substr(0, std::max(0, (int) equiv_file_name.size() - 21))
-          +
-              circuit_name.substr(0, std::max(0, (int) circuit_name.size() - 5))
-          +
-              ".log";
+          + circuit_name +
+          ".log";
   return optimize(xfers,
                   cost_upper_bound,
                   circuit_name,

--- a/src/quartz/tasograph/tasograph.h
+++ b/src/quartz/tasograph/tasograph.h
@@ -218,9 +218,21 @@ public:
                                   bool print_message,
                                   double cost_upper_bound = -1 /*default = current cost * 1.05*/,
                                   int timeout = 3600 /*1 hour*/);
+  /**
+   * Optimize this circuit.
+   * @param xfers The circuit transformations.
+   * @param cost_upper_bound The maximum cost of the circuits to be searched.
+   * @param circuit_name The circuit name shown in the log.
+   * @param log_file_name The file name to output the log. If empty, the log
+   * will be outputted to the screen.
+   * @param print_message To output the log or not.
+   * @param timeout Timeout in seconds.
+   * @return The optimized circuit.
+   */
   std::shared_ptr<Graph> optimize(const std::vector<GraphXfer *> &xfers,
                                   double cost_upper_bound,
                                   const std::string &circuit_name,
+                                  const std::string &log_file_name,
                                   bool print_message,
                                   int timeout = 3600 /*1 hour*/);
   void constant_and_rotation_elimination();

--- a/src/quartz/tasograph/tasograph.h
+++ b/src/quartz/tasograph/tasograph.h
@@ -212,6 +212,18 @@ public:
                   GateType target_rotation,
                   std::string circuit_name = "",
                   int timeout = 86400 /*1 day*/);
+  /**
+   * Optimize this circuit.
+   * @param ctx The context variable.
+   * @param equiv_file_name The ECC set file name.
+   * @param circuit_name The circuit name shown in the log.
+   * @param print_message To output the log or not. The log will be outputted
+   * to a file with name combined by the ECC set file name and the circuit
+   * file name.
+   * @param cost_upper_bound The maximum cost of the circuits to be searched.
+   * @param timeout Timeout in seconds.
+   * @return The optimized circuit.
+   */
   std::shared_ptr<Graph> optimize(Context *ctx,
                                   const std::string &equiv_file_name,
                                   const std::string &circuit_name,

--- a/src/test/test_optimize.cpp
+++ b/src/test/test_optimize.cpp
@@ -34,5 +34,5 @@ int main() {
   }
   std::cout << "number of xfers: " << xfers.size() << std::endl;
 
-  graph->optimize(xfers, graph->gate_count() * 1.05, "barenco_tof_3", true);
+  graph->optimize(xfers, graph->gate_count() * 1.05, "barenco_tof_3", "", true);
 }


### PR DESCRIPTION
Related PR = https://github.com/quantum-compiler/quartz/pull/37#issuecomment-1204384289

This PR makes the `optimize` function check in each iteration if the size of the candidate queue is more than 2000. If so, shrink it to 1000 to avoid consuming too much memory.

Also prints the log into a file in `optimize`.