### PR TITLE
[Optimizer] Reduce the number of xfers in optimize()

### DIFF
--- a/src/benchmark/nam_small_circuits.cpp
+++ b/src/benchmark/nam_small_circuits.cpp
@@ -60,7 +60,8 @@ void benchmark_nam(const std::string &circuit_name) {
   auto graph_after_search = graph_before_search->optimize(&dst_ctx,
                                                           ecc_set_name,
                                                           circuit_name, /*print_message=*/
-                                                          true, /*cost_upper_bound=*/
+                                                          true, /*cost_function=*/
+                                                          nullptr, /*cost_upper_bound=*/
                                                           -1, /*timeout=*/
                                                           10);
   end = std::chrono::steady_clock::now();

--- a/src/quartz/dag/dag.cpp
+++ b/src/quartz/dag/dag.cpp
@@ -482,6 +482,23 @@ int DAG::get_num_internal_parameters() const {
 
 int DAG::get_num_gates() const { return (int) edges.size(); }
 
+int DAG::get_circuit_depth() const {
+  std::vector<int> depth(get_num_qubits(), 0);
+  for (auto &edge : edges) {
+    if (edge->gate->is_quantum_gate()) {
+      int max_previous_depth = 0;
+      for (auto &input_node : edge->input_nodes) {
+        max_previous_depth =
+            std::max(max_previous_depth, depth[input_node->index]);
+      }
+      for (auto &input_node : edge->input_nodes) {
+        depth[input_node->index] = max_previous_depth + 1;
+      }
+    }
+  }
+  return *std::max_element(depth.begin(), depth.end());
+}
+
 bool DAG::qubit_used(int qubit_index) const {
   return outputs[qubit_index] != nodes[qubit_index].get();
 }

--- a/src/quartz/dag/dag.h
+++ b/src/quartz/dag/dag.h
@@ -51,6 +51,7 @@ class DAG {
   [[nodiscard]] int get_num_total_parameters() const;
   [[nodiscard]] int get_num_internal_parameters() const;
   [[nodiscard]] int get_num_gates() const;
+  [[nodiscard]] int get_circuit_depth() const;
   [[nodiscard]] bool qubit_used(int qubit_index) const;
   // Used by a parameter gate is considered as used here.
   [[nodiscard]] bool input_param_used(int param_index) const;

--- a/src/quartz/tasograph/tasograph.cpp
+++ b/src/quartz/tasograph/tasograph.cpp
@@ -1731,16 +1731,27 @@ std::shared_ptr<Graph> Graph::optimize(Context *ctx,
   }
 
   // Get xfer from the equivalent set
-  auto ecc = eqs.get_all_equivalence_sets();
+  auto eccs = eqs.get_all_equivalence_sets();
   std::vector<GraphXfer *> xfers;
-  for (const auto &eqcs : ecc) {
-    for (auto circ_0 : eqcs) {
-      for (auto circ_1 : eqcs) {
-        if (circ_0 != circ_1) {
-          auto xfer = GraphXfer::create_GraphXfer(ctx, circ_0, circ_1, false);
-          if (xfer != nullptr) {
-            xfers.push_back(xfer);
-          }
+  for (const auto &ecc : eccs) {
+    DAG *representative = ecc.front();
+    /*int representative_depth = representative->get_circuit_depth();
+    for (auto &circuit : ecc) {
+      int circuit_depth = circuit->get_circuit_depth();
+      if (circuit_depth < representative_depth) {
+        representative = circuit;
+        representative_depth = circuit_depth;
+      }
+    }*/
+    for (auto &circuit : ecc) {
+      if (circuit != representative) {
+        auto xfer = GraphXfer::create_GraphXfer(ctx, circuit, representative, false);
+        if (xfer != nullptr) {
+          xfers.push_back(xfer);
+        }
+        xfer = GraphXfer::create_GraphXfer(ctx, representative, circuit, false);
+        if (xfer != nullptr) {
+          xfers.push_back(xfer);
         }
       }
     }


### PR DESCRIPTION
This PR changes the `xfers` in 
```c++
  std::shared_ptr<Graph> optimize(Context *ctx,
                                  const std::string &equiv_file_name,
                                  const std::string &circuit_name,
                                  bool print_message,
                                  std::function<float(Graph *)> cost_function = nullptr,
                                  double cost_upper_bound = -1 /*default = current cost * 1.05*/,
                                  int timeout = 3600 /*1 hour*/);
```
to be only the circuit transformations involving the representative circuit.

Note that you can still specify the `xfer` set by calling the function
```c++
  std::shared_ptr<Graph> optimize(const std::vector<GraphXfer *> &xfers,
                                  double cost_upper_bound,
                                  const std::string &circuit_name,
                                  const std::string &log_file_name,
                                  bool print_message,
                                  std::function<float(Graph *)> cost_function = nullptr,
                                  int timeout = 3600 /*1 hour*/);
```

The nam_small_benchmark on laptop now:
```
tof_3 optimization result in 10.11 seconds: gate count = 35, circuit depth = 31, cost = 35
barenco_tof_3 optimization result in 10.107 seconds: gate count = 40, circuit depth = 37, cost = 40
mod_mult_55 optimization result in 10.266 seconds: gate count = 95, circuit depth = 46, cost = 95
vbe_adder_3 optimization result in 10.171 seconds: gate count = 92, circuit depth = 61, cost = 92
gf2^4_mult optimization result in 10.173 seconds: gate count = 180, circuit depth = 100, cost = 180
5 circuits, gate count optimized by 1.1284 times on average.
```