### PR TITLE
k-hop subgraph optimization for PPO

### DIFF
--- a/experiment/ppo-new/actor.py
+++ b/experiment/ppo-new/actor.py
@@ -730,7 +730,8 @@ class PPOAgent:
                     if self.subgraph_opt:
                         next_dgl_graph, next_nodes = self.khop_subgraph(next_dgl_graph, next_nodes)
                     eps_list.next_state.append(next_dgl_graph)
-                    eps_list.next_nodes.append(next_nodes)
+                # add next_nodes in all steps
+                eps_list.next_nodes.append(next_nodes)
 
                 # collect cur_graph info
                 if self.subgraph_opt:
@@ -745,14 +746,13 @@ class PPOAgent:
                 eps_list.reward.append(reward)
                 eps_list.game_over.append(game_over)
                 eps_list.node_value.append(action_node_values[i_eps])
-                eps_list.next_nodes.append(next_nodes)
                 eps_list.xfer_mask.append(cast(torch.BoolTensor, av_xfer_masks[i_eps]))
                 eps_list.xfer_logprob.append(action_xfer_logps[i_eps])
                 eps_list.info.append({})
                 
                 """collect info for graph buffer"""
                 graph_buffer = self.graph_buffers[buffer_idx_list[i_eps]]
-                
+
                 if i_step == last_eps_end + 1:
                     # the first step in an episode
                     graph_buffer.rewards.append([])
@@ -812,6 +812,7 @@ class PPOAgent:
         eps_list_cat = ExperienceList.new_empty()
         for eps_list in eps_lists:
             eps_list_cat += eps_list
+        eps_list_cat.sanity_check()
         return eps_list_cat
         
     def khop_subgraph(self, g: dgl.DGLGraph, nodes: List[int]) -> dgl.DGLGraph:

--- a/experiment/ppo-new/config/base_config.py
+++ b/experiment/ppo-new/config/base_config.py
@@ -93,6 +93,7 @@ class BaseConfig:
     greedy_sample: bool = False
     agent_collect: bool = True
     agent_batch_size: int = 128
+    subgraph_opt: bool = True
 
     # training
     max_iterations: int = int(1e8)

--- a/experiment/ppo-new/ds.py
+++ b/experiment/ppo-new/ds.py
@@ -132,7 +132,7 @@ class ExperienceList:
     def sanity_check(self) -> None:
         for name, field in self.items():
             assert len(field) == len(self), \
-                f'{len(name)} = len({name}) != len(self.state) = {len(self.state)})'
+                f'{len(name)} = len({name}) != len(self) = {len(self)})'
 
 
     def shuffle(self) -> None:

--- a/experiment/ppo-new/ds.py
+++ b/experiment/ppo-new/ds.py
@@ -107,6 +107,12 @@ class ExperienceList:
             getattr(self, field.name)
             for field in fields(self)
         ])
+    
+    def items(self):
+        return {
+            field.name: getattr(self, field.name)
+            for field in fields(self)
+        }.items()
 
     def __add__(self, other) -> ExperienceList:
         ret = ExperienceList.new_empty()
@@ -122,6 +128,12 @@ class ExperienceList:
     @staticmethod
     def new_empty() -> ExperienceList:
         return ExperienceList(*[[] for _ in range(len(fields(ExperienceList)))]) # type: ignore
+
+    def sanity_check(self) -> None:
+        for name, field in self.items():
+            assert len(field) == len(self), \
+                f'{len(name)} = len({name}) != len(self.state) = {len(self.state)})'
+
 
     def shuffle(self) -> None:
         self.state, self.action, self.reward, self.next_state, self.game_over, self.node_value, \

--- a/experiment/ppo-new/model/actor_critic.py
+++ b/experiment/ppo-new/model/actor_critic.py
@@ -47,6 +47,7 @@ class ActorCritic(nn.Module):
             self.device = device
             return
         
+        self.gnn_num_layers = gnn_num_layers
         self.device = device
         if gnn_type.lower() == 'QGNN'.lower():
             self.gnn = QGNN(

--- a/experiment/ppo-new/ppo.py
+++ b/experiment/ppo-new/ppo.py
@@ -161,6 +161,7 @@ class PPOMod:
             dyn_eps_len=self.cfg.dyn_eps_len,
             max_eps_len=self.cfg.max_eps_len,
             min_eps_len=self.cfg.min_eps_len,
+            subgraph_opt=self.cfg.subgraph_opt,
             output_full_seq=self.cfg.output_full_seq,
             output_dir=self.output_dir,
         )


### PR DESCRIPTION
1. fix: `next_nodes` information may be wrong.
2. feat: enable k-hop subgraph optimization by default, which only collects k-hop subgraph (in DGL) for training.