### PR TITLE
[Optimizer] Add a preprocessing pass to greedily optimize the circuit and add a benchmark

### DIFF
--- a/src/benchmark/CMakeLists.txt
+++ b/src/benchmark/CMakeLists.txt
@@ -5,3 +5,5 @@ link_directories("../..")
 
 file(GLOB_RECURSE NAM_SMALL_CIRCUITS "nam_small_circuits.cpp")
 add_executable(benchmark_nam_small_circuits ${NAM_SMALL_CIRCUITS})
+file(GLOB_RECURSE NAM_MIDDLE_CIRCUITS "nam_middle_circuits.cpp")
+add_executable(benchmark_nam_middle_circuits ${NAM_MIDDLE_CIRCUITS})

--- a/src/benchmark/nam_middle_circuits.cpp
+++ b/src/benchmark/nam_middle_circuits.cpp
@@ -1,0 +1,112 @@
+#include "quartz/parser/qasm_parser.h"
+#include "quartz/tasograph/substitution.h"
+#include "test/gen_ecc_set.h"
+#include <cmath>
+#include <filesystem>
+#include <sstream>
+
+using namespace quartz;
+
+static const std::string ecc_set_prefix = "Nam_6_3_";
+static const std::string ecc_set_name =
+    ecc_set_prefix + "complete_ECC_set.json";
+
+static int num_benchmark = 0;
+static double geomean_gate_count = 1;
+static std::stringstream summary_result;
+
+void benchmark_nam(const std::string &circuit_name) {
+  std::string circuit_path = "circuit/nam-benchmarks/" + circuit_name + ".qasm";
+  // Construct contexts
+  Context src_ctx({GateType::h, GateType::ccz, GateType::x, GateType::cx,
+                   GateType::input_qubit, GateType::input_param});
+  Context dst_ctx({GateType::h, GateType::x, GateType::rz, GateType::add,
+                   GateType::cx, GateType::input_qubit, GateType::input_param});
+  auto union_ctx = union_contexts(&src_ctx, &dst_ctx);
+
+  auto xfer_pair = GraphXfer::ccz_cx_rz_xfer(&union_ctx);
+  // Load qasm file
+  QASMParser qasm_parser(&src_ctx);
+  DAG *dag = nullptr;
+  if (!qasm_parser.load_qasm(circuit_path, dag)) {
+    std::cout << "Parser failed" << std::endl;
+    return;
+  }
+
+  Graph graph(&src_ctx, dag);
+
+  auto start = std::chrono::steady_clock::now();
+  // Greedy toffoli flip
+  auto graph_before_search = graph.toffoli_flip_greedy(
+      GateType::rz, xfer_pair.first, xfer_pair.second);
+  //   graph_before_search->to_qasm(input_fn + ".toffoli_flip", false, false);
+
+  auto end = std::chrono::steady_clock::now();
+
+  num_benchmark++;
+  geomean_gate_count *= graph_before_search->gate_count();
+
+  std::cout << circuit_name << " after toffoli flip in "
+            << (double)std::chrono::duration_cast<std::chrono::milliseconds>(
+                   end - start)
+                       .count() /
+                   1000.0
+            << " seconds: gate count = " << graph_before_search->gate_count()
+            << ", circuit depth = " << graph_before_search->circuit_depth()
+            << ", cost = " << graph_before_search->total_cost() << std::endl;
+
+  start = std::chrono::steady_clock::now();
+  // Optimization
+  auto graph_after_search = graph_before_search->optimize(
+      &dst_ctx, ecc_set_name, circuit_name, /*print_message=*/
+      true,                                 /*cost_function=*/
+      nullptr,                              /*cost_upper_bound=*/
+      -1,                                   /*timeout=*/
+      10);
+  end = std::chrono::steady_clock::now();
+
+  std::cout << circuit_name << " optimization result in "
+            << (double)std::chrono::duration_cast<std::chrono::milliseconds>(
+                   end - start)
+                       .count() /
+                   1000.0
+            << " seconds: gate count = " << graph_after_search->gate_count()
+            << ", circuit depth = " << graph_after_search->circuit_depth()
+            << ", cost = " << graph_after_search->total_cost() << std::endl;
+
+  summary_result
+      << circuit_name << " optimization result in "
+      << (double)std::chrono::duration_cast<std::chrono::milliseconds>(end -
+                                                                       start)
+                 .count() /
+             1000.0
+      << " seconds: gate count = " << graph_after_search->gate_count()
+      << ", circuit depth = " << graph_after_search->circuit_depth()
+      << ", cost = " << graph_after_search->total_cost() << std::endl;
+
+  geomean_gate_count /= graph_after_search->gate_count();
+  // graph_after_search->to_qasm(output_fn, false, false);
+}
+
+int main() {
+  if (!std::filesystem::exists(ecc_set_name)) {
+    std::cout << "Generating ECC set..." << std::endl;
+    gen_ecc_set(
+        {GateType::rz, GateType::h, GateType::cx, GateType::x, GateType::add},
+        ecc_set_prefix, true, 3, 2, 6);
+    std::cout << "ECC set generated." << std::endl;
+  }
+  // Logs are printed to Nam_6_3_barenco_tof_10.log, Nam_6_3_gf2^8_mult.log, ...
+  benchmark_nam("barenco_tof_10"); // 450 gates
+  benchmark_nam("gf2^8_mult");     // 883 gates
+  benchmark_nam("qcla_mod_7");     // 884 gates
+  benchmark_nam("adder_8");        // 900 gates
+  if (num_benchmark > 0) {
+    std::cout << "Summary:" << std::endl;
+    std::cout << summary_result.str();
+    std::cout << num_benchmark << " circuits, gate count optimized by "
+              << std::pow(geomean_gate_count, 1.0 / num_benchmark)
+              << " times on average." << std::endl;
+  }
+  return 0;
+}

--- a/src/quartz/tasograph/tasograph.cpp
+++ b/src/quartz/tasograph/tasograph.cpp
@@ -1477,6 +1477,8 @@ Graph::greedy_optimize(Context *ctx, const std::string &equiv_file_name,
     assert(false);
   }
 
+  auto original_cost = cost_function(this);
+
   // Get xfers that strictly reduce the cost from the ECC set
   auto eccs = eqs.get_all_equivalence_sets();
   std::vector<GraphXfer *> xfers;
@@ -1487,12 +1489,12 @@ Graph::greedy_optimize(Context *ctx, const std::string &equiv_file_name,
     graphs.reserve(ecc_size);
     graph_cost.reserve(ecc_size);
     for (auto &circuit : ecc) {
-      graphs.emplace_back(circuit);
+      graphs.emplace_back(ctx, circuit);
       graph_cost.emplace_back(cost_function(&graphs.back()));
     }
     int representative_id =
-        std::min_element(graph_cost.begin(), graph_cost.end()) -
-        graph_cost.begin();
+        (int)(std::min_element(graph_cost.begin(), graph_cost.end()) -
+              graph_cost.begin());
     for (int i = 0; i < ecc_size; i++) {
       if (graph_cost[i] != graph_cost[representative_id]) {
         auto xfer = GraphXfer::create_GraphXfer(ctx, ecc[i],
@@ -1504,9 +1506,46 @@ Graph::greedy_optimize(Context *ctx, const std::string &equiv_file_name,
     }
   }
   if (print_message) {
-    std::cout << "Number of xfers that reduce cost: " << xfers.size()
-              << std::endl;
+    std::cout << "greedy_optimize(): Number of xfers that reduce cost: "
+              << xfers.size() << std::endl;
   }
+
+  std::shared_ptr<Graph> optimized_graph = std::make_shared<Graph>(*this);
+  bool optimized_in_this_iteration;
+  std::vector<Op> all_nodes;
+  optimized_graph->topology_order_ops(all_nodes);
+  do {
+    optimized_in_this_iteration = false;
+    for (auto xfer : xfers) {
+      bool optimized_this_xfer;
+      do {
+        optimized_this_xfer = false;
+        for (auto const &node : all_nodes) {
+          auto new_graph = optimized_graph->apply_xfer(
+              xfer, node, context->has_parameterized_gate());
+          if (new_graph) {
+            optimized_graph.swap(new_graph);
+            // Update the nodes after applying a transformation.
+            all_nodes.clear();
+            optimized_graph->topology_order_ops(all_nodes);
+            optimized_this_xfer = true;
+            optimized_in_this_iteration = true;
+            // Since |all_nodes| has changed, we cannot continue this loop.
+            break;
+          }
+        }
+      } while (optimized_this_xfer);
+    }
+  } while (optimized_in_this_iteration);
+
+  auto optimized_cost = cost_function(optimized_graph.get());
+
+  if (print_message) {
+    std::cout << "greedy_optimize(): cost optimized from " << original_cost
+              << " to " << optimized_cost << std::endl;
+  }
+
+  return optimized_graph;
 }
 
 std::shared_ptr<Graph> Graph::optimize_legacy(
@@ -1818,8 +1857,11 @@ Graph::optimize(Context *ctx, const std::string &equiv_file_name,
   auto log_file_name =
       equiv_file_name.substr(0, std::max(0, (int)equiv_file_name.size() - 21)) +
       circuit_name + ".log";
-  return optimize(xfers, cost_upper_bound, circuit_name, log_file_name,
-                  print_message, cost_function, timeout);
+  auto preprocessed_graph =
+      greedy_optimize(ctx, equiv_file_name, print_message, cost_function);
+  return preprocessed_graph->optimize(xfers, cost_upper_bound, circuit_name,
+                                      log_file_name, print_message,
+                                      cost_function, timeout);
 }
 
 std::shared_ptr<Graph>

--- a/src/quartz/tasograph/tasograph.cpp
+++ b/src/quartz/tasograph/tasograph.cpp
@@ -1461,6 +1461,54 @@ void Graph::draw_circuit(const std::string &src_file_name,
              .c_str());
 }
 
+std::shared_ptr<Graph>
+Graph::greedy_optimize(Context *ctx, const std::string &equiv_file_name,
+                       bool print_message,
+                       std::function<float(Graph *)> cost_function) {
+  if (cost_function == nullptr) {
+    cost_function = [](Graph *graph) { return graph->total_cost(); };
+  }
+
+  EquivalenceSet eqs;
+  // Load equivalent dags from file
+  if (!eqs.load_json(ctx, equiv_file_name)) {
+    std::cout << "Failed to load equivalence file \"" << equiv_file_name
+              << "\"." << std::endl;
+    assert(false);
+  }
+
+  // Get xfers that strictly reduce the cost from the ECC set
+  auto eccs = eqs.get_all_equivalence_sets();
+  std::vector<GraphXfer *> xfers;
+  for (const auto &ecc : eccs) {
+    const int ecc_size = (int)ecc.size();
+    std::vector<Graph> graphs;
+    std::vector<int> graph_cost;
+    graphs.reserve(ecc_size);
+    graph_cost.reserve(ecc_size);
+    for (auto &circuit : ecc) {
+      graphs.emplace_back(circuit);
+      graph_cost.emplace_back(cost_function(&graphs.back()));
+    }
+    int representative_id =
+        std::min_element(graph_cost.begin(), graph_cost.end()) -
+        graph_cost.begin();
+    for (int i = 0; i < ecc_size; i++) {
+      if (graph_cost[i] != graph_cost[representative_id]) {
+        auto xfer = GraphXfer::create_GraphXfer(ctx, ecc[i],
+                                                ecc[representative_id], false);
+        if (xfer != nullptr) {
+          xfers.push_back(xfer);
+        }
+      }
+    }
+  }
+  if (print_message) {
+    std::cout << "Number of xfers that reduce cost: " << xfers.size()
+              << std::endl;
+  }
+}
+
 std::shared_ptr<Graph> Graph::optimize_legacy(
     float alpha, int budget, bool print_subst, Context *ctx,
     const std::string &equiv_file_name, bool use_simulated_annealing,

--- a/src/quartz/tasograph/tasograph.h
+++ b/src/quartz/tasograph/tasograph.h
@@ -200,6 +200,18 @@ public:
                                        Context *union_ctx,
                                        RuleParser *rule_parser,
                                        bool ignore_toffoli = false);
+  /**
+   * Greedily apply transformations towards lower cost.
+   * @param ctx The context variable.
+   * @param equiv_file_name The ECC set file name.
+   * @param print_message To output the log to the screen or not.
+   * @param cost_function The cost function.
+   * @return The optimized circuit.
+   */
+  std::shared_ptr<Graph>
+  greedy_optimize(Context *ctx, const std::string &equiv_file_name,
+                  bool print_message,
+                  std::function<float(Graph *)> cost_function = nullptr);
   std::shared_ptr<Graph>
   optimize_legacy(float alpha, int budget, bool print_subst, Context *ctx,
                   const std::string &equiv_file_name,


### PR DESCRIPTION
This PR prepends a preprocessing pass to the `optimize()` function -- the `greedy_optimize()` pass.

This pass greedily transforms the circuit towards lower cost (by default when the cost function is the gate count, this function greedily transforms the circuit towards fewer gates).

To show the effectiveness of this pass, I added a benchmark for middle-sized circuits (450-900 gates in the benchmark). (There is no significant difference in the current small benchmark.) Before this PR, the output of the middle-sized-circuit benchmark is:
```
barenco_tof_10 after toffoli flip in 0.113 seconds: gate count = 326, circuit depth = 282, cost = 326
Number of xfers: 62287
Timeout. Program terminated. Best cost is 323
barenco_tof_10 optimization result in 11.065 seconds: gate count = 323, circuit depth = 280, cost = 323
gf2^8_mult after toffoli flip in 0.387 seconds: gate count = 703, circuit depth = 235, cost = 703
Number of xfers: 62287
Timeout. Program terminated. Best cost is 703
gf2^8_mult optimization result in 11.494 seconds: gate count = 703, circuit depth = 235, cost = 703
qcla_mod_7 after toffoli flip in 0.972 seconds: gate count = 727, circuit depth = 208, cost = 727
Number of xfers: 62287
Timeout. Program terminated. Best cost is 726
qcla_mod_7 optimization result in 11.558 seconds: gate count = 726, circuit depth = 207, cost = 726
adder_8 after toffoli flip in 1.208 seconds: gate count = 732, circuit depth = 232, cost = 732
Number of xfers: 62287
Timeout. Program terminated. Best cost is 731
adder_8 optimization result in 11.5 seconds: gate count = 731, circuit depth = 232, cost = 731
Summary:
barenco_tof_10 optimization result in 11.065 seconds: gate count = 323, circuit depth = 280, cost = 323
gf2^8_mult optimization result in 11.494 seconds: gate count = 703, circuit depth = 235, cost = 703
qcla_mod_7 optimization result in 11.558 seconds: gate count = 726, circuit depth = 207, cost = 726
adder_8 optimization result in 11.5 seconds: gate count = 731, circuit depth = 232, cost = 731
4 circuits, gate count optimized by 1.003 times on average.
```

After this PR, the output is (it's a little bit unfair that the preprocessing pass didn't count towards the time limit of 10 seconds, but we've got much more improvement):
```
barenco_tof_10 after toffoli flip in 0.111 seconds: gate count = 326, circuit depth = 282, cost = 326
Number of xfers: 62287
greedy_optimize(): Number of xfers that reduce cost: 7667
greedy_optimize(): cost optimized from 326 to 248
Timeout. Program terminated. Best cost is 248
barenco_tof_10 optimization result in 12.294 seconds: gate count = 248, circuit depth = 228, cost = 248
gf2^8_mult after toffoli flip in 0.367 seconds: gate count = 703, circuit depth = 235, cost = 703
Number of xfers: 62287
greedy_optimize(): Number of xfers that reduce cost: 7667
greedy_optimize(): cost optimized from 703 to 703
Timeout. Program terminated. Best cost is 703
gf2^8_mult optimization result in 13.163 seconds: gate count = 703, circuit depth = 235, cost = 703
qcla_mod_7 after toffoli flip in 0.915 seconds: gate count = 727, circuit depth = 210, cost = 727
Number of xfers: 62287
greedy_optimize(): Number of xfers that reduce cost: 7667
greedy_optimize(): cost optimized from 727 to 655
Timeout. Program terminated. Best cost is 655
qcla_mod_7 optimization result in 14.009 seconds: gate count = 655, circuit depth = 197, cost = 655
adder_8 after toffoli flip in 1.243 seconds: gate count = 732, circuit depth = 232, cost = 732
Number of xfers: 62287
greedy_optimize(): Number of xfers that reduce cost: 7667
greedy_optimize(): cost optimized from 732 to 642
Timeout. Program terminated. Best cost is 642
adder_8 optimization result in 14.091 seconds: gate count = 642, circuit depth = 208, cost = 642
Summary:
barenco_tof_10 optimization result in 12.294 seconds: gate count = 248, circuit depth = 228, cost = 248
gf2^8_mult optimization result in 13.163 seconds: gate count = 703, circuit depth = 235, cost = 703
qcla_mod_7 optimization result in 14.009 seconds: gate count = 655, circuit depth = 197, cost = 655
adder_8 optimization result in 14.091 seconds: gate count = 642, circuit depth = 208, cost = 642
4 circuits, gate count optimized by 1.13569 times on average.
```

Btw, it takes 2025.11 seconds on my machine to generate a (6,3)-complete ECC set for the Nam gate set now, during which 1970.1 is spent on verification.