### PR TITLE
[Generator] Output the representative set

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ To generate an `(n,q)`-complete ECC set with `m` input parameters for some gate 
 you can change the main function in `src/test/gen_ecc_set.cpp` to the following:
 
 ```c++
-gen_ecc_set({Gate set}, "{Name of the gate set}_{n}_{q}_", true, q, m, n);
+gen_ecc_set({Gate set}, "{Name of the gate set}_{n}_{q}_", true, true, q, m, n);
 return 0;
 ```
 where `{Gate set}` can be `{GateType::rz, GateType::h, GateType::cx, GateType::x, GateType::add}` for the Nam gate set,

--- a/src/benchmark/nam_middle_circuits.cpp
+++ b/src/benchmark/nam_middle_circuits.cpp
@@ -93,7 +93,7 @@ int main() {
     std::cout << "Generating ECC set..." << std::endl;
     gen_ecc_set(
         {GateType::rz, GateType::h, GateType::cx, GateType::x, GateType::add},
-        ecc_set_prefix, true, 3, 2, 6);
+        ecc_set_prefix, true, false, 3, 2, 6);
     std::cout << "ECC set generated." << std::endl;
   }
   // Logs are printed to Nam_6_3_barenco_tof_10.log, Nam_6_3_gf2^8_mult.log, ...

--- a/src/benchmark/nam_small_circuits.cpp
+++ b/src/benchmark/nam_small_circuits.cpp
@@ -93,7 +93,7 @@ int main() {
     std::cout << "Generating ECC set..." << std::endl;
     gen_ecc_set(
         {GateType::rz, GateType::h, GateType::cx, GateType::x, GateType::add},
-        ecc_set_prefix, true, 3, 2, 4);
+        ecc_set_prefix, true, false, 3, 2, 4);
     std::cout << "ECC set generated." << std::endl;
   }
   // Logs are printed to Nam_4_3_tof_3.log, Nam_4_3_barenco_tof_3.log, ...

--- a/src/quartz/dataset/equivalence_set.cpp
+++ b/src/quartz/dataset/equivalence_set.cpp
@@ -432,6 +432,16 @@ void EquivalenceSet::clear() {
   classes_.clear();
 }
 
+std::unique_ptr<RepresentativeSet>
+EquivalenceSet::get_representative_set() const {
+  auto rep_set = std::make_unique<RepresentativeSet>();
+  rep_set->reserve(num_equivalence_classes());
+  for (auto &item : classes_) {
+    rep_set->insert(item->get_representative()->clone());
+  }
+  return rep_set;
+}
+
 bool EquivalenceSet::simplify(Context *ctx,
                               bool normalize_to_minimal_circuit_representation,
                               bool common_subcircuit_pruning,

--- a/src/quartz/dataset/equivalence_set.h
+++ b/src/quartz/dataset/equivalence_set.h
@@ -2,6 +2,7 @@
 
 #include "../context/context.h"
 #include "../dag/dag.h"
+#include "representative_set.h"
 
 #include <functional>
 #include <list>
@@ -94,6 +95,8 @@ public:
   bool save_json(const std::string &file_name) const;
 
   void clear();
+
+  std::unique_ptr<RepresentativeSet> get_representative_set() const;
 
   // A final pass of simplification before feeding the equivalences
   // to the optimizer.

--- a/src/quartz/dataset/representative_set.cpp
+++ b/src/quartz/dataset/representative_set.cpp
@@ -1,0 +1,92 @@
+#include "representative_set.h"
+
+#include <algorithm>
+#include <fstream>
+#include <limits>
+
+namespace quartz {
+
+bool RepresentativeSet::load_json(Context *ctx, const std::string &file_name) {
+  std::ifstream fin;
+  fin.open(file_name, std::ifstream::in);
+  if (!fin.is_open()) {
+    std::cerr << "RepresentativeSet fails to open " << file_name << std::endl;
+    return false;
+  }
+
+  // the DAGs
+  fin.ignore(std::numeric_limits<std::streamsize>::max(), '[');
+  char ch;
+  while (true) {
+    fin.get(ch);
+    while (ch != '[' && ch != ']') {
+      fin.get(ch);
+    }
+    if (ch == ']') {
+      break;
+    }
+
+    // New DAG
+    fin.unget(); // '['
+    auto dag = DAG::read_json(ctx, fin);
+    dags_.emplace_back(std::move(dag));
+  }
+  return true;
+}
+
+bool RepresentativeSet::save_json(const std::string &save_file_name) const {
+  std::ofstream fout;
+  fout.open(save_file_name, std::ofstream::out);
+  if (!fout.is_open()) {
+    return false;
+  }
+
+  fout << "[" << std::endl;
+  bool start = true;
+  for (const auto &dag : dags_) {
+    if (start) {
+      start = false;
+    } else {
+      fout << "," << std::endl;
+    }
+    auto dag_with_newline = dag->to_json();
+    // remove newline
+    fout << dag_with_newline.substr(0, dag_with_newline.size() - 1);
+  }
+  fout << "\n]" << std::endl;
+
+  return true;
+}
+
+void RepresentativeSet::clear() { dags_.clear(); }
+
+std::vector<DAG *> RepresentativeSet::get_all_dags() const {
+  std::vector<DAG *> result;
+  result.reserve(dags_.size());
+  for (const auto &dag : dags_) {
+    result.push_back(dag.get());
+  }
+  return result;
+}
+
+void RepresentativeSet::insert(std::unique_ptr<DAG> dag) {
+  dags_.push_back(std::move(dag));
+}
+
+int RepresentativeSet::size() const { return (int)dags_.size(); }
+
+void RepresentativeSet::reserve(std::size_t new_cap) { dags_.reserve(new_cap); }
+
+std::vector<std::unique_ptr<DAG>> RepresentativeSet::extract() {
+  return std::move(dags_);
+}
+
+void RepresentativeSet::set_dags(std::vector<std::unique_ptr<DAG>> dags) {
+  dags_ = std::move(dags);
+}
+
+void RepresentativeSet::sort() {
+  std::sort(dags_.begin(), dags_.end(), UniquePtrDAGComparator());
+}
+
+} // namespace quartz

--- a/src/quartz/dataset/representative_set.h
+++ b/src/quartz/dataset/representative_set.h
@@ -1,0 +1,38 @@
+#pragma once
+
+#include "../context/context.h"
+#include "../dag/dag.h"
+
+namespace quartz {
+
+class RepresentativeSet {
+public:
+  bool load_json(Context *ctx, const std::string &file_name);
+
+  bool save_json(const std::string &file_name) const;
+
+  void clear();
+
+  // Returns all DAGs in this representative set.
+  [[nodiscard]] std::vector<DAG *> get_all_dags() const;
+
+  void insert(std::unique_ptr<DAG> dag);
+
+  [[nodiscard]] int size() const;
+  void reserve(std::size_t new_cap);
+
+  // Extract all DAGs in this equivalence class, and make this class
+  // empty.
+  std::vector<std::unique_ptr<DAG>> extract();
+
+  // Replace |dags_| with |dags|.
+  void set_dags(std::vector<std::unique_ptr<DAG>> dags);
+
+  // Sort the circuits in this equivalence class by DAG::less_than().
+  void sort();
+
+private:
+  std::vector<std::unique_ptr<DAG>> dags_;
+};
+
+} // namespace quartz

--- a/src/test/gen_ecc_set.cpp
+++ b/src/test/gen_ecc_set.cpp
@@ -36,6 +36,6 @@ int main() {
   // }
   gen_ecc_set({GateType::t, GateType::tdg, GateType::h, GateType::x,
                GateType::cx, GateType::add},
-              "3_2_5_", true, 3, 0, 5);
+              "3_2_5_", true, true, 3, 0, 5);
   return 0;
 }

--- a/src/test/gen_ecc_set.h
+++ b/src/test/gen_ecc_set.h
@@ -47,6 +47,8 @@ void gen_ecc_set(const std::vector<GateType> &supported_gates,
   verification_time += end2 - start2;
   equiv_set.clear(); // this is necessary
   equiv_set.load_json(&ctx, file_prefix + "pruning.json");
+  auto rep_set = equiv_set.get_representative_set();
+  rep_set->save_json(file_prefix + "representative_set.json");
   std::cout << "Before ECC simplification: num_total_dags = "
             << equiv_set.num_total_dags() << ", num_equivalence_classes = "
             << equiv_set.num_equivalence_classes() << ", #transformations "

--- a/src/test/gen_ecc_set.h
+++ b/src/test/gen_ecc_set.h
@@ -6,13 +6,15 @@
 namespace quartz {
 void gen_ecc_set(const std::vector<GateType> &supported_gates,
                  const std::string &file_prefix, bool unique_parameters,
-                 int num_qubits, int num_input_parameters,
-                 int max_num_quantum_gates, int max_num_param_gates = 1);
+                 bool generate_representative_set, int num_qubits,
+                 int num_input_parameters, int max_num_quantum_gates,
+                 int max_num_param_gates = 1);
 
 void gen_ecc_set(const std::vector<GateType> &supported_gates,
                  const std::string &file_prefix, bool unique_parameters,
-                 int num_qubits, int num_input_parameters,
-                 int max_num_quantum_gates, int max_num_param_gates) {
+                 bool generate_representative_set, int num_qubits,
+                 int num_input_parameters, int max_num_quantum_gates,
+                 int max_num_param_gates) {
   Context ctx(supported_gates, num_qubits, num_input_parameters);
   Generator gen(&ctx);
 
@@ -36,7 +38,10 @@ void gen_ecc_set(const std::vector<GateType> &supported_gates,
                max_num_param_gates, &dataset1,      /*verify_equivalences=*/
                true, &equiv_set, unique_parameters, /*verbose=*/
                true, &verification_time);
-  dataset1.remove_singletons(&ctx);
+  if (!generate_representative_set) {
+    // For better performance
+    dataset1.remove_singletons(&ctx);
+  }
   dataset1.save_json(&ctx, file_prefix + "pruning_unverified.json");
 
   auto start2 = std::chrono::steady_clock::now();
@@ -47,8 +52,19 @@ void gen_ecc_set(const std::vector<GateType> &supported_gates,
   verification_time += end2 - start2;
   equiv_set.clear(); // this is necessary
   equiv_set.load_json(&ctx, file_prefix + "pruning.json");
-  auto rep_set = equiv_set.get_representative_set();
-  rep_set->save_json(file_prefix + "representative_set.json");
+  if (generate_representative_set) {
+    start2 = std::chrono::steady_clock::now();
+    auto rep_set = equiv_set.get_representative_set();
+    rep_set->sort();
+    rep_set->save_json(file_prefix + "representative_set.json");
+    end2 = std::chrono::steady_clock::now();
+    std::cout << "Representative set saved in "
+              << (double)std::chrono::duration_cast<std::chrono::milliseconds>(
+                     end2 - start2)
+                         .count() /
+                     1000.0
+              << " seconds." << std::endl;
+  }
   std::cout << "Before ECC simplification: num_total_dags = "
             << equiv_set.num_total_dags() << ", num_equivalence_classes = "
             << equiv_set.num_equivalence_classes() << ", #transformations "


### PR DESCRIPTION
This PR adds a parameter in `gen_ecc_set()` to output the representative set besides the ECC set or not.

If `generate_representative_set = true`, `gen_ecc_set()` will output a file with name like `Nam_4_3_representative_set.json` besides `Nam_4_3_complete_ECC_set.json`.