### PR TITLE
[bug] Sort each ECC when loading the ECC set

### DIFF
--- a/src/quartz/dataset/equivalence_set.cpp
+++ b/src/quartz/dataset/equivalence_set.cpp
@@ -346,6 +346,14 @@ bool EquivalenceSet::load_json(Context *ctx, const std::string &file_name,
       }
       equiv_class->insert(std::move(dag));
     }
+
+    // If the equivalence class is merged with some others,
+    // we need to select the new representative as the smaller one.
+    // Select the new representative can be done in O(1), but doing in
+    // O(nlogn) where n is the number of DAGs is fine here.
+    // For some reason, even if the equivalence class is not merged with any
+    // others here, we still need to sort the equivalence class.
+    equiv_class->sort();
   }
 
   // Move all previous representatives to the beginning of the


### PR DESCRIPTION
This PR sorts each ECC when loading the ECC set. If we don't do this, when 2 ECCs are merged together in the Python verifier, there is no guarantee that the ECC with the lexicographically smaller representative will appear first, so the new representative might be not maintained to still be the smallest one in the ECC. Simply sorting the ECC will solve this problem.