### PR TITLE
[Generator] Do not invoke the Python verifier by default when no parameters

### DIFF
--- a/src/quartz/context/context.cpp
+++ b/src/quartz/context/context.cpp
@@ -161,10 +161,6 @@ std::vector<ParamType> Context::get_all_generated_parameters() const {
   return random_parameters_;
 }
 
-DAG *Context::get_possible_representative(DAG *dag) {
-  return representatives_[dag->hash(this)];
-}
-
 void Context::set_representative(std::unique_ptr<DAG> dag) {
   representatives_[dag->hash(this)] = dag.get();
   representative_dags_.emplace_back(std::move(dag));
@@ -173,6 +169,16 @@ void Context::set_representative(std::unique_ptr<DAG> dag) {
 void Context::clear_representatives() {
   representatives_.clear();
   representative_dags_.clear();
+}
+
+bool Context::get_possible_representative(const DAGHashType &hash_value,
+                                          DAG *&representative) const {
+  auto it = representatives_.find(hash_value);
+  if (it == representatives_.end()) {
+    return false;
+  }
+  representative = it->second;
+  return true;
 }
 
 double Context::random_number() {

--- a/src/quartz/context/context.h
+++ b/src/quartz/context/context.h
@@ -40,14 +40,12 @@ public:
   // A hacky function: set a generated parameter.
   void set_generated_parameter(int id, ParamType param);
 
-  // This function assumes that two DAGs are equivalent iff they share the
-  // same hash value.
-  DAG *get_possible_representative(DAG *dag);
-
-  // This function assumes that two DAGs are equivalent iff they share the
-  // same hash value.
+  // These three functions are used in |Verifier::redundant()| for a version
+  // of RepGen algorithm that does not invoke Python verifier.
   void set_representative(std::unique_ptr<DAG> dag);
   void clear_representatives();
+  bool get_possible_representative(const DAGHashType &hash_value,
+                                   DAG *&representative) const;
 
   // This function generates a deterministic series of random numbers
   // ranging [0, 1].

--- a/src/quartz/dataset/dataset.cpp
+++ b/src/quartz/dataset/dataset.cpp
@@ -179,6 +179,22 @@ bool Dataset::insert(Context *ctx, std::unique_ptr<DAG> dag) {
   return ret;
 }
 
+bool Dataset::insert_to_nearby_set_if_exists(Context *ctx,
+                                             std::unique_ptr<DAG> dag) {
+  const auto hash_value = dag->hash(ctx);
+  for (const auto &hash_value_offset : {0, 1, -1}) {
+    auto it = dataset.find(hash_value + hash_value_offset);
+    if (it != dataset.end()) {
+      // Found a nearby set, insert the dag.
+      it->second.push_back(std::move(dag));
+      return false;
+    }
+  }
+  // The hash value is new.
+  dataset[hash_value].push_back(std::move(dag));
+  return true;
+}
+
 void Dataset::clear() {
   // Caveat here: if only dataset.clear() is called, the behavior will be
   // different with a brand new Dataset.

--- a/src/quartz/dataset/dataset.h
+++ b/src/quartz/dataset/dataset.h
@@ -29,6 +29,10 @@ public:
   // Returns true iff the hash value is new to the |dataset|.
   bool insert(Context *ctx, std::unique_ptr<DAG> dag);
 
+  // Inserts the dag to an existing set if the hash value plus or minus 1
+  // is found. Returns true iff there is no such existing set.
+  bool insert_to_nearby_set_if_exists(Context *ctx, std::unique_ptr<DAG> dag);
+
   // Make this Dataset a brand new one.
   void clear();
 

--- a/src/quartz/dataset/equivalence_set.cpp
+++ b/src/quartz/dataset/equivalence_set.cpp
@@ -346,6 +346,14 @@ bool EquivalenceSet::load_json(Context *ctx, const std::string &file_name,
       }
       equiv_class->insert(std::move(dag));
     }
+
+    // If the equivalence class is merged with some others,
+    // we need to select the new representative as the smaller one.
+    // Select the new representative can be done in O(1), but doing in
+    // O(nlogn) where n is the number of DAGs is fine here.
+    // For some reason, even if the equivalence class is not merged with any
+    // others here, we still need to sort the equivalence class.
+    equiv_class->sort();
   }
 
   // Move all previous representatives to the beginning of the

--- a/src/quartz/generator/generator.cpp
+++ b/src/quartz/generator/generator.cpp
@@ -23,7 +23,7 @@ void Generator::generate_dfs(int num_qubits, int max_num_input_parameters,
 
 void Generator::generate(
     int num_qubits, int num_input_parameters, int max_num_quantum_gates,
-    int max_num_param_gates, Dataset *dataset, bool verify_equivalences,
+    int max_num_param_gates, Dataset *dataset, bool invoke_python_verifier,
     EquivalenceSet *equiv_set, bool unique_parameters, bool verbose,
     decltype(std::chrono::steady_clock::now() -
              std::chrono::steady_clock::now()) *record_verification_time) {
@@ -33,7 +33,7 @@ void Generator::generate(
   empty_dag->generate_parameter_gates(context);
   empty_dag->hash(context); // generate other hash values
   std::vector<DAG *> dags_to_search(1, empty_dag.get());
-  if (verify_equivalences) {
+  if (invoke_python_verifier) {
     assert(equiv_set);
     auto equiv_class = std::make_unique<EquivalenceClass>();
     equiv_class->insert(std::make_unique<DAG>(*empty_dag));
@@ -54,20 +54,20 @@ void Generator::generate(
                 << " representative DAGs to search with " << num_gates - 1
                 << " gates." << std::endl;
     }
-    if (!verify_equivalences) {
+    if (!invoke_python_verifier) {
       assert(dataset);
       dags_to_search.clear();
       bfs(dags, max_num_param_gates, *dataset, &dags_to_search,
-          verify_equivalences, nullptr, unique_parameters);
+          invoke_python_verifier, nullptr, unique_parameters);
       dags.push_back(dags_to_search);
     } else {
       assert(dataset);
       assert(equiv_set);
-      bfs(dags, max_num_param_gates, *dataset, nullptr, verify_equivalences,
+      bfs(dags, max_num_param_gates, *dataset, nullptr, invoke_python_verifier,
           equiv_set, unique_parameters);
       // Do not verify when |num_gates == max_num_quantum_gates|.
       // This is to make the behavior the same when
-      // |verify_equivalences| is true or false.
+      // |invoke_python_verifier| is true or false.
       if (num_gates == max_num_quantum_gates) {
         break;
       }
@@ -79,7 +79,7 @@ void Generator::generate(
         start = std::chrono::steady_clock::now();
       }
       // Assume working directory is cmake-build-debug/ here.
-      system("python src/python/verifier/verify_equivalences.py "
+      system("python src/python/verifier/invoke_python_verifier.py "
              "tmp_before_verify.json tmp_after_verify.json");
       if (record_verification_time) {
         auto end = std::chrono::steady_clock::now();
@@ -339,11 +339,12 @@ void Generator::dfs(int gate_idx, int max_num_gates,
 void Generator::bfs(const std::vector<std::vector<DAG *>> &dags,
                     int max_num_param_gates, Dataset &dataset,
                     std::vector<DAG *> *new_representatives,
-                    bool verify_equivalences, const EquivalenceSet *equiv_set,
-                    bool unique_parameters) {
+                    bool invoke_python_verifier,
+                    const EquivalenceSet *equiv_set, bool unique_parameters) {
   auto try_to_add_to_result = [&](DAG *new_dag) {
     // A new DAG with |current_max_num_gates| + 1 gates.
-    if (verify_equivalences) {
+    if (invoke_python_verifier) {
+      // We will verify the equivalence later in Python.
       assert(equiv_set);
       if (!verifier_.redundant(context, equiv_set, new_dag)) {
         auto new_new_dag = std::make_unique<DAG>(*new_dag);
@@ -361,8 +362,9 @@ void Generator::bfs(const std::vector<std::vector<DAG *>> &dags,
       if (verifier_.redundant(context, new_dag)) {
         return;
       }
-      bool ret = dataset.insert(context, std::make_unique<DAG>(*new_dag));
-      // Presuming different hash values imply different DAGs.
+      // XXX: Try to insert to a set with hash value differing no more than 1.
+      bool ret = dataset.insert_to_nearby_set_if_exists(
+          context, std::make_unique<DAG>(*new_dag));
       if (ret) {
         // The DAG's hash value is new to the dataset.
         // Note: this is the second instance of DAG we create in

--- a/src/quartz/generator/generator.cpp
+++ b/src/quartz/generator/generator.cpp
@@ -378,7 +378,10 @@ void Generator::bfs(const std::vector<std::vector<DAG *>> &dags,
       }
     }
   };
-  for (auto &dag : dags.back()) {
+  for (auto &old_dag : dags.back()) {
+    // Create a new DAG to avoid editing the old one.
+    auto new_dag = std::make_unique<DAG>(*old_dag);
+    auto dag = new_dag.get();
     InputParamMaskType input_param_usage_mask;
     std::vector<InputParamMaskType> input_param_masks;
     if (unique_parameters) {
@@ -483,7 +486,6 @@ void Generator::bfs(const std::vector<std::vector<DAG *>> &dags,
       }
       qubit_indices.pop_back();
     }
-    dag->hash(context); // restore hash value
   }
 }
 

--- a/src/quartz/generator/generator.h
+++ b/src/quartz/generator/generator.h
@@ -35,15 +35,36 @@ public:
                     Dataset &dataset, bool restrict_search_space,
                     bool unique_parameters);
 
-  // Use BFS to generate all equivalent DAGs with |num_qubits| qubits,
-  // |num_input_parameters| input parameters (probably with some unused),
-  // and <= |max_num_quantum_gates| gates.
-  // If |unique_parameters| is true, we only search for DAGs that use
-  // each input parameters only once (note: use a doubled parameter, i.e.,
-  // Rx(2theta) is considered using the parameter theta once).
+  /**
+   * Use BFS to generate all equivalent DAGs with |num_qubits| qubits,
+   * |num_input_parameters| input parameters (probably with some unused),
+   * and <= |max_num_quantum_gates| gates.
+   *
+   * @param num_qubits number of qubits in the circuits generated.
+   * @param num_input_parameters number of input parameters in the circuits
+   * generated.
+   * @param max_num_quantum_gates max number of quantum gates in the circuits
+   * generated.
+   * @param max_num_param_gates currently unused.
+   * @param dataset the |Dataset| object to store the result.
+   * @param invoke_python_verifier if true, invoke Z3 verifier in Python to
+   * verify that the equivalences we found are indeed equivalent. Otherwise,
+   * we will simply trust the one-time random testing result, which may
+   * treat hash collision as equivalent. XXX: when this is false, we will
+   * treat any DAG with hash values differ no more than 1 with any
+   * representative as equivalent.
+   * @param equiv_set should be an empty |EquivalenceSet| object at the
+   * beginning, and will store the intermediate ECC sets during generation.
+   * @param unique_parameters if true, we only search for DAGs that use
+   * each input parameters only once (note: use a doubled parameter, i.e.,
+   * Rx(2theta) is considered using the parameter theta once).
+   * @param verbose print debug message or not.
+   * @param record_verification_time use |std::chrono::steady_clock| to
+   * record the verification time or not.
+   */
   void generate(
       int num_qubits, int num_input_parameters, int max_num_quantum_gates,
-      int max_num_param_gates, Dataset *dataset, bool verify_equivalences,
+      int max_num_param_gates, Dataset *dataset, bool invoke_python_verifier,
       EquivalenceSet *equiv_set, bool unique_parameters, bool verbose = false,
       decltype(std::chrono::steady_clock::now() -
                std::chrono::steady_clock::now()) *record_verification_time =
@@ -57,7 +78,7 @@ private:
   // |dags[i]| is the DAGs with |i| gates.
   void bfs(const std::vector<std::vector<DAG *>> &dags, int max_num_param_gates,
            Dataset &dataset, std::vector<DAG *> *new_representatives,
-           bool verify_equivalences, const EquivalenceSet *equiv_set,
+           bool invoke_python_verifier, const EquivalenceSet *equiv_set,
            bool unique_parameters);
 
   void dfs_parameter_gates(std::unique_ptr<DAG> dag, int remaining_gates,

--- a/src/test/gen_ecc_set.h
+++ b/src/test/gen_ecc_set.h
@@ -23,7 +23,7 @@ void gen_ecc_set(const std::vector<GateType> &supported_gates,
   Dataset dataset1;
 
   gen.generate(num_qubits, num_input_parameters, 1, max_num_param_gates,
-               &dataset1,                           /*verify_equivalences=*/
+               &dataset1,                           /*invoke_python_verifier=*/
                true, &equiv_set, unique_parameters, /*verbose=*/
                false);
   std::cout << "*** ch(" << file_prefix.substr(0, file_prefix.size() - 5)
@@ -34,9 +34,17 @@ void gen_ecc_set(const std::vector<GateType> &supported_gates,
 
   auto start = std::chrono::steady_clock::now();
   decltype(start - start) verification_time{0};
+  // We are not going to invoke the Python verifier when |num_input_parameters|
+  // is 0. This will be simply verifying two static matrices are equal.
+  //
+  // If we mistakenly treat two different matrices as equal due to
+  // floating-point error, our optimizations will still preserve the
+  // resulting circuit matrix up to an error of a small number times machine
+  // precision. Plus, this situation is known to be extremely rare.
   gen.generate(num_qubits, num_input_parameters, max_num_quantum_gates,
-               max_num_param_gates, &dataset1,      /*verify_equivalences=*/
-               true, &equiv_set, unique_parameters, /*verbose=*/
+               max_num_param_gates, &dataset1, /*invoke_python_verifier=*/
+               (num_input_parameters >= 1), &equiv_set,
+               unique_parameters, /*verbose=*/
                true, &verification_time);
   if (!generate_representative_set) {
     // For better performance

--- a/src/test/test_generator.h
+++ b/src/test/test_generator.h
@@ -18,7 +18,7 @@ void test_generator(const std::vector<GateType> &support_gates, int num_qubits,
   EquivalenceSet equiv_set;
   generator.generate(num_qubits, max_num_input_parameters, max_num_gates,
                      /*max_num_param_gates=*/1, &dataset,
-                     /*verify_equivalences=*/false, &equiv_set,
+                     /*invoke_python_verifier=*/false, &equiv_set,
                      /*unique_parameters=*/false);
   auto end = std::chrono::steady_clock::now();
   if (verbose) {

--- a/src/test/test_phase_shift.cpp
+++ b/src/test/test_phase_shift.cpp
@@ -23,7 +23,7 @@ int main() {
   EquivalenceSet equiv_set;
   auto start = std::chrono::steady_clock::now();
   gen.generate(num_qubits, num_input_parameters, max_num_gates,
-               max_num_param_gates, &dataset, /*verify_equivalences=*/
+               max_num_param_gates, &dataset, /*invoke_python_verifier=*/
                true, &equiv_set, /*unique_parameters=*/false, /*verbose=*/
                true);
   auto end = std::chrono::steady_clock::now();

--- a/src/test/test_pruning.h
+++ b/src/test/test_pruning.h
@@ -39,7 +39,7 @@ void test_pruning(
       }
       start = std::chrono::steady_clock::now();
       gen.generate(num_qubits, num_input_parameters, max_num_quantum_gates,
-                   max_num_param_gates, &dataset1,      /*verify_equivalences=*/
+                   max_num_param_gates, &dataset1, /*invoke_python_verifier=*/
                    true, &equiv_set, unique_parameters, /*verbose=*/
                    true, &verification_time);
       end = std::chrono::steady_clock::now();


### PR DESCRIPTION
This PR renames the parameter `verify_equivalences` of `generate()` to `invoke_python_verifier` as a switch to invoke the Python verifier or not. When this is `true`, the behavior is exactly the same as before this PR.

When `invoke_python_verifier` is `false`, Quartz will not invoke the Python verifier which verifies all equivalences by Z3. Instead, it treats circuits with hash values differing no more than 1 as equivalent.

When there are no parameters in the circuits, as long as two circuits' hash values are very close to each other, even if they are actually not equivalent, it is guaranteed that their matrices will not differ much. So it is considered safe to not invoke the Python verifier (which will accelerate the generation time by a lot) in this case.