### PR TITLE
[qasm] Add CircuitSeq::from_qasm_file()

### DIFF
--- a/src/quartz/circuitseq/circuitseq.cpp
+++ b/src/quartz/circuitseq/circuitseq.cpp
@@ -1,6 +1,7 @@
 #include "circuitseq.h"
 #include "../context/context.h"
 #include "../gate/gate.h"
+#include "../parser/qasm_parser.h"
 
 #include <algorithm>
 #include <cassert>
@@ -1022,6 +1023,16 @@ std::unique_ptr<CircuitSeq> CircuitSeq::read_json(Context *ctx,
   fin.ignore(std::numeric_limits<std::streamsize>::max(), ']');
 
   return result;
+}
+
+std::unique_ptr<CircuitSeq>
+CircuitSeq::from_qasm_file(Context *ctx, const std::string &filename) {
+  QASMParser parser(ctx);
+  CircuitSeq *seq = nullptr;
+  parser.load_qasm(filename, seq);
+  std::unique_ptr<CircuitSeq> ret;
+  ret.reset(seq); // transfer ownership of |seq|
+  return ret;
 }
 
 bool CircuitSeq::canonical_representation(

--- a/src/quartz/circuitseq/circuitseq.h
+++ b/src/quartz/circuitseq/circuitseq.h
@@ -88,6 +88,8 @@ public:
   [[nodiscard]] std::string to_string() const;
   [[nodiscard]] std::string to_json() const;
   static std::unique_ptr<CircuitSeq> read_json(Context *ctx, std::istream &fin);
+  static std::unique_ptr<CircuitSeq>
+  from_qasm_file(Context *ctx, const std::string &filename);
 
   // Returns true iff the CircuitSeq is already under the canonical
   // representation.

--- a/src/quartz/parser/qasm_parser.h
+++ b/src/quartz/parser/qasm_parser.h
@@ -26,19 +26,19 @@ public:
   bool load_qasm_stream(std::basic_istream<_CharT, _Traits> &qasm_stream,
                         CircuitSeq *&seq);
 
-  bool load_qasm_str(const std::string &qasm_str, CircuitSeq *&dag) {
+  bool load_qasm_str(const std::string &qasm_str, CircuitSeq *&seq) {
     std::stringstream sstream(qasm_str);
-    return load_qasm_stream(sstream, dag);
+    return load_qasm_stream(sstream, seq);
   }
 
-  bool load_qasm(const std::string &file_name, CircuitSeq *&dag) {
+  bool load_qasm(const std::string &file_name, CircuitSeq *&seq) {
     std::ifstream fin;
     fin.open(file_name, std::ifstream::in);
     if (!fin.is_open()) {
       std::cerr << "QASMParser fails to open " << file_name << std::endl;
       return false;
     }
-    const bool res = load_qasm_stream(fin, dag);
+    const bool res = load_qasm_stream(fin, seq);
     fin.close();
     return res;
   }


### PR DESCRIPTION
A follow-up of #63.

Now we can call `CircuitSeq::from_qasm_file` like `Graph::from_qasm_file`.