### PR TITLE
[gate] Add some support functions for controlled gates

### DIFF
--- a/src/quartz/circuitseq/circuitgate.cpp
+++ b/src/quartz/circuitseq/circuitgate.cpp
@@ -13,4 +13,34 @@ int CircuitGate::get_min_qubit_index() const {
   return result;
 }
 
+std::vector<int> CircuitGate::get_qubit_indices() const {
+  std::vector<int> result;
+  result.reserve(gate->get_num_qubits());
+  for (auto &input_node : input_wires) {
+    if (input_node->is_qubit()) {
+      result.push_back(input_node->index);
+    }
+  }
+  return result;
+}
+
+std::vector<int> CircuitGate::get_control_qubit_indices() const {
+  const int num_control_qubits = gate->get_num_control_qubits();
+  if (num_control_qubits == 0) {
+    return std::vector<int>();
+  }
+  std::vector<int> result;
+  result.reserve(num_control_qubits);
+  for (auto &input_node : input_wires) {
+    // Control qubits always appear first.
+    if (input_node->is_qubit()) {
+      result.push_back(input_node->index);
+      if (result.size() == num_control_qubits) {
+        break;
+      }
+    }
+  }
+  return result;
+}
+
 } // namespace quartz

--- a/src/quartz/circuitseq/circuitgate.h
+++ b/src/quartz/circuitseq/circuitgate.h
@@ -15,7 +15,12 @@ class CircuitWire;
  */
 class CircuitGate {
 public:
-  int get_min_qubit_index() const;
+  // Get the minimum qubit index of the gate.
+  [[nodiscard]] int get_min_qubit_index() const;
+  // Get the qubit indices of the gate.
+  [[nodiscard]] std::vector<int> get_qubit_indices() const;
+  // Get the control qubit indices of the gate if it is a controlled gate.
+  [[nodiscard]] std::vector<int> get_control_qubit_indices() const;
   std::vector<CircuitWire *> input_wires; // Include parameters!
   std::vector<CircuitWire *> output_wires;
 

--- a/src/quartz/gate/ccx.h
+++ b/src/quartz/gate/ccx.h
@@ -19,6 +19,7 @@ public:
              {0, 0, 0, 1, 0, 0, 0, 0}}) {}
   MatrixBase *get_matrix() override { return &mat; }
   bool is_sparse() const override { return true; }
+  int get_num_control_qubits() const override { return 2; }
   Matrix<8> mat;
 };
 

--- a/src/quartz/gate/ccz.h
+++ b/src/quartz/gate/ccz.h
@@ -19,6 +19,7 @@ public:
              {0, 0, 0, 0, 0, 0, 0, -1}}) {}
   MatrixBase *get_matrix() override { return &mat; }
   bool is_sparse() const override { return true; }
+  int get_num_control_qubits() const override { return 2; }
   Matrix<8> mat;
 };
 

--- a/src/quartz/gate/ch.h
+++ b/src/quartz/gate/ch.h
@@ -14,6 +14,7 @@ public:
              {0, 0, 1, 0},
              {0, 1 / std::sqrt(2), 0, -1 / std::sqrt(2)}}) {}
   MatrixBase *get_matrix() override { return &mat; }
+  int get_num_control_qubits() const override { return 1; }
   Matrix<4> mat;
 };
 

--- a/src/quartz/gate/cp.h
+++ b/src/quartz/gate/cp.h
@@ -22,6 +22,7 @@ public:
     return cached_matrices[phi].get();
   }
   bool is_sparse() const override { return true; }
+  int get_num_control_qubits() const override { return 1; }
   std::unordered_map<float, std::unique_ptr<Matrix<4>>> cached_matrices;
 };
 

--- a/src/quartz/gate/cx.h
+++ b/src/quartz/gate/cx.h
@@ -16,6 +16,7 @@ public:
               ComplexType(0)}}) {}
   MatrixBase *get_matrix() override { return &mat; }
   bool is_sparse() const override { return true; }
+  int get_num_control_qubits() const override { return 1; }
   Matrix<4> mat;
 };
 

--- a/src/quartz/gate/cz.h
+++ b/src/quartz/gate/cz.h
@@ -12,6 +12,7 @@ public:
         mat({{1, 0, 0, 0}, {0, 1, 0, 0}, {0, 0, 1, 0}, {0, 0, 0, -1}}) {}
   MatrixBase *get_matrix() override { return &mat; }
   bool is_sparse() const override { return true; }
+  int get_num_control_qubits() const override { return 1; }
   Matrix<4> mat;
 };
 

--- a/src/quartz/gate/gate.cpp
+++ b/src/quartz/gate/gate.cpp
@@ -25,6 +25,8 @@ bool Gate::is_symmetric() const { return false; }
 
 bool Gate::is_sparse() const { return false; }
 
+int Gate::get_num_control_qubits() const { return 0; }
+
 int Gate::get_num_qubits() const { return num_qubits; }
 
 int Gate::get_num_parameters() const { return num_parameters; }

--- a/src/quartz/gate/gate.h
+++ b/src/quartz/gate/gate.h
@@ -21,6 +21,9 @@ public:
   // Returns true iff the number of non-zero elements in the matrix
   // representation of the quantum gate is exactly 2 to the power of num_qubits.
   [[nodiscard]] virtual bool is_sparse() const;
+  // Returns the number of control qubits for controlled gates; or 0 if it is
+  // not a controlled gate.
+  [[nodiscard]] virtual int get_num_control_qubits() const;
   [[nodiscard]] int get_num_qubits() const;
   [[nodiscard]] int get_num_parameters() const;
   [[nodiscard]] bool is_parameter_gate() const;


### PR DESCRIPTION
This PR adds support functions `Gate::get_num_control_qubits()`, `CircuitGate::get_qubit_indices()`, `CircuitGate::get_control_qubit_indices()`.