### PR TITLE
[simulation] Add the s array to ILP and print the running time in test_simulation

### DIFF
--- a/src/python/simulator/ilp.py
+++ b/src/python/simulator/ilp.py
@@ -39,26 +39,11 @@ def solve_ilp(
         pulp.LpInteger,
     )
 
-    # s[i, j] = 1 iff a[i, j + 1] = 1 and a[i, j] = 0
-    s = pulp.LpVariable.dicts(
-        "s",
-        [(i, j) for i in range(num_qubits) for j in range(num_iterations - 1)],
-        0,
-        1,
-        pulp.LpInteger,
-    )
-
-    # minimize the total number of swaps
-    prob += sum([s[i, j] for i in range(num_qubits) for j in range(num_iterations - 1)])
+    prob += 0  # minimize nothing
 
     # For each iteration, we have at most k local qubits.
     for j in range(num_iterations):
         prob += sum([a[i, j] for i in range(num_qubits)]) <= num_local_qubits
-
-    # The definition of |s|.
-    for i in range(num_qubits):
-        for j in range(num_iterations - 1):
-            prob += a[i, j + 1] <= a[i, j] + s[i, j]
 
     # If a gate is executed before or at the j-th iteration,
     # this should also hold in the (j+1)-th iteration.

--- a/src/python/simulator/ilp.py
+++ b/src/python/simulator/ilp.py
@@ -39,11 +39,26 @@ def solve_ilp(
         pulp.LpInteger,
     )
 
-    prob += 0  # minimize nothing
+    # s[i, j] = 1 iff a[i, j + 1] = 1 and a[i, j] = 0
+    s = pulp.LpVariable.dicts(
+        "s",
+        [(i, j) for i in range(num_qubits) for j in range(num_iterations - 1)],
+        0,
+        1,
+        pulp.LpInteger,
+    )
+
+    # minimize the total number of swaps
+    prob += sum([s[i, j] for i in range(num_qubits) for j in range(num_iterations - 1)])
 
     # For each iteration, we have at most k local qubits.
     for j in range(num_iterations):
         prob += sum([a[i, j] for i in range(num_qubits)]) <= num_local_qubits
+
+    # The definition of |s|.
+    for i in range(num_qubits):
+        for j in range(num_iterations - 1):
+            prob += a[i, j + 1] <= a[i, j] + s[i, j]
 
     # If a gate is executed before or at the j-th iteration,
     # this should also hold in the (j+1)-th iteration.

--- a/src/test/test_simulation.cpp
+++ b/src/test/test_simulation.cpp
@@ -6,6 +6,7 @@
 #include "quartz/tasograph/tasograph.h"
 
 #include <algorithm>
+#include <chrono>
 #include <iostream>
 #include <unordered_map>
 #include <vector>
@@ -121,6 +122,7 @@ int num_iterations_by_heuristics(CircuitSeq *seq, int num_local_qubits,
 }
 
 int main() {
+  auto start = std::chrono::steady_clock::now();
   init_python_interpreter();
   PythonInterpreter interpreter;
   Context ctx({GateType::input_qubit, GateType::input_param, GateType::h,
@@ -182,5 +184,9 @@ int main() {
     }
   }
   // fclose(fout);
+  auto end = std::chrono::steady_clock::now();
+  std::cout
+      << std::chrono::duration_cast<std::chrono::seconds>(end - start).count()
+      << " seconds." << std::endl;
   return 0;
 }

--- a/src/test/test_simulation.cpp
+++ b/src/test/test_simulation.cpp
@@ -6,7 +6,6 @@
 #include "quartz/tasograph/tasograph.h"
 
 #include <algorithm>
-#include <chrono>
 #include <iostream>
 #include <unordered_map>
 #include <vector>
@@ -122,7 +121,6 @@ int num_iterations_by_heuristics(CircuitSeq *seq, int num_local_qubits,
 }
 
 int main() {
-  auto start = std::chrono::steady_clock::now();
   init_python_interpreter();
   PythonInterpreter interpreter;
   Context ctx({GateType::input_qubit, GateType::input_param, GateType::h,
@@ -184,9 +182,5 @@ int main() {
     }
   }
   // fclose(fout);
-  auto end = std::chrono::steady_clock::now();
-  std::cout
-      << std::chrono::duration_cast<std::chrono::seconds>(end - start).count()
-      << " seconds." << std::endl;
   return 0;
 }


### PR DESCRIPTION
This PR minimizes the number of swaps between iterations in the ILP.

However, it causes the current DP result to be much worse. Because there is only 1 global qubit in the current benchmark circuit, I think this is probably random.

Before this PR, test_simulation runs 541 seconds on my laptop and the costs are 295.8+319=614.8.
After this PR, test_simulation runs 4496 seconds on my laptop and the costs are 1364+10.4=1374.4.

This is probably because the second iteration after this PR contains only 1 gate:
```
CircuitSeq {
  Q0 = h(Q0)
  [Q0, Q28] = swap(Q0, Q28)
}
```
and the first iteration is setting qubit 0 as the global qubit. In this way, there are a lot of partially global sparse gates (e.g., `cp(Q10, Q0)`) in the first iteration, and they're not cost-efficient in the current DP.