### PR TITLE
[simulation] Fix a bug about ILP and DP

### DIFF
--- a/src/python/simulator/ilp.py
+++ b/src/python/simulator/ilp.py
@@ -51,9 +51,9 @@ def solve_ilp(
     # minimize the total number of swaps
     prob += sum([s[i, j] for i in range(num_qubits) for j in range(num_iterations - 1)])
 
-    # For each iteration, we have at most k local qubits.
+    # For each iteration, we have exactly k local qubits.
     for j in range(num_iterations):
-        prob += sum([a[i, j] for i in range(num_qubits)]) <= num_local_qubits
+        prob += sum([a[i, j] for i in range(num_qubits)]) == num_local_qubits
 
     # The definition of |s|.
     for i in range(num_qubits):


### PR DESCRIPTION

This PR fixes the bug of the DP not considering "global" gates. The ILP could output fewer than k local qubits before this PR, but we don't have enough devices to support more than n-k global qubits. This PR simply fixes the bug by enforcing the ILP to output exactly k local qubits.

It also fixes a bug introduced in https://github.com/quantum-compiler/quartz/commit/e0f0c961d9e199f8ee9a0b1411909f94f19f69fd which caused `Schedule::compute_end_schedule()` to not compute the cost accurately when the `result_kernels` parameter is `nullptr`.

It also changes
```c++
constexpr int kMaxNumOfStatus = 10000;
constexpr int kShrinkToNumOfStatus = 5000;
```
to
```c++
constexpr int kMaxNumOfStatus = 4000;
constexpr int kShrinkToNumOfStatus = 2000;
```
to reduce the running time.

After these changes,

- before #71, test_simulation runs 99 seconds on my workstation and the costs are 1382.4+10.4=1392.8;
- after #71, test_simulation runs 144 seconds on my workstation and the costs are 99+1372.6=1471.6.

I also tried changing the thresholds above to
```c++
constexpr int kMaxNumOfStatus = 2000;
constexpr int kShrinkToNumOfStatus = 1000;
```
and the DP results are:

- before #71, test_simulation runs 23 seconds on my workstation and the costs are 1395.2+10.4=1405.6;
- after #71, test_simulation runs 34 seconds on my workstation and the costs are 99+1383=1482.
