### PR TITLE
[Simulation] DP for shared-memory gates

### DIFF
--- a/src/quartz/simulator/kernel.cpp
+++ b/src/quartz/simulator/kernel.cpp
@@ -1,0 +1,17 @@
+#include "kernel.h"
+
+namespace quartz {
+std::string quartz::Kernel::to_string() const {
+  std::string result;
+  result += "qubits [";
+  for (int j = 0; j < (int)qubits.size(); j++) {
+    result += std::to_string(qubits[j]);
+    if (j != (int)qubits.size() - 1) {
+      result += ", ";
+    }
+  }
+  result += "], gates ";
+  result += gates.to_string();
+  return result;
+}
+} // namespace quartz

--- a/src/quartz/simulator/kernel.cpp
+++ b/src/quartz/simulator/kernel.cpp
@@ -11,9 +11,10 @@ std::string kernel_type_name(KernelType tp) {
   return "undefined";
 }
 
-std::string quartz::Kernel::to_string() const {
+std::string Kernel::to_string() const {
   std::string result;
-  result += "qubits [";
+  result += kernel_type_name(type);
+  result += ", qubits [";
   for (int j = 0; j < (int)qubits.size(); j++) {
     result += std::to_string(qubits[j]);
     if (j != (int)qubits.size() - 1) {

--- a/src/quartz/simulator/kernel.cpp
+++ b/src/quartz/simulator/kernel.cpp
@@ -1,6 +1,16 @@
 #include "kernel.h"
 
 namespace quartz {
+std::string kernel_type_name(KernelType tp) {
+  switch (tp) {
+  case KernelType::fusion:
+    return "fusion";
+  case KernelType::shared_memory:
+    return "shared_memory";
+  }
+  return "undefined";
+}
+
 std::string quartz::Kernel::to_string() const {
   std::string result;
   result += "qubits [";

--- a/src/quartz/simulator/kernel.h
+++ b/src/quartz/simulator/kernel.h
@@ -9,6 +9,8 @@ namespace quartz {
 
 enum KernelType { fusion, shared_memory };
 
+std::string kernel_type_name(KernelType tp);
+
 class Kernel {
 public:
   Kernel(const CircuitSeq &gates, const std::vector<int> &qubits,

--- a/src/quartz/simulator/kernel.h
+++ b/src/quartz/simulator/kernel.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include "quartz/circuitseq/circuitseq.h"
+
+#include <string>
+#include <vector>
+
+namespace quartz {
+
+enum KernelType { fusion, shared_memory };
+
+class Kernel {
+public:
+  Kernel(const CircuitSeq &gates, const std::vector<int> &qubits,
+         KernelType type)
+      : gates(gates), qubits(qubits), type(type) {}
+
+  [[nodiscard]] std::string to_string() const;
+  CircuitSeq gates;
+  std::vector<int> qubits;
+  KernelType type;
+};
+
+} // namespace quartz

--- a/src/quartz/simulator/kernel_cost.cpp
+++ b/src/quartz/simulator/kernel_cost.cpp
@@ -1,0 +1,22 @@
+#include "kernel_cost.h"
+
+namespace quartz {
+
+const std::vector<KernelCostType> &
+quartz::KernelCost::get_fusion_kernel_costs() const {
+  return fusion_kernel_costs_;
+}
+
+const KernelCostType &KernelCost::get_shared_memory_init_cost() const {
+  return shared_memory_init_cost_;
+}
+
+KernelCostType KernelCost::get_shared_memory_gate_cost(GateType tp) const {
+  return shared_memory_gate_cost_(tp);
+}
+
+int KernelCost::get_shared_memory_num_free_qubits() const {
+  return shared_memory_total_qubits_ - shared_memory_cacheline_qubits_;
+}
+
+} // namespace quartz

--- a/src/quartz/simulator/kernel_cost.cpp
+++ b/src/quartz/simulator/kernel_cost.cpp
@@ -19,4 +19,8 @@ int KernelCost::get_shared_memory_num_free_qubits() const {
   return shared_memory_total_qubits_ - shared_memory_cacheline_qubits_;
 }
 
+int KernelCost::get_optimal_fusion_kernel_size() const {
+  return optimal_fusion_kernel_size_;
+}
+
 } // namespace quartz

--- a/src/quartz/simulator/kernel_cost.h
+++ b/src/quartz/simulator/kernel_cost.h
@@ -1,0 +1,41 @@
+#pragma once
+
+#include "quartz/gate/gate_utils.h"
+
+#include <functional>
+#include <vector>
+
+namespace quartz {
+
+using KernelCostType = double;
+
+/**
+ * A class for the cost function of kernels.
+ */
+class KernelCost {
+public:
+  KernelCost(
+      const std::vector<KernelCostType> &fusion_kernel_costs,
+      const KernelCostType &shared_memory_init_cost,
+      const std::function<KernelCostType(GateType)> &shared_memory_gate_cost,
+      int shared_memory_total_qubits, int shared_memory_cacheline_qubits)
+      : fusion_kernel_costs_(fusion_kernel_costs),
+        shared_memory_init_cost_(shared_memory_init_cost),
+        shared_memory_gate_cost_(shared_memory_gate_cost),
+        shared_memory_total_qubits_(shared_memory_total_qubits),
+        shared_memory_cacheline_qubits_(shared_memory_cacheline_qubits) {}
+
+  [[nodiscard]] const std::vector<KernelCostType> &
+  get_fusion_kernel_costs() const;
+  [[nodiscard]] const KernelCostType &get_shared_memory_init_cost() const;
+  [[nodiscard]] KernelCostType get_shared_memory_gate_cost(GateType tp) const;
+  [[nodiscard]] int get_shared_memory_num_free_qubits() const;
+
+  std::vector<KernelCostType> fusion_kernel_costs_;
+  KernelCostType shared_memory_init_cost_;
+  std::function<KernelCostType(GateType)> shared_memory_gate_cost_;
+  int shared_memory_total_qubits_;
+  int shared_memory_cacheline_qubits_;
+};
+
+} // namespace quartz

--- a/src/quartz/simulator/kernel_cost.h
+++ b/src/quartz/simulator/kernel_cost.h
@@ -23,19 +23,35 @@ public:
         shared_memory_init_cost_(shared_memory_init_cost),
         shared_memory_gate_cost_(shared_memory_gate_cost),
         shared_memory_total_qubits_(shared_memory_total_qubits),
-        shared_memory_cacheline_qubits_(shared_memory_cacheline_qubits) {}
+        shared_memory_cacheline_qubits_(shared_memory_cacheline_qubits) {
+    if (fusion_kernel_costs.size() <= 1) {
+      optimal_fusion_kernel_size_ = 0;
+    } else {
+      optimal_fusion_kernel_size_ = 1;
+      KernelCostType optimal_kernel_size_cost = fusion_kernel_costs[1];
+      for (int i = 2; i < (int)fusion_kernel_costs.size(); i++) {
+        KernelCostType tmp = fusion_kernel_costs[i] / i;
+        if (tmp < optimal_kernel_size_cost) {
+          optimal_fusion_kernel_size_ = i;
+          optimal_kernel_size_cost = tmp;
+        }
+      }
+    }
+  }
 
   [[nodiscard]] const std::vector<KernelCostType> &
   get_fusion_kernel_costs() const;
   [[nodiscard]] const KernelCostType &get_shared_memory_init_cost() const;
   [[nodiscard]] KernelCostType get_shared_memory_gate_cost(GateType tp) const;
   [[nodiscard]] int get_shared_memory_num_free_qubits() const;
+  [[nodiscard]] int get_optimal_fusion_kernel_size() const;
 
   std::vector<KernelCostType> fusion_kernel_costs_;
   KernelCostType shared_memory_init_cost_;
   std::function<KernelCostType(GateType)> shared_memory_gate_cost_;
   int shared_memory_total_qubits_;
   int shared_memory_cacheline_qubits_;
+  int optimal_fusion_kernel_size_;
 };
 
 } // namespace quartz

--- a/src/quartz/simulator/kernel_cost.h
+++ b/src/quartz/simulator/kernel_cost.h
@@ -14,6 +14,18 @@ using KernelCostType = double;
  */
 class KernelCost {
 public:
+  /**
+   * The cost function of kernels.
+   * @param fusion_kernel_costs An array of costs for fusion kernels.
+   * The value of the 0-th index in the array should be 0 because it stands
+   * for a 0-qubit kernel.
+   * @param shared_memory_init_cost The cost of an empty shared-memory kernel.
+   * @param shared_memory_gate_cost The cost function of each gate in a
+   * shared-memory kernel.
+   * @param shared_memory_total_qubits
+   * @param shared_memory_cacheline_qubits Currently unused. The difference
+   * of the above 2 variables is the maximum size of a shared-memory kernel.
+   */
   KernelCost(
       const std::vector<KernelCostType> &fusion_kernel_costs,
       const KernelCostType &shared_memory_init_cost,

--- a/src/quartz/simulator/schedule.cpp
+++ b/src/quartz/simulator/schedule.cpp
@@ -448,9 +448,6 @@ bool Schedule::compute_kernel_schedule(const KernelCost &kernel_cost) {
     }
     std::sort(current_indices.begin(), current_indices.end());
     auto current_indices_hash = Status::get_hash(current_indices);
-    // TODO: add an option to directly execute the gate if it's a controlled
-    //  gate -- don't forget to remove the corresponding qubits from the
-    //  |absorbed_qubits| set if they are partially in the set.
 
     // TODO: make these numbers configurable
     constexpr int kMaxNumOfStatus = 4000;

--- a/src/quartz/simulator/schedule.h
+++ b/src/quartz/simulator/schedule.h
@@ -31,8 +31,7 @@ public:
    * algorithm, assuming there are no other kernels after the given ones.
    * The greedy algorithm is approximate -- it might not give the optimal
    * result.
-   * @param kernel_costs kernel_costs[i] represents the cost of an i-qubit
-   * kernel.
+   * @param kernel_cost The cost function of kernels.
    * @param kernels The non-intersecting kernels to be merged.
    * @param result_cost The sum of the cost of the resulting merged kernels.
    * @param result_kernels The resulting merged kernels, or nullptr if it is
@@ -40,10 +39,10 @@ public:
    * @return True iff the computation succeeds.
    */
   static bool
-  compute_end_schedule(const std::vector<KernelCostType> &kernel_costs,
-                       const std::vector<std::vector<int>> &kernels,
+  compute_end_schedule(const KernelCost &kernel_cost,
+                       const std::vector<std::pair<std::vector<int>, KernelType>> &kernels,
                        KernelCostType &result_cost,
-                       std::vector<std::vector<int>> *result_kernels);
+                       std::vector<std::pair<std::vector<int>, KernelType>> *result_kernels);
 
   /**
    * Compute the schedule using dynamic programming.

--- a/src/quartz/simulator/schedule.h
+++ b/src/quartz/simulator/schedule.h
@@ -38,11 +38,11 @@ public:
    * not necessary to record them.
    * @return True iff the computation succeeds.
    */
-  static bool
-  compute_end_schedule(const KernelCost &kernel_cost,
-                       const std::vector<std::pair<std::vector<int>, KernelType>> &kernels,
-                       KernelCostType &result_cost,
-                       std::vector<std::pair<std::vector<int>, KernelType>> *result_kernels);
+  static bool compute_end_schedule(
+      const KernelCost &kernel_cost,
+      const std::vector<std::pair<std::vector<int>, KernelType>> &kernels,
+      KernelCostType &result_cost,
+      std::vector<std::pair<std::vector<int>, KernelType>> *result_kernels);
 
   /**
    * Compute the schedule using dynamic programming.

--- a/src/test/test_simulation.cpp
+++ b/src/test/test_simulation.cpp
@@ -140,9 +140,9 @@ int main() {
   }
   KernelCost kernel_cost(
       /*fusion_kernel_costs=*/{0, 10.4, 10.400001, 10.400002, 11, 40, 46, 66},
-      /*shared_memory_init_cost=*/10.4,
+      /*shared_memory_init_cost=*/10,
       /*shared_memory_gate_cost=*/[](GateType) { return 0.8; },
-      /*shared_memory_total_qubits=*/10, /*shared_memory_cacheline_qubits=*/3);
+      /*shared_memory_total_qubits=*/11, /*shared_memory_cacheline_qubits=*/3);
   // FILE *fout = fopen("result.txt", "w");
   for (auto circuit : circuit_names) {
     // fprintf(fout, "\n", circuit.c_str());

--- a/src/test/test_simulation.cpp
+++ b/src/test/test_simulation.cpp
@@ -129,11 +129,11 @@ int main() {
                GateType::x, GateType::ry, GateType::u2, GateType::u3,
                GateType::cx, GateType::cz, GateType::cp, GateType::swap});
   std::vector<std::string> circuit_names = {
-      "dj"
+      "qft"
       // "realamprandom"
   };
-  // 29 total qubits, 28 local qubits
-  std::vector<int> num_qubits = {29};
+  // 31 total qubits, 28 local qubits
+  std::vector<int> num_qubits = {31};
   std::vector<int> num_local_qubits;
   for (int i = 28; i <= 28; i++) {
     num_local_qubits.push_back(i);

--- a/src/test/test_simulation.cpp
+++ b/src/test/test_simulation.cpp
@@ -138,6 +138,11 @@ int main() {
   for (int i = 28; i <= 28; i++) {
     num_local_qubits.push_back(i);
   }
+  KernelCost kernel_cost(
+      /*fusion_kernel_costs=*/{0, 10.4, 10.400001, 10.400002, 11, 40, 46, 66},
+      /*shared_memory_init_cost=*/10.4,
+      /*shared_memory_gate_cost=*/[](GateType) { return 0.8; },
+      /*shared_memory_total_qubits=*/10, /*shared_memory_cacheline_qubits=*/3);
   // FILE *fout = fopen("result.txt", "w");
   for (auto circuit : circuit_names) {
     // fprintf(fout, "\n", circuit.c_str());
@@ -172,9 +177,8 @@ int main() {
         // fprintf(fout, " %d", result);
         local_qubits =
             compute_local_qubits_with_ilp(*seq, local_q, &ctx, &interpreter);
-        auto schedules = get_schedules(
-            *seq, local_qubits, {0, 10.4, 10.400001, 10.400002, 11, 40, 46, 66},
-            &ctx, /*absorb_single_qubit_gates=*/true);
+        auto schedules = get_schedules(*seq, local_qubits, kernel_cost, &ctx,
+                                       /*absorb_single_qubit_gates=*/true);
         for (auto &schedule : schedules) {
           std::cout << "cost = " << schedule.cost_ << std::endl;
           schedule.print_kernel_schedule();


### PR DESCRIPTION
Also fixes a bug introduced in #78 that caused some single-qubit gates to be not executed.

Benchmark: `test_simulation`, `qft` circuit, 31 total qubits, 28 local qubits.
- Before this PR: 25 + 123 = 148 kernels, total cost = 275 + 1351.8 = 1626.8, running time = 53s
- After this PR with max shared-memory kernel size = 7: 22 + 117 = 139 kernels, total cost = 253 + 1371.6 = 1624.6
- After this PR with max shared-memory kernel size = 8: 5 + 50 = 55 kernels, total cost = 82.8 + 364 = 446.8, running time = 42s

For `dj` circuit with 31 total qubits and 28 local qubits, we get 4 + 1 = 5 kernels and total cost = 78 + 11 = 89 now.