### PR TITLE
[simulation] Fix CX in execution schedules when the target is global

### DIFF
--- a/src/quartz/gate/ccz.h
+++ b/src/quartz/gate/ccz.h
@@ -18,6 +18,7 @@ public:
              {0, 0, 0, 0, 0, 0, 1, 0},
              {0, 0, 0, 0, 0, 0, 0, -1}}) {}
   MatrixBase *get_matrix() override { return &mat; }
+  bool is_symmetric() const override { return true; }
   bool is_sparse() const override { return true; }
   int get_num_control_qubits() const override { return 2; }
   Matrix<8> mat;

--- a/src/quartz/gate/cp.h
+++ b/src/quartz/gate/cp.h
@@ -21,6 +21,7 @@ public:
     }
     return cached_matrices[phi].get();
   }
+  bool is_symmetric() const override { return true; }
   bool is_sparse() const override { return true; }
   int get_num_control_qubits() const override { return 1; }
   std::unordered_map<float, std::unique_ptr<Matrix<4>>> cached_matrices;

--- a/src/quartz/gate/cz.h
+++ b/src/quartz/gate/cz.h
@@ -11,6 +11,7 @@ public:
       : Gate(GateType::cz, 2 /*num_qubits*/, 0 /*num_parameters*/),
         mat({{1, 0, 0, 0}, {0, 1, 0, 0}, {0, 0, 1, 0}, {0, 0, 0, -1}}) {}
   MatrixBase *get_matrix() override { return &mat; }
+  bool is_symmetric() const override { return true; }
   bool is_sparse() const override { return true; }
   int get_num_control_qubits() const override { return 1; }
   Matrix<4> mat;

--- a/src/quartz/gate/gate.h
+++ b/src/quartz/gate/gate.h
@@ -16,8 +16,11 @@ public:
   virtual MatrixBase *get_matrix(const std::vector<ParamType> &params);
   virtual ParamType compute(const std::vector<ParamType> &input_params);
   [[nodiscard]] virtual bool is_commutative() const; // for traditional gates
-  [[nodiscard]] virtual bool
-  is_symmetric() const; // for 2-qubit gates; currently unused (always false)
+  /**
+   * @return True iff the gate is a multi-qubit gate and the gate remains
+   * the same under any qubit permutation (e.g., CZ, CP, CCZ, SWAP).
+   */
+  [[nodiscard]] virtual bool is_symmetric() const;
   // Returns true iff the number of non-zero elements in the matrix
   // representation of the quantum gate is exactly 2 to the power of num_qubits.
   [[nodiscard]] virtual bool is_sparse() const;

--- a/src/quartz/gate/swap.h
+++ b/src/quartz/gate/swap.h
@@ -11,6 +11,7 @@ public:
       : Gate(GateType::swap, 2 /*num_qubits*/, 0 /*num_parameters*/),
         mat({{1, 0, 0, 0}, {0, 0, 1, 0}, {0, 1, 0, 0}, {0, 0, 0, 1}}) {}
   MatrixBase *get_matrix() override { return &mat; }
+  bool is_symmetric() const override { return true; }
   bool is_sparse() const override { return true; }
   Matrix<4> mat;
 };

--- a/src/quartz/pybind/pybind.cpp
+++ b/src/quartz/pybind/pybind.cpp
@@ -45,7 +45,7 @@ void init_python_interpreter() {
 
 std::vector<std::vector<int>> PythonInterpreter::solve_ilp(
     const std::vector<std::vector<int>> &circuit_gate_qubits,
-    const std::vector<bool> &circuit_gate_is_sparse,
+    const std::vector<int> &circuit_gate_executable_type,
     const std::vector<std::vector<int>> &out_gate, int num_qubits,
     int num_local_qubits, int num_iterations, bool print_solution) {
   if (!solve_ilp_) {
@@ -53,7 +53,7 @@ std::vector<std::vector<int>> PythonInterpreter::solve_ilp(
         py::module::import("simulator.ilp").attr("solve_ilp"));
   }
   auto result =
-      solve_ilp_(circuit_gate_qubits, circuit_gate_is_sparse, out_gate,
+      solve_ilp_(circuit_gate_qubits, circuit_gate_executable_type, out_gate,
                  num_qubits, num_local_qubits, num_iterations, print_solution);
   return result.cast<std::vector<std::vector<int>>>();
 }

--- a/src/quartz/pybind/pybind.h
+++ b/src/quartz/pybind/pybind.h
@@ -14,7 +14,7 @@ class PythonInterpreter {
 public:
   std::vector<std::vector<int>>
   solve_ilp(const std::vector<std::vector<int>> &circuit_gate_qubits,
-            const std::vector<bool> &circuit_gate_is_sparse,
+            const std::vector<int> &circuit_gate_executable_type,
             const std::vector<std::vector<int>> &out_gate, int num_qubits,
             int num_local_qubits, int num_iterations,
             bool print_solution = false);

--- a/src/quartz/simulator/schedule.cpp
+++ b/src/quartz/simulator/schedule.cpp
@@ -1188,7 +1188,7 @@ compute_local_qubits_with_ilp(const CircuitSeq &sequence, int num_local_qubits,
       }
     } else {
       if (sequence.gates[i]->gate->is_sparse()) {
-        // A non-controlled gate is always executable if its matrix's rank is 1.
+        // A non-controlled gate is always executable if it is "sparse".
         // The only multi-qubit case here is the SWAP gate.
         // XXX: The usage of is_sparse() needs to be changed if we ever
         // introduce multi-qubit gates that is sparse but not executable.


### PR DESCRIPTION
Previously, we treated a gate as executable as long as it is "sparse" (a permutation matrix times a diagonal matrix).

But this is not true for the CX gate: the gate is only executable when the target qubit is local.

Now the logic becomes:
- For controlled gates, we need the target qubit to be local when and only when the gate is not *symmetric* (i.e., every qubit can be a control qubit).
- For non-controlled gates, we need all qubits to be local when it is a "dense" gate (single-qubit gates with at least 3 non-zero entries in the matrix, and possibly all non-controlled multi-qubit gates except for the SWAP gate).