### PR TITLE
[simulation] Consider cacheline qubits in DP for shared-memory kernels

### DIFF
--- a/src/python/simulator/ilp.py
+++ b/src/python/simulator/ilp.py
@@ -3,6 +3,8 @@ import qiskit
 import qiskit.circuit.library.standard_gates as gates
 
 
+# Partition the circuit into stages.
+# The return value is a list of sets of local qubits.
 def solve_ilp(
     circuit_gate_qubits,
     circuit_gate_executable_type,

--- a/src/quartz/simulator/kernel_cost.cpp
+++ b/src/quartz/simulator/kernel_cost.cpp
@@ -19,6 +19,10 @@ int KernelCost::get_shared_memory_num_free_qubits() const {
   return shared_memory_total_qubits_ - shared_memory_cacheline_qubits_;
 }
 
+int KernelCost::get_shared_memory_num_cacheline_qubits() const {
+  return shared_memory_cacheline_qubits_;
+}
+
 int KernelCost::get_optimal_fusion_kernel_size() const {
   return optimal_fusion_kernel_size_;
 }

--- a/src/quartz/simulator/kernel_cost.h
+++ b/src/quartz/simulator/kernel_cost.h
@@ -22,9 +22,10 @@ public:
    * @param shared_memory_init_cost The cost of an empty shared-memory kernel.
    * @param shared_memory_gate_cost The cost function of each gate in a
    * shared-memory kernel.
-   * @param shared_memory_total_qubits
-   * @param shared_memory_cacheline_qubits Currently unused. The difference
-   * of the above 2 variables is the maximum size of a shared-memory kernel.
+   * @param shared_memory_total_qubits The maximum size of a shared-memory
+   * kernel.
+   * @param shared_memory_cacheline_qubits Any shared-memory kernel must
+   * contain this number of the least significant qubits.
    */
   KernelCost(
       const std::vector<KernelCostType> &fusion_kernel_costs,
@@ -56,6 +57,7 @@ public:
   [[nodiscard]] const KernelCostType &get_shared_memory_init_cost() const;
   [[nodiscard]] KernelCostType get_shared_memory_gate_cost(GateType tp) const;
   [[nodiscard]] int get_shared_memory_num_free_qubits() const;
+  [[nodiscard]] int get_shared_memory_num_cacheline_qubits() const;
   [[nodiscard]] int get_optimal_fusion_kernel_size() const;
 
   std::vector<KernelCostType> fusion_kernel_costs_;

--- a/src/quartz/simulator/schedule.h
+++ b/src/quartz/simulator/schedule.h
@@ -17,9 +17,8 @@ namespace quartz {
  */
 class Schedule {
 public:
-  Schedule(const CircuitSeq &sequence, const std::vector<bool> &local_qubit,
-           Context *ctx)
-      : cost_(), sequence_(sequence), local_qubit_(local_qubit), ctx_(ctx) {}
+  Schedule(const CircuitSeq &sequence, const std::vector<int> &local_qubit,
+           Context *ctx);
 
   // Compute the number of down sets for the circuit sequence.
   [[nodiscard]] size_t num_down_sets();
@@ -68,8 +67,12 @@ private:
   // The original circuit sequence.
   CircuitSeq sequence_;
 
+  // The set of local qubits.
+  // |local_qubit_[0]| is the least significant bit.
+  std::vector<int> local_qubit_;
+
   // The mask for local qubits.
-  std::vector<bool> local_qubit_;
+  std::vector<bool> local_qubit_mask_;
 
   Context *ctx_;
 };
@@ -88,12 +91,12 @@ private:
  */
 std::vector<Schedule>
 get_schedules(const CircuitSeq &sequence,
-              const std::vector<std::vector<bool>> &local_qubits,
+              const std::vector<std::vector<int>> &local_qubits,
               const KernelCost &kernel_cost, Context *ctx,
               bool absorb_single_qubit_gates);
 
 class PythonInterpreter;
-std::vector<std::vector<bool>>
+std::vector<std::vector<int>>
 compute_local_qubits_with_ilp(const CircuitSeq &sequence, int num_local_qubits,
                               Context *ctx, PythonInterpreter *interpreter);
 } // namespace quartz

--- a/src/quartz/simulator/schedule.h
+++ b/src/quartz/simulator/schedule.h
@@ -32,6 +32,10 @@ public:
    * result.
    * @param kernel_cost The cost function of kernels.
    * @param kernels The non-intersecting kernels to be merged.
+   * @param is_shared_memory_cacheline_qubit A vector of size equal to the
+   * number of qubits, denoting if the qubits are in the shared-memory
+   * cacheline. When in doubt, it is safe to pass in a vector of |num_qubits|
+   * false's.
    * @param result_cost The sum of the cost of the resulting merged kernels.
    * @param result_kernels The resulting merged kernels, or nullptr if it is
    * not necessary to record them.
@@ -40,6 +44,7 @@ public:
   static bool compute_end_schedule(
       const KernelCost &kernel_cost,
       const std::vector<std::pair<std::vector<int>, KernelType>> &kernels,
+      const std::vector<bool> &is_shared_memory_cacheline_qubit,
       KernelCostType &result_cost,
       std::vector<std::pair<std::vector<int>, KernelType>> *result_kernels);
 

--- a/src/quartz/simulator/schedule.h
+++ b/src/quartz/simulator/schedule.h
@@ -18,7 +18,7 @@ namespace quartz {
 class Schedule {
 public:
   Schedule(const CircuitSeq &sequence, const std::vector<int> &local_qubit,
-           Context *ctx);
+           const std::vector<int> &global_qubit, Context *ctx);
 
   // Compute the number of down sets for the circuit sequence.
   [[nodiscard]] size_t num_down_sets();
@@ -75,6 +75,10 @@ private:
   // The set of local qubits.
   // |local_qubit_[0]| is the least significant bit.
   std::vector<int> local_qubit_;
+
+  // The set of non-local qubits.
+  // |global_qubit_[0]| is the least significant bit.
+  std::vector<int> global_qubit_;
 
   // The mask for local qubits.
   std::vector<bool> local_qubit_mask_;

--- a/src/test/test_simulation.cpp
+++ b/src/test/test_simulation.cpp
@@ -171,7 +171,7 @@ int main() {
 
       // fprintf(fout, "%d", num_q);
       for (int local_q : num_local_qubits) {
-        std::vector<std::vector<bool>> local_qubits;
+        std::vector<std::vector<int>> local_qubits;
         // int result =
         // num_iterations_by_heuristics(seq.get(), local_q, local_qubits);
         // fprintf(fout, " %d", result);


### PR DESCRIPTION
A follow-up of #80. Changes `Schedule::local_qubit_` from `std::vector<bool>` to `std::vector<int>`, and it is now assumed that the least significant bit is placed in `local_qubit_[0]`; the ILP outputs qubit indices in ascending order now, so the qubit with the lowest index will always be considered as the least significant bit.

Benchmark: test_simulation, qft circuit, 31 total qubits, 28 local qubits, max shared-memory kernel size=11, shared-memory cacheline size=3.

Before: 42 + 10 = 52 kernels, total cost = 322.2 + 114.4 = 436.6, running time = 24s
After: 42 + 9 = 51 kernels, total cost = 322.2 + 113.8 = 436, running time = 24s