### PR TITLE
fix u3 matrix implementation

### DIFF
--- a/src/quartz/gate/u3.h
+++ b/src/quartz/gate/u3.h
@@ -18,7 +18,7 @@ public:
         cached_matrices[theta][phi].find(lambda) ==
             cached_matrices[theta][phi].end()) {
       auto mat = std::make_unique<Matrix<2>>(Matrix<2>(
-          {{cos(theta), sin(theta) * (cos(lambda) + 1.0i * sin(lambda))},
+          {{cos(theta), -sin(theta) * (cos(lambda) + 1.0i * sin(lambda))},
            {sin(theta) * (cos(phi) + 1.0i * sin(phi)),
             cos(theta) * (cos(phi + lambda) + 1.0i * sin(phi + lambda))}}));
       cached_matrices[theta][phi][lambda] = std::move(mat);


### PR DESCRIPTION
the upper right element should contain a minus sign, which was missing from `u3.h` but is present in the `u3` implementation in `src/python/verifier/gates.py`