### PR TITLE
[simulation] Fix wrong cost for shared-memory kernels

### DIFF
--- a/src/quartz/simulator/schedule.cpp
+++ b/src/quartz/simulator/schedule.cpp
@@ -703,7 +703,14 @@ bool Schedule::compute_kernel_schedule(const KernelCost &kernel_cost) {
                                              current_merging_kernel_type);
             std::sort(local_schedule.sets.back().first.begin(),
                       local_schedule.sets.back().first.end());
-            new_cost += kernel_costs[current_merging_kernel.size()];
+            assert(current_merging_kernel_type == KernelType::fusion ||
+                   current_merging_kernel_type == KernelType::shared_memory);
+            // We record the cost here when closing the kernel.
+            if (current_merging_kernel_type == KernelType::fusion) {
+              new_cost += kernel_costs[current_merging_kernel.size()];
+            } else {
+              new_cost += kernel_cost.get_shared_memory_init_cost();
+            }
             std::vector<int> absorbing_set;
             for (auto &index : current_merging_kernel) {
               if (!current_index[index]) {

--- a/src/test/test_simulation.cpp
+++ b/src/test/test_simulation.cpp
@@ -142,7 +142,7 @@ int main() {
       /*fusion_kernel_costs=*/{0, 10.4, 10.400001, 10.400002, 11, 40, 46, 66},
       /*shared_memory_init_cost=*/10,
       /*shared_memory_gate_cost=*/[](GateType) { return 0.8; },
-      /*shared_memory_total_qubits=*/11, /*shared_memory_cacheline_qubits=*/3);
+      /*shared_memory_total_qubits=*/10, /*shared_memory_cacheline_qubits=*/3);
   // FILE *fout = fopen("result.txt", "w");
   for (auto circuit : circuit_names) {
     // fprintf(fout, "\n", circuit.c_str());


### PR DESCRIPTION
Previously shared-memory kernels incorrectly used fusion kernels' cost when being closed. This PR fixes this problem.

Benchmark: test_simulation, qft circuit, 31 total qubits, 28 local qubits, max shared-memory kernel size=10, shared-memory cacheline size=3.

Before: 86 + 12 = 98 kernels (79 fusion, 19 shared-memory), total cost = 933.4 + 132.4 = 1065.8, running time = 33s
After: 42 + 10 = 52 kernels (2 fusion, 50 shared-memory), total cost = 733.6 + 192.4 = 926, running time = 29s