### PR TITLE
[simulation] Only require target qubits to be active in shared-memory kernels (stage 1)

### DIFF
--- a/src/quartz/gate/ccz.h
+++ b/src/quartz/gate/ccz.h
@@ -20,6 +20,7 @@ public:
   MatrixBase *get_matrix() override { return &mat; }
   bool is_symmetric() const override { return true; }
   bool is_sparse() const override { return true; }
+  bool is_diagonal() const override { return true; }
   int get_num_control_qubits() const override { return 2; }
   Matrix<8> mat;
 };

--- a/src/quartz/gate/cp.h
+++ b/src/quartz/gate/cp.h
@@ -23,6 +23,7 @@ public:
   }
   bool is_symmetric() const override { return true; }
   bool is_sparse() const override { return true; }
+  bool is_diagonal() const override { return true; }
   int get_num_control_qubits() const override { return 1; }
   std::unordered_map<float, std::unique_ptr<Matrix<4>>> cached_matrices;
 };

--- a/src/quartz/gate/cu1.h
+++ b/src/quartz/gate/cu1.h
@@ -22,6 +22,7 @@ public:
     return cached_matrices[phi].get();
   }
   bool is_sparse() const override { return true; }
+  bool is_diagonal() const override { return true; }
   int get_num_control_qubits() const override { return 1; }
   std::unordered_map<ParamType, std::unique_ptr<Matrix<4>>> cached_matrices;
 };

--- a/src/quartz/gate/cz.h
+++ b/src/quartz/gate/cz.h
@@ -13,6 +13,7 @@ public:
   MatrixBase *get_matrix() override { return &mat; }
   bool is_symmetric() const override { return true; }
   bool is_sparse() const override { return true; }
+  bool is_diagonal() const override { return true; }
   int get_num_control_qubits() const override { return 1; }
   Matrix<4> mat;
 };

--- a/src/quartz/gate/gate.cpp
+++ b/src/quartz/gate/gate.cpp
@@ -25,6 +25,8 @@ bool Gate::is_symmetric() const { return false; }
 
 bool Gate::is_sparse() const { return false; }
 
+bool Gate::is_diagonal() const { return false; }
+
 int Gate::get_num_control_qubits() const { return 0; }
 
 int Gate::get_num_qubits() const { return num_qubits; }

--- a/src/quartz/gate/gate.h
+++ b/src/quartz/gate/gate.h
@@ -17,15 +17,28 @@ public:
   virtual ParamType compute(const std::vector<ParamType> &input_params);
   [[nodiscard]] virtual bool is_commutative() const; // for traditional gates
   /**
-   * @return True iff the gate is a multi-qubit gate and the gate remains
+   * @return True if the gate is a multi-qubit gate and the gate remains
    * the same under any qubit permutation (e.g., CZ, CP, CCZ, SWAP).
+   * Default value is false.
    */
   [[nodiscard]] virtual bool is_symmetric() const;
-  // Returns true iff the number of non-zero elements in the matrix
-  // representation of the quantum gate is exactly 2 to the power of num_qubits.
+  /**
+   * @return True if the number of non-zero elements in the matrix
+   * representation of the quantum gate is exactly 2 to the power of num_qubits.
+   * Default value is false.
+   */
   [[nodiscard]] virtual bool is_sparse() const;
-  // Returns the number of control qubits for controlled gates; or 0 if it is
-  // not a controlled gate.
+  /**
+   * @return True if the matrix representation of the quantum gate is a
+   * diagonal matrix (e.g., Z, CZ, P, CP).
+   * Default value is false.
+   */
+  [[nodiscard]] virtual bool is_diagonal() const;
+  /**
+   * @return The number of control qubits for controlled gates; or 0 if it is
+   * not a controlled gate.
+   * Default value is 0.
+   */
   [[nodiscard]] virtual int get_num_control_qubits() const;
   [[nodiscard]] int get_num_qubits() const;
   [[nodiscard]] int get_num_parameters() const;

--- a/src/quartz/gate/p.h
+++ b/src/quartz/gate/p.h
@@ -19,6 +19,7 @@ public:
     return cached_matrices[phi].get();
   }
   bool is_sparse() const override { return true; }
+  bool is_diagonal() const override { return true; }
   std::unordered_map<ParamType, std::unique_ptr<Matrix<2>>> cached_matrices;
 };
 

--- a/src/quartz/gate/pdg.h
+++ b/src/quartz/gate/pdg.h
@@ -19,6 +19,7 @@ public:
     return cached_matrices[phi].get();
   }
   bool is_sparse() const override { return true; }
+  bool is_diagonal() const override { return true; }
   std::unordered_map<float, std::unique_ptr<Matrix<2>>> cached_matrices;
 };
 

--- a/src/quartz/gate/s.h
+++ b/src/quartz/gate/s.h
@@ -11,6 +11,7 @@ public:
 
   MatrixBase *get_matrix() override { return &mat; }
   bool is_sparse() const override { return true; }
+  bool is_diagonal() const override { return true; }
   Matrix<2> mat;
 };
 } // namespace quartz

--- a/src/quartz/gate/sdg.h
+++ b/src/quartz/gate/sdg.h
@@ -12,6 +12,7 @@ public:
 
   MatrixBase *get_matrix() override { return &mat; }
   bool is_sparse() const override { return true; }
+  bool is_diagonal() const override { return true; }
   Matrix<2> mat;
 };
 } // namespace quartz

--- a/src/quartz/gate/t.h
+++ b/src/quartz/gate/t.h
@@ -11,6 +11,7 @@ public:
 
   MatrixBase *get_matrix() override { return &mat; }
   bool is_sparse() const override { return true; }
+  bool is_diagonal() const override { return true; }
   Matrix<2> mat;
 };
 

--- a/src/quartz/gate/tdg.h
+++ b/src/quartz/gate/tdg.h
@@ -11,6 +11,7 @@ public:
 
   MatrixBase *get_matrix() override { return &mat; }
   bool is_sparse() const override { return true; }
+  bool is_diagonal() const override { return true; }
   Matrix<2> mat;
 };
 

--- a/src/quartz/gate/u1.h
+++ b/src/quartz/gate/u1.h
@@ -19,6 +19,7 @@ public:
     return cached_matrices[lambda].get();
   }
   bool is_sparse() const override { return true; }
+  bool is_diagonal() const override { return true; }
   std::unordered_map<ParamType, std::unique_ptr<Matrix<2>>> cached_matrices;
 };
 

--- a/src/quartz/gate/z.h
+++ b/src/quartz/gate/z.h
@@ -11,6 +11,7 @@ public:
 
   MatrixBase *get_matrix() override { return &mat; }
   bool is_sparse() const override { return true; }
+  bool is_diagonal() const override { return true; }
   Matrix<2> mat;
 };
 


### PR DESCRIPTION
The ultimate goal for this PR is to make the DP only require target qubits to be active in shared-memory kernels for controlled gates, and not require any qubit to be active for gates with diagonal matrices (e.g., Z, CZ, P, CP).

This PR modifies the absorbing kernel optimization part to adapt it, and also the greedy execution part. Therefore (because it didn't modify the DP transition), the final schedule could be much better than what the DP algorithm anticipated, and there can be many empty kernels.

Benchmark: test_simulation, qft circuit, 31 total qubits, 28 local qubits, max shared-memory kernel size=10, shared-memory cacheline size=3.

Before: 42 + 10 = 52 kernels (2 fusion, 50 shared-memory), total cost = 733.6 + 192.4 = 926, running time = 29s
After: 9 + 9 = 18 kernels (2 fusion, 16 shared-memory), total cost = 402.2 + 180.6 = 582.8, running time = 45s