### PR TITLE
[simulation] Only require target qubits to be active in shared-memory kernels (stage 2)

### DIFF
--- a/src/quartz/circuitseq/circuitseq.cpp
+++ b/src/quartz/circuitseq/circuitseq.cpp
@@ -930,8 +930,8 @@ std::string CircuitSeq::to_string(bool line_number) const {
     if (line_number) {
       char buffer[20]; // enough to store any int
       int max_line_number_width =
-          std::max(1, (int)std::floor(std::log10(num_gates - 0.01)));
-      sprintf(buffer, "% *d", max_line_number_width, i);
+          std::max(1, (int)std::ceil(std::log10(num_gates - 0.01)));
+      sprintf(buffer, "%*d", max_line_number_width, i);
       result += std::string(buffer) + ": ";
     } else {
       result += "  ";

--- a/src/quartz/circuitseq/circuitseq.cpp
+++ b/src/quartz/circuitseq/circuitseq.cpp
@@ -922,12 +922,20 @@ void CircuitSeq::print(Context *ctx) const {
   }
 }
 
-std::string CircuitSeq::to_string() const {
+std::string CircuitSeq::to_string(bool line_number) const {
   std::string result;
   result += "CircuitSeq {\n";
   const int num_gates = (int)gates.size();
   for (int i = 0; i < num_gates; i++) {
-    result += "  ";
+    if (line_number) {
+      char buffer[20]; // enough to store any int
+      int max_line_number_width =
+          std::max(1, (int)std::floor(std::log10(num_gates - 0.01)));
+      sprintf(buffer, "% *d", max_line_number_width, i);
+      result += std::string(buffer) + ": ";
+    } else {
+      result += "  ";
+    }
     result += gates[i]->to_string();
     result += "\n";
   }

--- a/src/quartz/circuitseq/circuitseq.h
+++ b/src/quartz/circuitseq/circuitseq.h
@@ -94,7 +94,7 @@ public:
   // Returns the number of internal parameters removed.
   int remove_unused_internal_parameters();
   void print(Context *ctx) const;
-  [[nodiscard]] std::string to_string() const;
+  [[nodiscard]] std::string to_string(bool line_number = false) const;
   [[nodiscard]] std::string to_json() const;
   static std::unique_ptr<CircuitSeq> read_json(Context *ctx, std::istream &fin);
   static std::unique_ptr<CircuitSeq>

--- a/src/quartz/simulator/kernel.cpp
+++ b/src/quartz/simulator/kernel.cpp
@@ -60,6 +60,10 @@ bool KernelInDP::operator==(const KernelInDP &b) const {
   return true;
 }
 
+bool KernelInDP::operator<(const KernelInDP &b) const {
+  return active_qubits[0] < b.active_qubits[0];
+}
+
 std::string KernelInDP::to_string() const {
   std::string result;
   result += kernel_type_name(tp);

--- a/src/quartz/simulator/kernel.cpp
+++ b/src/quartz/simulator/kernel.cpp
@@ -1,5 +1,7 @@
 #include "kernel.h"
 
+#include <cassert>
+
 namespace quartz {
 std::string kernel_type_name(KernelType tp) {
   switch (tp) {
@@ -61,7 +63,21 @@ bool KernelInDP::operator==(const KernelInDP &b) const {
 }
 
 bool KernelInDP::operator<(const KernelInDP &b) const {
-  return active_qubits[0] < b.active_qubits[0];
+  // Put all kernels with non-empty |active_qubits| at the beginning.
+  if (!active_qubits.empty() && !b.active_qubits.empty()) {
+    // And sort them in ascending order of the first active qubit.
+    return active_qubits[0] < b.active_qubits[0];
+  } else if (active_qubits.empty() != b.active_qubits.empty()) {
+    // If this |active_qubits| is not empty, this is smaller.
+    return b.active_qubits.empty();
+  } else {
+    // Assume we don't have kernels with empty |active_qubits| and empty
+    // |touching_qubits|.
+    assert(!touching_qubits.empty() && !b.touching_qubits.empty());
+    // Sort kernels with empty |active_qubits| in ascending order of the first
+    // touching qubit.
+    return touching_qubits[0] < b.touching_qubits[0];
+  }
 }
 
 std::string KernelInDP::to_string() const {

--- a/src/quartz/simulator/kernel.cpp
+++ b/src/quartz/simulator/kernel.cpp
@@ -25,4 +25,63 @@ std::string Kernel::to_string() const {
   result += gates.to_string();
   return result;
 }
+
+size_t KernelInDP::get_hash() const {
+  size_t result = 5381 + (int)tp;
+  for (const auto &i : active_qubits) {
+    result = result * 33 + i;
+  }
+  for (const auto &i : touching_qubits) {
+    result = result * 33 + i;
+  }
+  return result;
+}
+
+bool KernelInDP::operator==(const KernelInDP &b) const {
+  if (tp != b.tp) {
+    return false;
+  }
+  if (active_qubits.size() != b.active_qubits.size()) {
+    return false;
+  }
+  for (int j = 0; j < (int)active_qubits.size(); j++) {
+    if (active_qubits[j] != b.active_qubits[j]) {
+      return false;
+    }
+  }
+  if (touching_qubits.size() != b.touching_qubits.size()) {
+    return false;
+  }
+  for (int j = 0; j < (int)touching_qubits.size(); j++) {
+    if (touching_qubits[j] != b.touching_qubits[j]) {
+      return false;
+    }
+  }
+  return true;
+}
+
+std::string KernelInDP::to_string() const {
+  std::string result;
+  result += kernel_type_name(tp);
+  result += "{";
+  for (int j = 0; j < (int)active_qubits.size(); j++) {
+    result += std::to_string(active_qubits[j]);
+    if (j != (int)active_qubits.size() - 1) {
+      result += ", ";
+    }
+  }
+  result += "}";
+  if (!touching_qubits.empty()) {
+    result += " touching {";
+    for (int j = 0; j < (int)touching_qubits.size(); j++) {
+      result += std::to_string(touching_qubits[j]);
+      if (j != (int)touching_qubits.size() - 1) {
+        result += ", ";
+      }
+    }
+    result += "}";
+  }
+  return result;
+}
+
 } // namespace quartz

--- a/src/quartz/simulator/kernel.h
+++ b/src/quartz/simulator/kernel.h
@@ -11,6 +11,9 @@ enum KernelType { fusion, shared_memory };
 
 std::string kernel_type_name(KernelType tp);
 
+/**
+ * A kernel used in the output of schedule.
+ */
 class Kernel {
 public:
   Kernel(const CircuitSeq &gates, const std::vector<int> &qubits,
@@ -21,6 +24,24 @@ public:
   CircuitSeq gates;
   std::vector<int> qubits;
   KernelType type;
+};
+
+/**
+ * A kernel used in the state of dynamic programming when computing the
+ * schedule.
+ */
+struct KernelInDP {
+public:
+  KernelInDP(const std::vector<int> &active_qubits,
+             const std::vector<int> touching_qubits, KernelType tp)
+      : active_qubits(active_qubits), touching_qubits(touching_qubits), tp(tp) {
+  }
+  size_t get_hash() const;
+  bool operator==(const KernelInDP &b) const;
+  [[nodiscard]] std::string to_string() const;
+  std::vector<int> active_qubits;
+  std::vector<int> touching_qubits;
+  KernelType tp;
 };
 
 } // namespace quartz

--- a/src/quartz/simulator/kernel.h
+++ b/src/quartz/simulator/kernel.h
@@ -32,12 +32,18 @@ public:
  */
 struct KernelInDP {
 public:
+  // It is unspecified what the kernel type is if the default constructor
+  // is called.
+  KernelInDP() {}
   KernelInDP(const std::vector<int> &active_qubits,
-             const std::vector<int> touching_qubits, KernelType tp)
+             const std::vector<int> &touching_qubits, KernelType tp)
       : active_qubits(active_qubits), touching_qubits(touching_qubits), tp(tp) {
   }
   size_t get_hash() const;
   bool operator==(const KernelInDP &b) const;
+  // A partial order: only compare the first element of |active_qubits|.
+  // Undefined behavior if any of the two |active_qubits| is empty.
+  bool operator<(const KernelInDP &b) const;
   [[nodiscard]] std::string to_string() const;
   std::vector<int> active_qubits;
   std::vector<int> touching_qubits;

--- a/src/quartz/simulator/schedule.cpp
+++ b/src/quartz/simulator/schedule.cpp
@@ -1651,6 +1651,7 @@ get_schedules(const CircuitSeq &sequence,
             /*gates=*/CircuitSeq(num_qubits,
                                  sequence.get_num_input_parameters()),
             /*qubits=*/std::vector<int>(), /*type=*/KernelType::shared_memory);
+        schedule.cost_ += kernel_cost.get_shared_memory_init_cost();
         int remaining_free_qubits =
             kernel_cost.get_shared_memory_num_free_qubits();
         for (int index = 0; index < num_qubits; index++) {

--- a/src/quartz/simulator/schedule.cpp
+++ b/src/quartz/simulator/schedule.cpp
@@ -1669,11 +1669,10 @@ get_schedules(const CircuitSeq &sequence,
           }
         }
         // Close this kernel now.
-        try_to_execute_single_qubit_gates(
-            (int)schedule.kernels.size() - 1, 0);
+        try_to_execute_single_qubit_gates((int)schedule.kernels.size() - 1, 0);
         // Then we execute the gates in this kernel.
-        for (int j = 0;
-             j < (int)schedule.kernels.back().gates.gates.size(); j++) {
+        for (int j = 0; j < (int)schedule.kernels.back().gates.gates.size();
+             j++) {
           auto &gate = schedule.kernels.back().gates.gates[j];
           auto &gate_indices_queue = gate_indices[gate->to_string()];
           assert(!gate_indices_queue.empty());
@@ -1682,13 +1681,12 @@ get_schedules(const CircuitSeq &sequence,
           const int original_index = gate_indices_queue.front();
           for (auto &next_single_qubit_gate :
                next_single_qubit_gates[original_index]) {
-            single_qubit_gate_indices[next_single_qubit_gate]
-                .second.erase(original_index);
+            single_qubit_gate_indices[next_single_qubit_gate].second.erase(
+                original_index);
             if (single_qubit_gate_indices[next_single_qubit_gate]
                     .second.empty()) {
               single_qubit_gate_to_execute.push_back(
-                  single_qubit_gate_indices[next_single_qubit_gate]
-                      .first);
+                  single_qubit_gate_indices[next_single_qubit_gate].first);
               // Insert the gate after this gate.
               try_to_execute_single_qubit_gates(
                   (int)schedule.kernels.size() - 1, j + 1);

--- a/src/quartz/simulator/schedule.h
+++ b/src/quartz/simulator/schedule.h
@@ -18,12 +18,15 @@ namespace quartz {
 class Schedule {
 public:
   Schedule(const CircuitSeq &sequence, const std::vector<int> &local_qubit,
-           const std::vector<int> &global_qubit, Context *ctx);
+           const std::vector<int> &global_qubit,
+           int num_shared_memory_cacheline_qubits, Context *ctx);
 
   // Compute the number of down sets for the circuit sequence.
   [[nodiscard]] size_t num_down_sets();
 
   [[nodiscard]] bool is_local_qubit(int index) const;
+
+  [[nodiscard]] bool is_shared_memory_cacheline_qubit(int index) const;
 
   /**
    * Compute which kernels to merge together at the end using a greedy
@@ -32,21 +35,15 @@ public:
    * result.
    * @param kernel_cost The cost function of kernels.
    * @param kernels The non-intersecting kernels to be merged.
-   * @param is_shared_memory_cacheline_qubit A vector of size equal to the
-   * number of qubits, denoting if the qubits are in the shared-memory
-   * cacheline. When in doubt, it is safe to pass in a vector of |num_qubits|
-   * false's.
    * @param result_cost The sum of the cost of the resulting merged kernels.
    * @param result_kernels The resulting merged kernels, or nullptr if it is
    * not necessary to record them.
    * @return True iff the computation succeeds.
    */
-  static bool compute_end_schedule(
-      const KernelCost &kernel_cost,
-      const std::vector<KernelInDP> &kernels,
-      const std::vector<bool> &is_shared_memory_cacheline_qubit,
-      KernelCostType &result_cost,
-      std::vector<KernelInDP> *result_kernels);
+  bool compute_end_schedule(const KernelCost &kernel_cost,
+                            const std::vector<KernelInDP> &kernels,
+                            KernelCostType &result_cost,
+                            std::vector<KernelInDP> *result_kernels) const;
 
   /**
    * Compute the schedule using dynamic programming.
@@ -82,6 +79,9 @@ private:
 
   // The mask for local qubits.
   std::vector<bool> local_qubit_mask_;
+
+  // The mask for shared-memory cacheline qubits.
+  std::vector<bool> shared_memory_cacheline_qubit_mask_;
 
   Context *ctx_;
 };

--- a/src/quartz/simulator/schedule.h
+++ b/src/quartz/simulator/schedule.h
@@ -43,10 +43,10 @@ public:
    */
   static bool compute_end_schedule(
       const KernelCost &kernel_cost,
-      const std::vector<std::pair<std::vector<int>, KernelType>> &kernels,
+      const std::vector<KernelInDP> &kernels,
       const std::vector<bool> &is_shared_memory_cacheline_qubit,
       KernelCostType &result_cost,
-      std::vector<std::pair<std::vector<int>, KernelType>> *result_kernels);
+      std::vector<KernelInDP> *result_kernels);
 
   /**
    * Compute the schedule using dynamic programming.


### PR DESCRIPTION
A follow-up of #97.

Changes:
- The DP status is now a product of 2 lists `vector<KernelInDP> open_kernels` and `vector<KernelInDP> absorbing_kernels`, where `KernelInDP` is a tuple of `vector<int> active_qubits`, `vector<int> touching_qubits`, and `KernelType tp`.
  - When `tp` is `fusion`, the set `touching_qubits` is always empty for now. A qubit can appear in multiple `touching_qubits`, but if a qubit appears in one `active_qubits`, it cannot appear in any other `active_qubits` or `touching_qubits`.
  - You can think of it as a status of operations with no data dependencies where `active_qubits` is a write operation and `touching_qubits` is a read operation.
  - `KernelInDP` is sorted by the first active qubit. Kernels with no active qubits are placed after kernels with some active qubits; they are sorted by the first touching qubit. It is assumed that each kernel has at least one active or touching qubit.
  - When computing the hash value for the DP status, `active_qubits`, `touching_qubits`, and `tp` are all taken into account for `open_kernels`, but `absorbing_kernels` is not used for now.
  - When merging two kernels, the `active_qubits` is the union of two `active_qubits` set and it is guaranteed that there are no duplicates. However, there can be duplicates in `touching_qubits`. Just to be safe, we also try to remove all active qubits from the merged `touching_qubits` set, although it should not happen if any active qubit appears in any touching qubits set.
  - `absorbing_kernels` only records closed kernels with non-empty `active_qubits`.
- When restoring single-qubit gates, it is assumed that they can be pushed towards right/later/the end by swapping with adjacent **control** qubit of controlled gates (or any qubit of a diagonal controlled gate), no matter what qubit the single-qubit gate operates on (but they are not always pushed). However, in some cases (when the single-qubit gate is a *dense* gate) we cannot do that. So the schedule can produce the wrong simulation result for now.
- `f[i & 1]` and `f[~i & 1]` are renamed to `f_prev` and `f_next` to make the code slightly more readable.
- The class `Schedule` now records the number of shared-memory cacheline qubits so it can provide a function `bool is_shared_memory_cacheline_qubit(int index)`.
- A parameter `bool line_number = false` is added to `CircuitSeq::to_string()` for easier debugging.
- 
```C++
constexpr int kMaxNumOfStatus = 4000;
constexpr int kShrinkToNumOfStatus = 2000;
```
is changed to
```C++
constexpr int kMaxNumOfStatus = 2000;
constexpr int kShrinkToNumOfStatus = 1000;
```
to make it run faster.
- A lot of TODOs added.
- The case when `absorb_single_qubit_gates = false` is not tested for this version.

Benchmark: test_simulation, qft circuit, 31 total qubits, 28 local qubits, max shared-memory kernel size=10, shared-memory cacheline size=3.

Before: 9 + 9 = 18 kernels (2 fusion, 16 shared-memory), total cost = 402.2 + 180.6 = 582.8, running time = 45s
After: 4 + 4 = 8 kernels (0 fusion, 8 shared-memory), total cost = 353.6 + 135.2 = 488.8, running time = 15s