### PR TITLE
[simulation] Bug fixes about executing gates in the DP

### DIFF
--- a/src/quartz/simulator/schedule.cpp
+++ b/src/quartz/simulator/schedule.cpp
@@ -470,10 +470,10 @@ bool Schedule::compute_kernel_schedule(
   initial_status.compute_hash();
   f[0][initial_status] = std::make_pair(0, LocalSchedule());
   auto update_f =
-      [&](std::unordered_map<Status, std::pair<KernelCostType, LocalSchedule>,
-                             StatusHash> &f,
-          const Status &s, const KernelCostType &new_cost,
-          const LocalSchedule &local_schedule) {
+      [](std::unordered_map<Status, std::pair<KernelCostType, LocalSchedule>,
+                            StatusHash> &f,
+         const Status &s, const KernelCostType &new_cost,
+         const LocalSchedule &local_schedule) {
         auto it = f.find(s);
         if (it == f.end()) {
           f.insert(std::make_pair(s, std::make_pair(new_cost, local_schedule)));
@@ -920,7 +920,8 @@ bool Schedule::compute_kernel_schedule(
               local_schedule.kernels.back().touching_qubits.clear();
               for (int index = 0; index < num_qubits; index++) {
                 if (touching[index]) {
-                  local_schedule.kernels.back().touching_qubits.push_back(index);
+                  local_schedule.kernels.back().touching_qubits.push_back(
+                      index);
                 }
               }
             }

--- a/src/test/test_simulation.cpp
+++ b/src/test/test_simulation.cpp
@@ -129,11 +129,11 @@ int main() {
                GateType::x, GateType::ry, GateType::u2, GateType::u3,
                GateType::cx, GateType::cz, GateType::cp, GateType::swap});
   std::vector<std::string> circuit_names = {
-      "qft"
-      // "realamprandom"
+//      "qft"
+       "realamprandom"
   };
   // 31 total qubits, 28 local qubits
-  std::vector<int> num_qubits = {31};
+  std::vector<int> num_qubits = {28};
   std::vector<int> num_local_qubits;
   for (int i = 28; i <= 28; i++) {
     num_local_qubits.push_back(i);

--- a/src/test/test_simulation.cpp
+++ b/src/test/test_simulation.cpp
@@ -130,7 +130,7 @@ int main() {
                GateType::cx, GateType::cz, GateType::cp, GateType::swap});
   std::vector<std::string> circuit_names = {
       "qft"
-//       "realamprandom"
+      // "realamprandom"
   };
   // 31 total qubits, 28 local qubits
   std::vector<int> num_qubits = {31};

--- a/src/test/test_simulation.cpp
+++ b/src/test/test_simulation.cpp
@@ -129,11 +129,11 @@ int main() {
                GateType::x, GateType::ry, GateType::u2, GateType::u3,
                GateType::cx, GateType::cz, GateType::cp, GateType::swap});
   std::vector<std::string> circuit_names = {
-//      "qft"
-       "realamprandom"
+      "qft"
+//       "realamprandom"
   };
   // 31 total qubits, 28 local qubits
-  std::vector<int> num_qubits = {28};
+  std::vector<int> num_qubits = {31};
   std::vector<int> num_local_qubits;
   for (int i = 28; i <= 28; i++) {
     num_local_qubits.push_back(i);


### PR DESCRIPTION
Changes:
- Fixes the bug when greedily executing the kernels after the DP, we might execute multi-qubit gates with a non-insular qubit before executing a previous multi-qubit gate with the same qubit as an insular qubit before this PR.
- When closing shared-memory kernels, we now add as many `touching_qubits` as possible, instead of sticking to the existing `touching_qubits`. However, we still do not remove existing absorbing kernels, although it may be better to remove some existing absorbing kernels' `active_qubits` in exchange for more `touching_qubits` in the new absorbing kernel.

TODOs:
- We still have empty kernels in `realamprandom`.
- We may want to update the cost for each gate based on the single-qubit gates attached to it.
- Do we want to try removing some existing absorbing kernels' `active_qubits` in exchange for more `touching_qubits` in the new absorbing kernel?
- We now have a mismatch about `touching_kernels` in DP and after DP when greedily executing the gates. This may cause more gates to be put in the earlier kernel when it can be put into a later kernel instead. This can be bad if the earlier kernel is a shared-memory kernel and the later kernel is a fusion kernel.

Benchmark: `realamprandom`, 28 total qubits, 28 local qubits
Before: 42 kernels (6 fusion (0 non-empty), 36 shared-memory (30 non-empty)), cost = 1318.8, running time = 52s
After: 22 kernels (1 fusion (0 non-empty), 21 shared-memory (20 non-empty)), cost = 1125.8, running time = 52s