### PR TITLE
[simulation] Sort the qubits in ILP

### DIFF
--- a/src/python/simulator/ilp.py
+++ b/src/python/simulator/ilp.py
@@ -133,6 +133,7 @@ def solve_ilp(
                 if v.name.startswith("a") and v.varValue == 1.0:
                     if v.name.endswith(str(j) + ")"):
                         result[j].append(int(v.name.split("(")[1].split(",")[0]))
+            result[j] = sorted(result[j])
         return result
 
 


### PR DESCRIPTION
Previously the ILP outputs qubits in alphabetical order on `string(int)` for the first stage.
Now we sort it to be simply an increasing order.