### PR TITLE
[simulation] Consider the cost of attaching single-qubit gates

### DIFF
--- a/src/quartz/simulator/schedule.h
+++ b/src/quartz/simulator/schedule.h
@@ -55,12 +55,16 @@ public:
    * @param non_insular_qubit_indices The set of non-insular qubit indices
    * for each gate, if any of them should be considered differently from
    * what we would have computed from the gate itself.
+   * @param shared_memory_gate_costs The cost for each gate if put into a
+   * shared-memory kernel, if any of them should be considered differently from
+   * what we would have computed from the gate itself.
    * @return True iff the computation succeeds. The results are stored in
    * the member variables |kernels|, |kernel_qubits|, and |cost_|.
    */
   bool compute_kernel_schedule(
       const KernelCost &kernel_cost,
-      const std::vector<std::vector<int>> &non_insular_qubit_indices = {});
+      const std::vector<std::vector<int>> &non_insular_qubit_indices = {},
+      const std::vector<KernelCostType> &shared_memory_gate_costs = {});
 
   [[nodiscard]] int get_num_kernels() const;
   void print_kernel_schedule() const;


### PR DESCRIPTION
A follow-up of #100 and #102.

Benchmark: `realamprandom`, 28 total qubits, 28 local qubits
Before: 22 kernels (1 fusion (0 non-empty), 21 shared-memory (20 non-empty)), cost = 1125.8, running time = 34s
After: 22 kernels (1 fusion (0 non-empty), 21 shared-memory (19 non-empty)), cost = 1215.4, running time = 34s

We may design a more fine-grained cost function to make better use of this.