### PR TITLE
[simulator] Use general controlled gates in simulation schedule and fix a bug

### DIFF
--- a/src/quartz/circuitseq/circuitgate.cpp
+++ b/src/quartz/circuitseq/circuitgate.cpp
@@ -1,6 +1,7 @@
 #include "circuitgate.h"
 #include "circuitwire.h"
 
+#include <algorithm>
 #include <cassert>
 
 namespace quartz {
@@ -135,8 +136,8 @@ std::string CircuitGate::to_string() const {
   result += gate_type_name(gate->tp);
   if (gate->get_num_control_qubits() > 0) {
     auto control_state = gate->get_control_state();
-    if (std::find(control_state.begin(), control_state.end(), false) !=
-        control_state.end()) {
+    if (!std::all_of(control_state.begin(), control_state.end(),
+                     [](bool v) { return v; })) {
       // Not a simple controlled gate
       result += "[";
       for (const auto &value : control_state) {

--- a/src/quartz/circuitseq/circuitgate.cpp
+++ b/src/quartz/circuitseq/circuitgate.cpp
@@ -133,6 +133,18 @@ std::string CircuitGate::to_string() const {
   }
   result += " = ";
   result += gate_type_name(gate->tp);
+  if (gate->get_num_control_qubits() > 0) {
+    auto control_state = gate->get_control_state();
+    if (std::find(control_state.begin(), control_state.end(), false) !=
+        control_state.end()) {
+      // Not a simple controlled gate
+      result += "[";
+      for (const auto &value : control_state) {
+        result += (int)value + '0';
+      }
+      result += "]";
+    }
+  }
   result += "(";
   for (int j = 0; j < (int)input_wires.size(); j++) {
     result += input_wires[j]->to_string();

--- a/src/quartz/context/context.cpp
+++ b/src/quartz/context/context.cpp
@@ -49,6 +49,31 @@ Gate *Context::get_gate(GateType tp) {
     return nullptr;
 }
 
+Gate *Context::get_general_controlled_gate(GateType tp,
+                                           const std::vector<bool> &state) {
+  auto it1 = general_controlled_gates_.find(tp);
+  if (it1 == general_controlled_gates_.end()) {
+    it1 = general_controlled_gates_.insert(
+        general_controlled_gates_.end(),
+        std::make_pair(
+            tp,
+            std::unordered_map<std::vector<bool>, std::unique_ptr<Gate>>()));
+  }
+  auto it2 = it1->second.find(state);
+  if (it2 == it1->second.end()) {
+    // Create a new general controlled gate if not found.
+    Gate *controlled_gate = get_gate(tp);
+    if (!controlled_gate) {
+      return nullptr;
+    }
+    it2 = it1->second.insert(
+        it1->second.end(),
+        std::make_pair(state, std::make_unique<GeneralControlledGate>(
+                                  controlled_gate, state)));
+  }
+  return it2->second.get();
+}
+
 bool Context::insert_gate(GateType tp) {
   if (gates_.count(tp) > 0) {
     return false;

--- a/src/quartz/context/context.h
+++ b/src/quartz/context/context.h
@@ -20,6 +20,8 @@ public:
   Context(const std::vector<GateType> &supported_gates, const int num_qubits,
           const int num_params);
   Gate *get_gate(GateType tp);
+  Gate *get_general_controlled_gate(GateType tp,
+                                    const std::vector<bool> &state);
   [[nodiscard]] const std::vector<GateType> &get_supported_gates() const;
   [[nodiscard]] const std::vector<GateType> &
   get_supported_parameter_gates() const;
@@ -62,6 +64,9 @@ public:
 private:
   size_t global_unique_id;
   std::unordered_map<GateType, std::unique_ptr<Gate>> gates_;
+  std::unordered_map<
+      GateType, std::unordered_map<std::vector<bool>, std::unique_ptr<Gate>>>
+      general_controlled_gates_;
   std::vector<GateType> supported_gates_;
   std::vector<GateType> supported_parameter_gates_;
   std::vector<GateType> supported_quantum_gates_;

--- a/src/quartz/gate/all_gates.h
+++ b/src/quartz/gate/all_gates.h
@@ -9,6 +9,7 @@
 #include "cx.h"
 #include "cz.h"
 #include "gate.h"
+#include "general_controlled_gate.h"
 #include "h.h"
 #include "input_param.h"
 #include "input_qubit.h"

--- a/src/quartz/gate/gate.cpp
+++ b/src/quartz/gate/gate.cpp
@@ -29,6 +29,10 @@ bool Gate::is_diagonal() const { return false; }
 
 int Gate::get_num_control_qubits() const { return 0; }
 
+std::vector<bool> Gate::get_control_state() const {
+  return std::vector<bool>(get_num_control_qubits(), true);
+}
+
 int Gate::get_num_qubits() const { return num_qubits; }
 
 int Gate::get_num_parameters() const { return num_parameters; }

--- a/src/quartz/gate/gate.h
+++ b/src/quartz/gate/gate.h
@@ -40,6 +40,12 @@ public:
    * Default value is 0.
    */
   [[nodiscard]] virtual int get_num_control_qubits() const;
+  /**
+   * @return The control state for controlled gates. Only overridden by
+   * GeneralControlledGate.
+   * Default value is a vector of |get_num_control_qubits()| true's.
+   */
+  [[nodiscard]] virtual std::vector<bool> get_control_state() const;
   [[nodiscard]] int get_num_qubits() const;
   [[nodiscard]] int get_num_parameters() const;
   [[nodiscard]] bool is_parameter_gate() const;

--- a/src/quartz/gate/gates.inc.h
+++ b/src/quartz/gate/gates.inc.h
@@ -1,4 +1,6 @@
 // A mapping from GateType to Gate subclasses.
+// Note that we don't have GeneralControlledGate here because we may need
+// to deal with it separately.
 PER_GATE(h, HGate)
 PER_GATE(x, XGate)
 PER_GATE(y, YGate)

--- a/src/quartz/gate/general_controlled_gate.h
+++ b/src/quartz/gate/general_controlled_gate.h
@@ -1,0 +1,77 @@
+#pragma once
+
+#include "../math/matrix.h"
+#include "gate.h"
+#include <assert.h>
+
+namespace quartz {
+class GeneralControlledGate : public Gate {
+public:
+  GeneralControlledGate(Gate *controlled_gate, const std::vector<bool> &state)
+      : controlled_gate_(controlled_gate), state_(state),
+        Gate(controlled_gate->tp, controlled_gate->num_qubits,
+             controlled_gate->num_parameters) {}
+  void permute_matrix(MatrixBase *mat) {
+    assert(num_qubits <= 30);
+    for (int i = 0; i < (1 << num_qubits); i++) {
+      int new_i = i;
+      for (int k = 0; k < (int)state_.size(); k++) {
+        if (!state_[k]) {
+          new_i ^= (1 << k);
+        }
+      }
+      if (new_i < i) {
+        // already swapped
+        continue;
+      }
+      for (int j = 0; j < (1 << num_qubits); j++) {
+        int new_j = j;
+        for (int k = 0; k < (int)state_.size(); k++) {
+          if (!state_[k]) {
+            new_j ^= (1 << k);
+          }
+        }
+        std::swap((*mat)[i][j], (*mat)[new_i][new_j]);
+      }
+    }
+  }
+  // TODO: Cache the results, avoid memory leakage
+  MatrixBase *get_matrix() override {
+    auto result = new MatrixBase(*controlled_gate_->get_matrix());
+    permute_matrix(result);
+    return result;
+  }
+  // TODO: Cache the results, avoid memory leakage
+  MatrixBase *get_matrix(const std::vector<ParamType> &params) override {
+    auto result = new MatrixBase(*controlled_gate_->get_matrix(params));
+    permute_matrix(result);
+    return result;
+  }
+  bool is_symmetric() const override {
+    if (std::find(state_.begin(), state_.end(), false) == state_.end()) {
+      // Same as the original gate
+      return controlled_gate_->is_symmetric();
+    }
+    // Otherwise, no guarantee
+    return false;
+  }
+  bool is_sparse() const override {
+    // Same as the original gate
+    return controlled_gate_->is_sparse();
+  }
+  bool is_diagonal() const override {
+    if (std::find(state_.begin(), state_.end(), false) == state_.end()) {
+      // Same as the original gate
+      return controlled_gate_->is_diagonal();
+    }
+    // Otherwise, no guarantee
+    return false;
+  }
+  int get_num_control_qubits() const override {
+    // Same as the original gate
+    return controlled_gate_->get_num_control_qubits();
+  }
+  Gate *controlled_gate_;
+  std::vector<bool> state_;
+};
+} // namespace quartz

--- a/src/quartz/gate/general_controlled_gate.h
+++ b/src/quartz/gate/general_controlled_gate.h
@@ -71,9 +71,7 @@ public:
     // Same as the original gate
     return controlled_gate_->get_num_control_qubits();
   }
-  std::vector<bool> get_control_state() const override {
-    return state_;
-  }
+  std::vector<bool> get_control_state() const override { return state_; }
   Gate *controlled_gate_;
   std::vector<bool> state_;
 };

--- a/src/quartz/gate/general_controlled_gate.h
+++ b/src/quartz/gate/general_controlled_gate.h
@@ -71,6 +71,9 @@ public:
     // Same as the original gate
     return controlled_gate_->get_num_control_qubits();
   }
+  std::vector<bool> get_control_state() const override {
+    return state_;
+  }
   Gate *controlled_gate_;
   std::vector<bool> state_;
 };

--- a/src/quartz/simulator/schedule.cpp
+++ b/src/quartz/simulator/schedule.cpp
@@ -1827,8 +1827,8 @@ get_schedules(const CircuitSeq &sequence,
                   1);
               k++;
             }
-            if (std::find(control_state.begin(), control_state.end(), false) !=
-                control_state.end()) {
+            if (!std::all_of(control_state.begin(), control_state.end(),
+                             [](bool v) { return v; })) {
               // Not a simple controlled gate
               schedule.kernels[i].gates.gates[j]->gate =
                   ctx->get_general_controlled_gate(

--- a/src/quartz/simulator/schedule.cpp
+++ b/src/quartz/simulator/schedule.cpp
@@ -851,22 +851,42 @@ bool Schedule::compute_kernel_schedule(
       }
       // Sort the absorbing kernels in ascending order.
       std::sort(new_absorbing_kernels.begin(), new_absorbing_kernels.end());
+      auto update_absorbing_kernels_for_new_fusion_kernel = [&]() {
+        // For fusion kernels, we need to update the |absorbing_kernels|'s
+        // |touching_qubits| again.
+        // Loop in reverse order so that we do not need to worry about
+        // the index change during removal.
+        for (int k = (int)new_absorbing_kernels.size() - 1; k >= 0; k--) {
+          // Remove all qubits of the current gate from the
+          // touching qubits in |absorbing_kernels|.
+          // Loop in reverse order so that we do not need to worry about
+          // the index change during removal.
+          for (int j = (int)new_absorbing_kernels[k].touching_qubits.size() - 1;
+               j >= 0; j--) {
+            if (current_index[new_absorbing_kernels[k].touching_qubits[j]]) {
+              new_absorbing_kernels[k].touching_qubits.erase(
+                  new_absorbing_kernels[k].touching_qubits.begin() + j);
+            }
+          }
+        }
+      };
 
       if (intersect_kernel_indices.empty()) {
         // Optimization:
         // The current gate is not touching any kernels on the frontier.
         // Directly add the gate to the frontier.
         auto new_status = current_status;
-        new_status.insert_set(current_single_gate_fusion_kernel);
-        new_status.absorbing_kernels = new_absorbing_kernels;
-        new_status.hash ^= current_single_gate_fusion_kernel_hash;
-        update_f(f_next, new_status, current_cost, current_local_schedule);
-
-        new_status = current_status;
         new_status.insert_set(current_single_gate_shared_memory_kernel);
         new_status.absorbing_kernels = new_absorbing_kernels;
         new_status.hash ^= current_single_gate_shared_memory_kernel_hash;
-        current_cost += current_gate_cost;
+        update_f(f_next, new_status, current_cost + current_gate_cost,
+                 current_local_schedule);
+
+        update_absorbing_kernels_for_new_fusion_kernel();
+        new_status = current_status;
+        new_status.insert_set(current_single_gate_fusion_kernel);
+        new_status.absorbing_kernels = new_absorbing_kernels;
+        new_status.hash ^= current_single_gate_fusion_kernel_hash;
         update_f(f_next, new_status, current_cost, current_local_schedule);
         continue;
       }
@@ -950,8 +970,13 @@ bool Schedule::compute_kernel_schedule(
               }
             }
             for (auto &index : local_schedule.kernels.back().touching_qubits) {
-              if (!current_non_insular_index[index]) {
+              if (!current_non_insular_index[index] &&
+                  (!current_index[index] ||
+                   current_gate_kernel.tp == KernelType::shared_memory)) {
                 // Similarly, we block the target qubits in the
+                // |touching_qubits| set.
+                // If the current gate is in a fusion kernel, we also need
+                // to block the insular qubits in the current gate in the
                 // |touching_qubits| set.
                 absorbing_kernel.touching_qubits.push_back(index);
               }
@@ -1181,17 +1206,19 @@ bool Schedule::compute_kernel_schedule(
       // Start the search with touching_set_index=-1 and
       // kernel_index=num_kernels, so that we can decide whether to merge the
       // first "touching set" with the current gate or not inside the search.
-      search_merging_kernels(
-          search_merging_kernels,
-          /*current_gate_kernel=*/current_single_gate_fusion_kernel,
-          /*current_merging_kernel=*/KernelInDP(), /*cost=*/current_cost,
-          /*touching_set_index=*/-1, /*kernel_index=*/num_kernels);
       // For shared-memory kernels, we account for the gate cost now.
       search_merging_kernels(
           search_merging_kernels,
           /*current_gate_kernel=*/current_single_gate_shared_memory_kernel,
           /*current_merging_kernel=*/KernelInDP(),
           /*cost=*/current_cost + current_gate_cost,
+          /*touching_set_index=*/-1, /*kernel_index=*/num_kernels);
+
+      update_absorbing_kernels_for_new_fusion_kernel();
+      search_merging_kernels(
+          search_merging_kernels,
+          /*current_gate_kernel=*/current_single_gate_fusion_kernel,
+          /*current_merging_kernel=*/KernelInDP(), /*cost=*/current_cost,
           /*touching_set_index=*/-1, /*kernel_index=*/num_kernels);
     }
   } // end of for (int i = 0; i < num_gates; i++)
@@ -1382,15 +1409,27 @@ get_schedules(const CircuitSeq &sequence,
   std::vector<std::vector<KernelCostType>> shared_memory_gate_costs(
       local_qubits.size());
 
-  // |have_dense_single_qubit_gate[i][j]|: if there is a dense single-qubit gate
-  // on qubit |j| that is not executed yet in the |i|-th stage;
-  // only computed when |attach_single_qubit_gates| is true
-  //  std::deque<std::vector<bool>> have_dense_single_qubit_gate;
-  //  std::vector<std::pair<int, std::unordered_set<int>>>
-  //      single_qubit_gate_indices_;
+  // |should_flip_control_qubit[i][j]|: if the |j|-th qubit in the |i|-th gate
+  // should be flipped if we remove all single-qubit sparse non-diagonal gates
+  // (e.g., X gate)
+  // |flipping[i]|: if the |i|-th qubit is flipped now if we remove them
+  std::vector<std::vector<bool>> should_flip_control_qubit(num_gates);
+  std::vector<bool> flipping(num_qubits, false);
 
   if (debug) {
     std::cout << "get_schedules for " << sequence.to_string(true) << std::endl;
+  }
+
+  for (int i = 0; i < num_gates; i++) {
+    if (sequence.gates[i]->gate->get_num_qubits() == 1 &&
+        sequence.gates[i]->gate->is_sparse() &&
+        !sequence.gates[i]->gate->is_diagonal()) {
+      flipping[sequence.gates[i]->get_min_qubit_index()].flip();
+    } else if (sequence.gates[i]->gate->get_num_control_qubits() > 0) {
+      for (auto &qubit : sequence.gates[i]->get_control_qubit_indices()) {
+        should_flip_control_qubit[i].push_back(flipping[qubit]);
+      }
+    }
   }
 
   int num_stage = -1;
@@ -1544,6 +1583,14 @@ get_schedules(const CircuitSeq &sequence,
             // the matrix on the local qubit is sparse.
             if (!sequence.gates[i]->gate->is_sparse()) {
               has_dense_single_qubit_gate[current_local_qubits[0]] = true;
+            }
+
+            if (sequence.gates[i]->gate->tp == GateType::cx ||
+                sequence.gates[i]->gate->tp == GateType::ccx) {
+              std::cerr << "Warning: CX or CCX gate attached to another gate. "
+                        << "The schedule may be different for each device, "
+                        << "but we only output the schedule for the device "
+                        << "where CX or CCX is not executed here." << std::endl;
             }
           } else {
             // Either a global gate or a multi-qubit gate.
@@ -1729,13 +1776,21 @@ get_schedules(const CircuitSeq &sequence,
   }
   if (attach_single_qubit_gates) {
     // Restore the single-qubit gates.
+    // Adjust controlled gates.
+    flipping.assign(num_qubits, false);
     for (auto &schedule : result) {
       for (int i = 0; i < schedule.get_num_kernels(); i++) {
         // Returns the number of gates inserted.
         auto insert_single_qubit_gates =
-            [&schedule, &i, &sequence](const std::vector<int> &gate_indices,
-                                       int insert_location) {
+            [&schedule, &i, &sequence, &flipping](
+                const std::vector<int> &gate_indices, int insert_location) {
               for (auto &gate_index : gate_indices) {
+                if (sequence.gates[gate_index]->gate->get_num_qubits() == 1 &&
+                    sequence.gates[gate_index]->gate->is_sparse() &&
+                    !sequence.gates[gate_index]->gate->is_diagonal()) {
+                  flipping[sequence.gates[gate_index]->get_min_qubit_index()]
+                      .flip();
+                }
                 schedule.kernels[i].gates.insert_gate(
                     insert_location, sequence.gates[gate_index].get());
                 insert_location++;
@@ -1750,10 +1805,44 @@ get_schedules(const CircuitSeq &sequence,
           auto &gate_indices_queue = gate_indices[gate->to_string()];
           assert(!gate_indices_queue.empty());
 
-          // We execute the gate now.
           const int original_index = gate_indices_queue.front();
           gate_indices_queue.pop();
           j += insert_single_qubit_gates(attach_front[original_index], j);
+
+          // We execute the gate now.
+          std::vector<bool> control_state;
+          if (schedule.kernels[i]
+                  .gates.gates[j]
+                  ->gate->get_num_control_qubits() > 0) {
+            assert(schedule.kernels[i]
+                       .gates.gates[j]
+                       ->gate->get_num_control_qubits() ==
+                   (int)should_flip_control_qubit[original_index].size());
+            int k = 0;
+            for (auto &qubit : schedule.kernels[i]
+                                   .gates.gates[j]
+                                   ->get_control_qubit_indices()) {
+              control_state.push_back(
+                  should_flip_control_qubit[original_index][k] ^ flipping[k] ^
+                  1);
+              k++;
+            }
+            if (std::find(control_state.begin(), control_state.end(), false) !=
+                control_state.end()) {
+              // Not a simple controlled gate
+              schedule.kernels[i].gates.gates[j]->gate =
+                  ctx->get_general_controlled_gate(
+                      schedule.kernels[i].gates.gates[j]->gate->tp,
+                      control_state);
+            }
+          }
+          if (schedule.kernels[i].gates.gates[j]->gate->get_num_qubits() == 1 &&
+              schedule.kernels[i].gates.gates[j]->gate->is_sparse() &&
+              !schedule.kernels[i].gates.gates[j]->gate->is_diagonal()) {
+            flipping[schedule.kernels[i].gates.gates[j]->get_min_qubit_index()]
+                .flip();
+          }
+
           j += insert_single_qubit_gates(attach_back[original_index], j + 1);
         }
       }

--- a/src/quartz/simulator/schedule.h
+++ b/src/quartz/simulator/schedule.h
@@ -47,10 +47,16 @@ public:
 
   /**
    * Compute the schedule using dynamic programming.
-   * A kernel with a single controlled gate (e.g., CX) is assumed to have
-   * half of the cost of a kernel with a single corresponding non-controlled
-   * gate (e.g., X). A kernel with one CCX is assumed to have 1/4 of the
-   * cost of a kernel with X.
+   * Note that it is possible for this DP to give wrong results only when
+   * there are both X gate and controlled gates: it assumes we can swap
+   * single-qubit sparse gates with adjacent controlled gates if the
+   * single-qubit gate operates on the same qubit as the control qubit of
+   * the controlled gate. For example, it may reorder
+   * X(Q0) CZ(Q0, Q1)
+   * to
+   * CZ(Q0, Q1) X(Q0)
+   * where the correct schedule should be
+   * CZ[0](Q0, Q1) X(Q0).
    * @param kernel_cost The cost function of kernels.
    * @param non_insular_qubit_indices The set of non-insular qubit indices
    * for each gate, if any of them should be considered differently from


### PR DESCRIPTION
Related issue = #105

This PR adds general controlled gates and outputs them in the simulation schedule. It takes into consideration all `X` gates, and changes the control state of controlled gates whenever necessary. For example,
```
CZ[0](Q1, Q2)
```
means to apply a `Z` gate to `Q2` when `Q1` is |0> instead of |1>.

This PR does not support handling the removal of `CX` gates but it prints a warning message whenever a `CX` gate is removed.

Other changes:
- Fixes a bug introduced in #102 which may cause the same qubit to appear in an open fusion kernel's active qubits and an absorbing shared-memory kernel's touching qubits at the same time. This did not cause problems in previous experiments.

Benchmark: exactly the same as #104.