### PR TITLE
[legion] single-device 28-qubits dj tested (no shm)

### DIFF
--- a/config/config.linux
+++ b/config/config.linux
@@ -6,16 +6,18 @@ echo " Defaults for Linux machine"
 CUQUANTUM_DIR=~/qs/cuquantum-linux-x86_64-22.11.0.13-archive
 
 # set CUDA dir in case cmake cannot autodetect a path
-CUDA_DIR=/opt/nvidia/hpc_sdk/Linux_x86_64/22.5/cuda/11.7
+# CUDA_DIR=/opt/nvidia/hpc_sdk/Linux_x86_64/22.5/cuda/11.7
+CUDA_DIR=/usr/local/cuda-11.7
 
 # set nccl dir
-NCCL_DIR=/global/common/software/nersc/pm-2022q4/sw/nccl-2.15.5-ofi-r4
+# NCCL_DIR=/global/common/software/nersc/pm-2022q4/sw/nccl-2.15.5-ofi-r4
+NCCL_DIR=~/nccl/build
 
 # using simulator
 QUARTZ_USE_SIMULATOR=ON
 
 # backend
-USE_LEGION=OFF
+USE_LEGION=ON
 
 . $(dirname $0)/config.inc
 run_cmake $*

--- a/src/sim/examples/legion-based/CMakeLists.txt
+++ b/src/sim/examples/legion-based/CMakeLists.txt
@@ -9,6 +9,7 @@ set(CPU_SRC
 cuda_add_executable(${project_target} ${CPU_SRC})
 target_include_directories(${project_target} PRIVATE ${QSIM_INCLUDE_DIRS} ${CMAKE_INSTALL_INCLUDEDIR})
 message("QSIM_INCLUDE_DIRS: ${QSIM_INCLUDE_DIRS}")
+message("CMAKE_INSTALL_INCLUDEDIR: ${CMAKE_INSTALL_INCLUDEDIR}")
 target_link_libraries(${project_target} -Wl,--whole-archive quansim -Wl,--no-whole-archive ${QSIM_EXT_LIBRARIES})
 
 set(BIN_DEST "bin")

--- a/src/sim/examples/legion-based/test_sim_legion.cc
+++ b/src/sim/examples/legion-based/test_sim_legion.cc
@@ -25,28 +25,28 @@ void sim::top_level_task(
     Task const *task, std::vector<PhysicalRegion> const &regions, Context ctx,
     Runtime *runtime) {
   DSConfig config;
-  bool use_ilp = false;
-  quartz::init_python_interpreter();
+  bool use_ilp = true;
+  // quartz::init_python_interpreter();
   quartz::PythonInterpreter interpreter;
   quartz::Context qtz({GateType::input_qubit, GateType::input_param,
-                        GateType::h, GateType::x, GateType::ry, GateType::u2,
-                        GateType::u3, GateType::cx, GateType::cz, GateType::cp,
-                        GateType::swap});
+                       GateType::h, GateType::x, GateType::ry, GateType::u2,
+                       GateType::u3, GateType::cx, GateType::cz, GateType::cp,
+                       GateType::p, GateType::z, GateType::swap});
   // auto seq = quartz::CircuitSeq::from_qasm_file(
   //     &qtz, std::string("/home/ubuntu/quartz-master/circuit/MQTBench_") +
   //               std::to_string(config.num_all_qubits) + "q/qft"
   //               "_indep_qiskit_" + std::to_string(config.num_all_qubits) +
   //               ".qasm");
   auto seq = quartz::CircuitSeq::from_qasm_file(
-      &qtz, std::string("/home/ubuntu/quartz-master/circuit/MQTBench_29") +
+      &qtz, std::string("/home/ubuntu/quartz-master/circuit/MQTBench_28") +
                 "q/dj"
-                "_indep_qiskit_29" +
+                "_indep_qiskit_28" +
                 ".qasm");
   sim::qcircuit::Circuit<double> circuit(config.num_all_qubits,
                                          config.num_local_qubits, (1 << (config.num_all_qubits - config.num_local_qubits)), 0, 1);
-  // circuit.compile(seq.get(), &qtz, &interpreter, use_ilp);
-  // DistributedSimulator simulator(config, circuit);
-  // simulator.run();
+  circuit.compile(seq.get(), &qtz, &interpreter, use_ilp);
+  DistributedSimulator simulator(config, circuit);
+  simulator.run();
 }
 
 DSConfig::DSConfig() {
@@ -98,6 +98,11 @@ int main(int argc, char **argv) {
   // This needs to be set, otherwise NCCL will try to use group kernel launches,
   // which are not compatible with the Realm CUDA hijack.
   setenv("NCCL_LAUNCH_MODE", "PARALLEL", true);
+  setenv("PYTHONPATH", "/home/ubuntu/.local/lib/python3.8/site-packages", true /*overwrite*/);
+  quartz::init_python_interpreter();
+
+  char *python_path = getenv("PYTHONPATH");
+  printf("python path: %s\n", python_path);
 
   Runtime::set_top_level_task_id(TOP_LEVEL_TASK_ID);
   {

--- a/src/sim/include/const.h
+++ b/src/sim/include/const.h
@@ -27,12 +27,12 @@ typedef cuDoubleComplex qComplex;
 
 #define SHARED_MEM_SIZE 10
 #define MAX_GATE 600
-#define MAX_FUSED_GATE 100
+#define MAX_FUSED_GATE 10
 #define THREAD_DEP 7
 #define MAX_KERNEL_SIZE 6
-#define MAX_BATCHED_TASKS 100
+#define MAX_BATCHED_TASKS 20
 #define MAX_DEVICES 4
-#define MAX_TOTAL_DEVICES 64
+#define MAX_TOTAL_DEVICES 16
 #define MAX_QUBIT 40
 
 enum class KernelGateType {

--- a/src/sim/include/distributed_simulator.h
+++ b/src/sim/include/distributed_simulator.h
@@ -1,5 +1,4 @@
 #include "cuda_helper.h"
-#include "simgate.h"
 #include "circuit.h"
 #include "mapper.h"
 

--- a/src/sim/include/simgate.h
+++ b/src/sim/include/simgate.h
@@ -38,7 +38,7 @@ struct FusedGate {
   // qindex target_physical = 0;
   // qindex control_physical = 0;
 
-  qComplex matrix[MAX_TOTAL_DEVICES*(1<<MAX_KERNEL_SIZE)];
+  qComplex matrix[MAX_TOTAL_DEVICES*(1<<MAX_KERNEL_SIZE)*(1<<MAX_KERNEL_SIZE)];
 
   FusedGate(const Gate<qreal> &gate) {
     num_target = gate.num_target;

--- a/src/sim/src/offload/distributed_simulator.cu
+++ b/src/sim/src/offload/distributed_simulator.cu
@@ -12,7 +12,7 @@ DistributedSimulator::cuda_init_task(Task const *task,
   cudaStreamCreate(&stream);
   DSConfig const *config = (DSConfig *)task->args;
   DSHandler handle;
-  handle.workSpaceSize = (size_t)4 * 1024 * 1024 * 1024; // 1GB work space
+  handle.workSpaceSize = (size_t)4 * 1024 * 1024 * 1024; // 4GB work space
   handle.num_local_qubits = config->num_local_qubits;
   handle.num_all_qubits = config->num_all_qubits;
   printf("Num_local_qubits = %lld\n", handle.num_local_qubits);
@@ -100,7 +100,6 @@ void DistributedSimulator::sv_init_task(
     Task const *task, std::vector<PhysicalRegion> const &regions, Context ctx,
     Runtime *runtime) {
   // TODO: implement this function
-  printf("SV Init...\n");
   return;
 }
 
@@ -142,6 +141,11 @@ void DistributedSimulator::store_task(
 
   Domain domain = runtime->get_index_space_domain(
       ctx, task->regions[0].region.get_index_space());
+  Domain domain2 = runtime->get_index_space_domain(
+      ctx, task->regions[1].region.get_index_space());
+    
+  assert(domain.get_volume()==domain2.get_volume());
+  
   
   cudaMemcpyAsync(cpu_sv.get_void_ptr(),
             gpu_state_vector.get_void_ptr(),


### PR DESCRIPTION
Legion-based offload version is tested on single device for 28-qubit (24 local) dj circuit.

To FIX: we cannot `malloc` for more memory to store the gates info to pass to the tasks. It seems that there will be some memory corruption. Need to check if Legion has any restrictions on this.

The shm kernels are not tested in this PR.