### PR TITLE
[QASM] Add CircuitSeq::to_qasm_file()

### DIFF
--- a/src/quartz/circuitseq/circuitgate.h
+++ b/src/quartz/circuitseq/circuitgate.h
@@ -8,6 +8,7 @@
 namespace quartz {
 
 class CircuitWire;
+class Context;
 
 /**
  * A gate in the circuit.
@@ -26,6 +27,8 @@ public:
   // Get the "non-insular" qubit indices of the gate.
   [[nodiscard]] std::vector<int> get_non_insular_qubit_indices() const;
   [[nodiscard]] std::string to_string() const;
+  [[nodiscard]] std::string to_qasm_style_string(Context *ctx,
+                                                 int param_precision) const;
   std::vector<CircuitWire *> input_wires; // Include parameters!
   std::vector<CircuitWire *> output_wires;
 

--- a/src/quartz/circuitseq/circuitseq.cpp
+++ b/src/quartz/circuitseq/circuitseq.cpp
@@ -6,6 +6,7 @@
 #include <algorithm>
 #include <cassert>
 #include <charconv>
+#include <fstream>
 #include <queue>
 #include <unordered_set>
 #include <utility>
@@ -1141,6 +1142,23 @@ CircuitSeq::from_qasm_file(Context *ctx, const std::string &filename) {
   std::unique_ptr<CircuitSeq> ret;
   ret.reset(seq); // transfer ownership of |seq|
   return ret;
+}
+
+bool CircuitSeq::to_qasm_file(Context *ctx, const std::string &filename,
+                              int param_precision) const {
+  std::ofstream fout(filename);
+  if (!fout.is_open()) {
+    return false;
+  }
+  fout << "OPENQASM 2.0;\n"
+          "include \"qelib1.inc\";\n"
+          "qreg q["
+       << get_num_qubits() << "];\n";
+  for (auto &gate : gates) {
+    fout << gate->to_qasm_style_string(ctx, param_precision);
+  }
+  fout.close();
+  return true;
 }
 
 bool CircuitSeq::canonical_representation(

--- a/src/quartz/circuitseq/circuitseq.h
+++ b/src/quartz/circuitseq/circuitseq.h
@@ -99,6 +99,8 @@ public:
   static std::unique_ptr<CircuitSeq> read_json(Context *ctx, std::istream &fin);
   static std::unique_ptr<CircuitSeq>
   from_qasm_file(Context *ctx, const std::string &filename);
+  bool to_qasm_file(Context *ctx, const std::string &filename,
+                    int param_precision = 15) const;
 
   // Returns true iff the CircuitSeq is already under the canonical
   // representation.


### PR DESCRIPTION
This PR adds a function to output `CircuitSeq` to an OpenQASM 2.0 file.

It outputs all qubits in one `qreg`, and all parameters are kept 15 digits by default.