### PR TITLE
[simulation] Fix a bug which may have caused multi-qubit gates to be attached

### DIFF
--- a/src/test/test_simulation.cpp
+++ b/src/test/test_simulation.cpp
@@ -138,10 +138,16 @@ int main() {
   for (int i = 28; i <= 28; i++) {
     num_local_qubits.push_back(i);
   }
-  KernelCost kernel_cost(
-      /*fusion_kernel_costs=*/{0, 10.4, 10.400001, 10.400002, 11, 40, 46, 66},
-      /*shared_memory_init_cost=*/10,
-      /*shared_memory_gate_cost=*/[](GateType) { return 0.8; },
+  quartz::KernelCost kernel_cost(
+      /*fusion_kernel_costs=*/{0, 6.4, 6.2, 6.5, 6.4, 6.4, 25.8, 32.4},
+      /*shared_memory_init_cost=*/6,
+      /*shared_memory_gate_cost=*/
+      [](quartz::GateType type) {
+        if (type == quartz::GateType::swap)
+          return 1000.0;
+        else
+          return 0.5;
+      },
       /*shared_memory_total_qubits=*/10, /*shared_memory_cacheline_qubits=*/3);
   // FILE *fout = fopen("result.txt", "w");
   for (auto circuit : circuit_names) {


### PR DESCRIPTION
There is one case that is missed when postponing attaching single-qubit gates to multi-qubit gates as far as possible in #100: if there is a multi-qubit gate with exactly one local qubit in the current stage but at least one of the global qubits will become local in the next stage, then we must attach the gate in this stage. This PR implements this case.

This PR also updates `test_simulation` to the new cost function and also adds some debug assertions.

Benchmark: qft circuit, 33 total qubits, 28 total qubits, with the new cost function:
Before (wrong): 14 fusion, 3 shared-memory, total cost = 256 + 25.4 = 281.4, running time = 12s
After: 14 fusion, 3 shared-memory, total cost = 268.5 + 25.4 = 293.9, running time = 13s
If we remove all `SWAP` gates: total cost = 7 fusion (2 empty), 4 shared-memory, total cost = 81 + 218.1 - 12.6 = 286.5, running time = 11s