### PR TITLE
[simulation] Remove empty kernels and schedules

### DIFF
--- a/src/quartz/simulator/schedule.h
+++ b/src/quartz/simulator/schedule.h
@@ -75,6 +75,12 @@ public:
   [[nodiscard]] int get_num_kernels() const;
   void print_kernel_schedule() const;
 
+  /**
+   * Remove kernels with no gates and update the cost.
+   * @return The number of empty kernels removed.
+   */
+  int remove_empty_kernels(const KernelCost &kernel_cost);
+
   // The result simulation schedule. We will execute the kernels one by one,
   // and each kernel contains a sequence of gates.
   std::vector<Kernel> kernels;


### PR DESCRIPTION
This PR removes empty kernels and schedules generated in `get_schedules()`.

It also restricts the warning about attaching CX and CXX gates to be printed at most once.