### PR TITLE
fix segfault

### DIFF
--- a/src/quartz/tasograph/substitution.cpp
+++ b/src/quartz/tasograph/substitution.cpp
@@ -738,7 +738,8 @@ void GraphXfer::unmatch(OpX *srcOp, Op op, const Graph *graph) {
     if (in.op == nullptr) {
       // Update mappedInputsa
       auto it = mappedInputs.find(in.idx);
-      mappedInputs.erase(it);
+      if (it != mappedInputs.end())
+        mappedInputs.erase(it);
     }
   }
   // Unmap op


### PR DESCRIPTION
Calling `erase (map.end())` is undefined behavior, and was segfaulting for me. 