### PR TITLE
[build] Update requirements.txt

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,3 +1,4 @@
+black>=22.1.0
 certifi==2021.10.8
 cffi==1.15.0
 charset-normalizer==2.0.10
@@ -24,7 +25,6 @@ qiskit-ignis==0.7.1
 qiskit-terra==0.23.3
 requests==2.27.1
 requests-ntlm==1.1.0
-retworkx==0.10.2
 scipy>=1.7.3
 six==1.16.0
 stevedore==3.5.0


### PR DESCRIPTION
Removed `retworkx` because it depends on a Rust compiler which may not be present for some users. If we actually use `retworkx` somewhere in Quartz, we can add it back. The error message indicating a missing Rust compiler is:
```
  error: subprocess-exited-with-error

  × Building wheel for retworkx (pyproject.toml) did not run successfully.
  │ exit code: 1
  ╰─> [32 lines of output]
      running bdist_wheel
      running build
      running build_py
      creating build
      creating build\lib.win-amd64-cpython-311
      creating build\lib.win-amd64-cpython-311\retworkx
      copying retworkx\__init__.py -> build\lib.win-amd64-cpython-311\retworkx
      creating build\lib.win-amd64-cpython-311\retworkx\visualization
      copying retworkx\visualization\graphviz.py -> build\lib.win-amd64-cpython-311\retworkx\visualization
      copying retworkx\visualization\matplotlib.py -> build\lib.win-amd64-cpython-311\retworkx\visualization
      copying retworkx\visualization\__init__.py -> build\lib.win-amd64-cpython-311\retworkx\visualization
      running egg_info
      writing retworkx.egg-info\PKG-INFO
      writing dependency_links to retworkx.egg-info\dependency_links.txt
      writing requirements to retworkx.egg-info\requires.txt
      writing top-level names to retworkx.egg-info\top_level.txt
      reading manifest file 'retworkx.egg-info\SOURCES.txt'
      reading manifest template 'MANIFEST.in'
      writing manifest file 'retworkx.egg-info\SOURCES.txt'
      running build_ext
      running build_rust
      error: can't find Rust compiler

      If you are using an outdated pip version, it is possible a prebuilt wheel is available for this package but pip is not able to install from it. Installing from the wheel would avoid the need for a Rust compiler.

      To update pip, run:

          pip install --upgrade pip

      and then retry package installation.

      If you did intend to build this package from source, try installing a Rust compiler from your system package manager and ensure it is on the PATH during installation. Alternatively, rustup (available at https://rustup.rs) is the recommended way to download and update the Rust compiler toolchain.
      [end of output]

  note: This error originates from a subprocess, and is likely not a problem with pip.
  ERROR: Failed building wheel for retworkx
Successfully built cffi numpy psutil python-constraint qiskit
Failed to build retworkx
ERROR: Could not build wheels for retworkx, which is required to install pyproject.toml-based projects
```

Added `black` for Python formatting.