### PR TITLE
[refactor] Let Context know which input parameters are symbolic

### DIFF
--- a/src/quartz/circuitseq/circuitseq.cpp
+++ b/src/quartz/circuitseq/circuitseq.cpp
@@ -600,10 +600,8 @@ int CircuitSeq::get_circuit_depth() const {
   return *std::max_element(depth.begin(), depth.end());
 }
 
-ParamType CircuitSeq::get_parameter_value(Context *ctx, int para_idx) const {
-  assert(para_idx >= 0 && para_idx < get_num_total_parameters());
-  assert(para_idx < ctx->input_parameters.size());
-  return ctx->input_parameters[para_idx];
+ParamType CircuitSeq::get_parameter_value(Context *ctx, int para_idx) {
+  return ctx->get_param_value(para_idx);
 }
 
 bool CircuitSeq::qubit_used(int qubit_index) const {

--- a/src/quartz/circuitseq/circuitseq.h
+++ b/src/quartz/circuitseq/circuitseq.h
@@ -15,6 +15,7 @@ class Context;
 
 class CircuitSeq {
 public:
+  // TODO: Input parameters should be handled in Context instead of here
   CircuitSeq(int num_qubits, int num_input_parameters);
   CircuitSeq(const CircuitSeq &other); // clone a CircuitSeq
   [[nodiscard]] std::unique_ptr<CircuitSeq> clone() const;
@@ -58,7 +59,8 @@ public:
   [[nodiscard]] int get_num_internal_parameters() const;
   [[nodiscard]] int get_num_gates() const;
   [[nodiscard]] int get_circuit_depth() const;
-  [[nodiscard]] ParamType get_parameter_value(Context *ctx, int para_idx) const;
+  [[nodiscard]] static ParamType get_parameter_value(Context *ctx,
+                                                     int para_idx);
   [[nodiscard]] bool qubit_used(int qubit_index) const;
   // Used by a parameter gate is considered as used here.
   [[nodiscard]] bool input_param_used(int param_index) const;

--- a/src/quartz/context/context.cpp
+++ b/src/quartz/context/context.cpp
@@ -181,6 +181,36 @@ bool Context::get_possible_representative(const CircuitSeqHashType &hash_value,
   return true;
 }
 
+ParamType Context::get_param_value(int id) const {
+  assert(id >= 0 && id < (int)parameters_.size());
+  return parameters_[id];
+}
+
+void Context::set_param_value(int id, const ParamType &param) {
+  while (id >= (int)parameters_.size()) {
+    parameters_.emplace_back();
+  }
+  parameters_[id] = param;
+}
+
+int Context::get_new_param_id(bool is_symbolic) {
+  assert(is_parameter_symbolic_.size() == num_parameters_);
+  is_parameter_symbolic_.push_back(is_symbolic);
+  return num_parameters_++;
+}
+
+int Context::get_num_parameters() const { return num_parameters_; }
+
+bool Context::param_is_symbolic(int id) const {
+  return id >= 0 && id < (int)is_parameter_symbolic_.size() &&
+         is_parameter_symbolic_[id];
+}
+
+bool Context::param_has_value(int id) const {
+  return id >= 0 && id < (int)is_parameter_symbolic_.size() &&
+         !is_parameter_symbolic_[id];
+}
+
 double Context::random_number() {
   static std::uniform_real_distribution<double> dis_real(0, 1);
   return dis_real(gen);

--- a/src/quartz/context/context.h
+++ b/src/quartz/context/context.h
@@ -47,6 +47,15 @@ public:
   bool get_possible_representative(const CircuitSeqHashType &hash_value,
                                    CircuitSeq *&representative) const;
 
+  ParamType get_param_value(int id) const;
+  void set_param_value(int id, const ParamType &param);
+  // TODO: Use this function when generating symbolic parameters
+  int get_new_param_id(bool is_symbolic);
+  // TODO: This function should not be needed
+  int get_num_parameters() const;
+  bool param_is_symbolic(int id) const;
+  bool param_has_value(int id) const;
+
   // This function generates a deterministic series of random numbers
   // ranging [0, 1].
   double random_number();
@@ -54,12 +63,6 @@ public:
 private:
   bool insert_gate(GateType tp);
 
-public:
-  // The parameters from the input QASM file.
-  // Written by QASMParser.
-  std::vector<ParamType> input_parameters;
-
-private:
   size_t global_unique_id;
   std::unordered_map<GateType, std::unique_ptr<Gate>> gates_;
   std::vector<GateType> supported_gates_;
@@ -74,8 +77,15 @@ private:
   std::unordered_map<CircuitSeqHashType, CircuitSeq *> representatives_;
   // Standard mersenne_twister_engine seeded with 0
   std::mt19937 gen{0};
+
+  // The concrete parameters are from the input QASM file,
+  // written by QASMParser.
+  std::vector<ParamType> parameters_;
+  std::vector<bool> is_parameter_symbolic_;
+  int num_parameters_{0};
 };
 
+// TODO: This function does not consider the parameters
 Context union_contexts(Context *ctx_0, Context *ctx_1);
 
 } // namespace quartz

--- a/src/quartz/parser/qasm_parser.h
+++ b/src/quartz/parser/qasm_parser.h
@@ -66,7 +66,7 @@ bool QASMParser::load_qasm_stream(
   // ordered alphabetically.
   std::map<std::string, int> index_offset;
   std::unordered_map<ParamType, int> parameters;
-  int num_total_params = context->input_parameters.size();
+  int num_total_params = context->get_num_parameters();
 
   while (std::getline(qasm_stream, line, ';')) {
     // Replace comma with space
@@ -200,8 +200,11 @@ bool QASMParser::load_qasm_stream(
           p = -p;
         if (parameters.count(p) == 0) {
           seq->add_input_parameter();
-          parameters[p] = num_total_params++;
-          context->input_parameters.push_back(p);
+          int param_id = context->get_new_param_id(/*is_symbolic=*/false);
+          num_total_params++;
+          assert(param_id == num_total_params);
+          parameters[p] = param_id;
+          context->set_param_value(param_id, p);
         }
         param_indices[i] = parameters[p];
       }

--- a/src/quartz/tasograph/tasograph.cpp
+++ b/src/quartz/tasograph/tasograph.cpp
@@ -164,10 +164,8 @@ Graph::Graph(Context *ctx, const CircuitSeq *seq)
                       context->get_gate(GateType::input_param));
         add_edge(srcOp, dstOp, 0, dstIdx);
 
-        // JATIN_NOTE: I replaced the assertion here, with an if statement.
-        // assert(node->index < (int)context->input_parameters.size());
-        if (node->index < (int)context->input_parameters.size()) {
-          constant_param_values[srcOp] = context->input_parameters[node->index];
+        if (context->param_has_value(node->index)) {
+          constant_param_values[srcOp] = context->get_param_value(node->index);
         }
       }
     }


### PR DESCRIPTION
A follow-up from https://github.com/quantum-compiler/quartz/pull/125#issuecomment-1542549883.

I think this can serve as a first step to move the control of all parameters from `CircuitSeq` to `Context`. This might need a more careful design for `Context` though.