### PR TITLE
[CI] Fix incompatible Python version with symengine

### DIFF
--- a/env.yml
+++ b/env.yml
@@ -9,7 +9,7 @@ dependencies:
   - python>=3.11,<3.12
   - openmp
   - pip:
-    - cython==3.0.0
+    - cython>=3.0.0
     - pybind11>=2.6.2
-    - z3-solver
-    - qiskit==0.42.1
+    - z3-solver>=4.8.12.0
+    - qiskit>=0.42.1

--- a/env.yml
+++ b/env.yml
@@ -12,4 +12,4 @@ dependencies:
     - cython>=3.0a1
     - pybind11>=2.6.2
     - z3-solver==4.8.12.0
-    - qiskit==0.23.3
+    - qiskit==0.25.0

--- a/env.yml
+++ b/env.yml
@@ -11,5 +11,5 @@ dependencies:
   - pip:
     - cython>=3.0a1
     - pybind11>=2.6.2
-    - z3-solver
-    - qiskit
+    - z3-solver==4.8.12.0
+    - qiskit==0.23.3

--- a/env.yml
+++ b/env.yml
@@ -6,7 +6,7 @@ channels:
   - conda-forge
 dependencies:
   - pip
-  - python==3.11
+  - python>=3.11,<3.12
   - openmp
   - pip:
     - cython==3.0.0

--- a/env.yml
+++ b/env.yml
@@ -6,7 +6,7 @@ channels:
   - conda-forge
 dependencies:
   - pip
-  - python
+  - python==3.11
   - openmp
   - pip:
     - cython==3.0.0

--- a/env.yml
+++ b/env.yml
@@ -11,5 +11,5 @@ dependencies:
   - pip:
     - cython==3.0.0
     - pybind11>=2.6.2
-    - z3-solver==4.8.12.0
-    - qiskit==0.44.0
+    - z3-solver
+    - qiskit==0.42.0

--- a/env.yml
+++ b/env.yml
@@ -9,7 +9,7 @@ dependencies:
   - python
   - openmp
   - pip:
-    - cython>=3.0a1
+    - cython==3.0.0
     - pybind11>=2.6.2
     - z3-solver==4.8.12.0
-    - qiskit==0.25.0
+    - qiskit==0.44.0

--- a/env.yml
+++ b/env.yml
@@ -12,4 +12,4 @@ dependencies:
     - cython==3.0.0
     - pybind11>=2.6.2
     - z3-solver
-    - qiskit==0.42.0
+    - qiskit==0.42.1

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -19,7 +19,7 @@ pybind11>=2.6.2
 pycparser==2.21
 python-constraint==1.4.0
 python-dateutil==2.8.2
-qiskit==0.42.0
+qiskit==0.42.1
 qiskit-aer==0.12.0
 qiskit-ibmq-provider==0.20.2
 qiskit-ignis==0.7.1
@@ -29,7 +29,7 @@ requests-ntlm==1.1.0
 scipy>=1.7.3
 six==1.16.0
 stevedore==3.5.0
-symengine==0.9.2
+symengine==0.10.0
 sympy==1.9
 urllib3==1.26.8
 websocket-client==1.5.1

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -19,11 +19,11 @@ pybind11>=2.6.2
 pycparser==2.21
 python-constraint==1.4.0
 python-dateutil==2.8.2
-qiskit==0.44.0
+qiskit==0.42.0
 qiskit-aer==0.12.0
 qiskit-ibmq-provider==0.20.2
 qiskit-ignis==0.7.1
-qiskit-terra==0.25.0
+qiskit-terra==0.23.3
 requests==2.27.1
 requests-ntlm==1.1.0
 scipy>=1.7.3

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -29,7 +29,6 @@ requests-ntlm==1.1.0
 scipy>=1.7.3
 six==1.16.0
 stevedore==3.5.0
-symengine==0.10.0
 sympy==1.9
 urllib3==1.26.8
 websocket-client==1.5.1

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -29,6 +29,7 @@ requests-ntlm==1.1.0
 scipy>=1.7.3
 six==1.16.0
 stevedore==3.5.0
+symengine==0.10.0
 sympy==1.9
 urllib3==1.26.8
 websocket-client==1.5.1

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -23,13 +23,13 @@ qiskit==0.42.1
 qiskit-aer==0.12.0
 qiskit-ibmq-provider==0.20.2
 qiskit-ignis==0.7.1
-qiskit-terra==0.23.3
+qiskit-terra==0.25.0
 requests==2.27.1
 requests-ntlm==1.1.0
 scipy>=1.7.3
 six==1.16.0
 stevedore==3.5.0
-symengine==0.10.0
+symengine==0.9.2
 sympy==1.9
 urllib3==1.26.8
 websocket-client==1.5.1

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -19,7 +19,7 @@ pybind11>=2.6.2
 pycparser==2.21
 python-constraint==1.4.0
 python-dateutil==2.8.2
-qiskit==0.42.1
+qiskit==0.44.0
 qiskit-aer==0.12.0
 qiskit-ibmq-provider==0.20.2
 qiskit-ignis==0.7.1

--- a/python/setup.py
+++ b/python/setup.py
@@ -30,6 +30,7 @@ def config_cython():
                     "quartz.%s" % fn[:-4],
                     ["%s/%s" % (path, fn)],
                     include_dirs=[
+                        "../src/",
                         "../src/quartz/",
                         "/usr/local/include/",
                         os.path.join(user_home_path, "usr_local/include"),
@@ -62,7 +63,7 @@ setup(
     description="Quartz: Superoptimization of Quantum Circuits",
     zip_safe=False,
     install_requires=[],
-    packages=find_packages(),
+    packages=['quartz'],
     url='https://github.com/quantum-compiler/quartz',
     ext_modules=config_cython(),
 )

--- a/python/setup.py
+++ b/python/setup.py
@@ -30,7 +30,6 @@ def config_cython():
                     "quartz.%s" % fn[:-4],
                     ["%s/%s" % (path, fn)],
                     include_dirs=[
-                        "../src/",
                         "../src/quartz/",
                         "/usr/local/include/",
                         os.path.join(user_home_path, "usr_local/include"),
@@ -63,7 +62,7 @@ setup(
     description="Quartz: Superoptimization of Quantum Circuits",
     zip_safe=False,
     install_requires=[],
-    packages=['quartz'],
+    packages=['quartz'],  # find_packages()
     url='https://github.com/quantum-compiler/quartz',
     ext_modules=config_cython(),
 )


### PR DESCRIPTION
Previously env.yml automatically chose the latest Qiskit version. On Oct 4, 2023, Qiskit-terra released v0.25.2.1 (Qiskit v0.44.0), which required `symengine < 0.10`. While symengine v0.10 fixed a bug in #110, previous CI used symengine v0.9.2, and the line `symengine < 0.10` existed in Qiskit-terra since March, so this is probably not the exact reason why CI failed.

After several tries, fixing Python to any minor version of 3.11 (i.e., < 3.12) seems to solve this issue. It seems that symengine does not support Python 3.12 yet (https://github.com/symengine/symengine-wheels/issues/11, https://github.com/Qiskit/qiskit/issues/10887).