### PR TITLE
[Simulator] Randomly permute gates before the simple DP

### DIFF
--- a/src/quartz/circuitseq/circuitseq.cpp
+++ b/src/quartz/circuitseq/circuitseq.cpp
@@ -1380,9 +1380,10 @@ CircuitSeq::random_gate_permutation(size_t seed) const {
     free_wires.clear();
 
     if (!free_gates.empty()) {
-      // Find a random free circuit_gate (gate).
-      int random_loc =
-          std::uniform_int_distribution<int>(0, (int)free_gates.size())(rng);
+      // Find a random free circuit_gate (gate)
+      // in [0, (int)free_gates.size() - 1].
+      int random_loc = std::uniform_int_distribution<int>(
+          0, (int)free_gates.size() - 1)(rng);
       CircuitGate *free_gate = free_gates[random_loc];
       free_gates.erase(free_gates.begin() + random_loc);
 

--- a/src/quartz/circuitseq/circuitseq.cpp
+++ b/src/quartz/circuitseq/circuitseq.cpp
@@ -1321,6 +1321,84 @@ bool CircuitSeq::to_canonical_representation() {
   return false;
 }
 
+[[nodiscard]] std::unique_ptr<CircuitSeq>
+CircuitSeq::random_gate_permutation(size_t seed) const {
+  auto output_seq = std::make_unique<CircuitSeq>(get_num_qubits(),
+                                                 get_num_input_parameters());
+  std::mt19937 rng(seed);
+  // Add all parameter "gates" first.
+  for (auto &circuit_gate : gates) {
+    if (circuit_gate->gate->is_parameter_gate()) {
+      output_seq->add_gate(circuit_gate.get());
+    }
+  }
+
+  std::unordered_map<CircuitWire *, int> wire_id;
+  std::unordered_map<CircuitGate *, int> gate_id;
+  for (int i = 0; i < (int)wires.size(); i++) {
+    wire_id[wires[i].get()] = i;
+  }
+  for (int i = 0; i < (int)gates.size(); i++) {
+    gate_id[gates[i].get()] = i;
+  }
+
+  std::vector<CircuitGate *> free_gates;
+  std::vector<CircuitWire *> free_wires;
+  free_wires.reserve(get_num_qubits() + get_num_input_parameters());
+
+  // Construct the |free_wires| vector with the input qubit wires.
+  std::vector<int> wire_in_degree(wires.size(), 0);
+  std::vector<int> gate_in_degree(gates.size(), 0);
+  for (auto &wire : wires) {
+    if (wire->is_parameter()) {
+      wire_in_degree[wire_id[wire.get()]] = -1;
+      continue;
+    }
+    wire_in_degree[wire_id[wire.get()]] = (int)wire->input_gates.size();
+    if (!wire_in_degree[wire_id[wire.get()]]) {
+      free_wires.push_back(wire.get());
+    }
+  }
+  for (auto &circuit_gate : gates) {
+    gate_in_degree[gate_id[circuit_gate.get()]] = 0;
+    for (auto &input_wire : circuit_gate->input_wires) {
+      if (input_wire->is_qubit()) {
+        gate_in_degree[gate_id[circuit_gate.get()]]++;
+      }
+    }
+  }
+
+  while (!free_wires.empty() || !free_gates.empty()) {
+    // Remove the wires in |free_wires|.
+    for (auto &wire : free_wires) {
+      for (auto &output_gate : wire->output_gates) {
+        if (!--gate_in_degree[gate_id[output_gate]]) {
+          free_gates.push_back(output_gate);
+        }
+      }
+    }
+    free_wires.clear();
+
+    if (!free_gates.empty()) {
+      // Find a random free circuit_gate (gate).
+      int random_loc =
+          std::uniform_int_distribution<int>(0, (int)free_gates.size())(rng);
+      CircuitGate *free_gate = free_gates[random_loc];
+      free_gates.erase(free_gates.begin() + random_loc);
+
+      output_seq->add_gate(free_gate);
+
+      // Update the free wires.
+      for (auto &output_wire : free_gate->output_wires) {
+        if (!--wire_in_degree[wire_id[output_wire]]) {
+          free_wires.push_back(output_wire);
+        }
+      }
+    }
+  }
+  return output_seq;
+}
+
 std::unique_ptr<CircuitSeq>
 CircuitSeq::get_permuted_seq(const std::vector<int> &qubit_permutation,
                              const std::vector<int> &param_permutation) const {

--- a/src/quartz/circuitseq/circuitseq.h
+++ b/src/quartz/circuitseq/circuitseq.h
@@ -104,60 +104,88 @@ public:
   bool to_qasm_file(Context *ctx, const std::string &filename,
                     int param_precision = 15) const;
 
-  // Returns true iff the CircuitSeq is already under the canonical
-  // representation.
-  // Canonical representation is a sequence representation of a
-  // circuit such that the sequence is the lexicographically smallest
-  // topological order of the circuit, where the gates are compared by:
-  // 1. The qubit indices in lexicographical order.
-  //    If the smallest qubit indices two gates operate on
-  //    are different, the gate with the smaller one is considered
-  //    smaller. For example,
-  //      (q1, q4) < (q2, q3);
-  //      (q1, q3) < (q1, q4);
-  //      (q1, q3) < (q2);
-  //      (q1) < (q1, q3).
-  //    Note that two gates operating on the same qubit is impossible
-  //    for the topological order of one circuit, but we still define it
-  //    for the completeness of comparing different circuits.
-  // 2. If the qubit indices are all the same, compare the gate type.
-  //
-  // The parameter "gates" are placed at the beginning.
-  //
-  // If |output| is true, store the canonical representation into
-  // |output_seq|.
-  // The parameter |output_seq| should be a pointer containing nullptr
-  // (otherwise its content will be deleted).
-  // This functions guarantees that if and only if two sequence
-  // representations share the same canonical representation, they have
-  // the same circuit representation.
+  /**
+   * Canonical representation is a sequence representation of a
+   * circuit such that the sequence is the lexicographically smallest
+   * topological order of the circuit, where the gates are compared by:
+   * 1. The qubit indices in lexicographical order.
+   *    If the smallest qubit indices two gates operate on
+   *    are different, the gate with the smaller one is considered
+   *    smaller. For example,
+   *      (q1, q4) < (q2, q3);
+   *      (q1, q3) < (q1, q4);
+   *      (q1, q3) < (q2);
+   *      (q1) < (q1, q3).
+   *    Note that two gates operating on the same qubit is impossible
+   *    for the topological order of one circuit, but we still define it
+   *    for the completeness of comparing different circuits.
+   * 2. If the qubit indices are all the same, compare the gate type.
+   * 
+   * The parameter "gates" are placed at the beginning.
+   *
+   * This functions guarantees that if and only if two sequence
+   * representations share the same canonical representation, they have
+   * the same circuit representation.
+   * 
+   * @param output_seq If |output| is true, store the canonical representation
+   * into |output_seq|.
+   * The parameter |output_seq| should be a pointer containing nullptr
+   * (otherwise its content will be deleted).
+   * @param output Whether to output the canonical representation. Default is
+   * true.
+   * @return True iff the CircuitSeq is already under the canonical
+   * representation.
+   */
   bool canonical_representation(std::unique_ptr<CircuitSeq> *output_seq,
                                 bool output = true) const;
   [[nodiscard]] bool is_canonical_representation() const;
-  // Returns true iff this is NOT canonical representation
-  // (so the function changes this CircuitSeq to canonical representation).
+  /**
+   * Convert this CircuitSeq to canonical representation.
+   * @return True iff this is NOT canonical representation
+   * (so the function modifies this CircuitSeq).
+   */
   bool to_canonical_representation();
+
+  /**
+   * Permute the quantum gates randomly. This function topologically sorts
+   * the sequence and uniformly randomly pick one quantum gate among all choices
+   * each time.
+   * @param seed The random seed used for randomness in this function.
+   * Default is 0.
+   * @return The permuted circuit sequence.
+   */
+  [[nodiscard]] std::unique_ptr<CircuitSeq>
+  random_gate_permutation(size_t seed = 0) const;
+  /**
+   * Permute the qubits and input parameters.
+   * @param qubit_permutation The qubit permutation. The size must be the
+   * same as the number of qubits.
+   * @param param_permutation The input parameter permutation. If the size is
+   * smaller than the total number of input parameters, this function only
+   * permutes a prefix of input parameters corresponding to |param_permutation|.
+   * @return The permuted circuit sequence.
+   */
   [[nodiscard]] std::unique_ptr<CircuitSeq>
   get_permuted_seq(const std::vector<int> &qubit_permutation,
                    const std::vector<int> &param_permutation) const;
 
   // Returns quantum gates which do not topologically depend on any other
   // quantum gates.
-  std::vector<CircuitGate *> first_quantum_gates() const;
+  [[nodiscard]] std::vector<CircuitGate *> first_quantum_gates() const;
   // Returns quantum gates which can appear at last in some topological
   // order of the CircuitSeq.
-  std::vector<CircuitGate *> last_quantum_gates() const;
+  [[nodiscard]] std::vector<CircuitGate *> last_quantum_gates() const;
 
   static bool same_gate(const CircuitSeq &seq1, int index1,
                         const CircuitSeq &seq2, int index2);
 
   static bool same_gate(CircuitGate *gate1, CircuitGate *gate2);
 
-private:
   void clone_from(const CircuitSeq &other,
                   const std::vector<int> &qubit_permutation,
                   const std::vector<int> &param_permutation);
 
+  private:
   // A helper function used by |CircuitSeqHashType hash(Context *ctx)|.
   static void generate_hash_values(
       Context *ctx, const ComplexType &hash_value,

--- a/src/quartz/circuitseq/circuitseq.h
+++ b/src/quartz/circuitseq/circuitseq.h
@@ -152,10 +152,15 @@ public:
    * each time.
    * @param seed The random seed used for randomness in this function.
    * Default is 0.
+   * @param result_permutation Store the result permutation in this array
+   * if it is not nullptr. Requires the size to be at least the number of
+   * quantum gates if not nullptr. The behavior is undefined if there is
+   * a non-quantum gate and this parameter is not nullptr. Default is nullptr.
    * @return The permuted circuit sequence.
    */
   [[nodiscard]] std::unique_ptr<CircuitSeq>
-  random_gate_permutation(size_t seed = 0) const;
+  random_gate_permutation(size_t seed = 0,
+                          int *result_permutation = nullptr) const;
   /**
    * Permute the qubits and input parameters.
    * @param qubit_permutation The qubit permutation. The size must be the

--- a/src/quartz/circuitseq/circuitseq.h
+++ b/src/quartz/circuitseq/circuitseq.h
@@ -120,13 +120,13 @@ public:
    *    for the topological order of one circuit, but we still define it
    *    for the completeness of comparing different circuits.
    * 2. If the qubit indices are all the same, compare the gate type.
-   * 
+   *
    * The parameter "gates" are placed at the beginning.
    *
    * This functions guarantees that if and only if two sequence
    * representations share the same canonical representation, they have
    * the same circuit representation.
-   * 
+   *
    * @param output_seq If |output| is true, store the canonical representation
    * into |output_seq|.
    * The parameter |output_seq| should be a pointer containing nullptr
@@ -181,11 +181,11 @@ public:
 
   static bool same_gate(CircuitGate *gate1, CircuitGate *gate2);
 
+private:
   void clone_from(const CircuitSeq &other,
                   const std::vector<int> &qubit_permutation,
                   const std::vector<int> &param_permutation);
 
-  private:
   // A helper function used by |CircuitSeqHashType hash(Context *ctx)|.
   static void generate_hash_values(
       Context *ctx, const ComplexType &hash_value,

--- a/src/quartz/simulator/schedule.h
+++ b/src/quartz/simulator/schedule.h
@@ -17,7 +17,8 @@ namespace quartz {
  */
 class Schedule {
 public:
-  Schedule(const CircuitSeq &sequence, const std::vector<int> &local_qubit,
+  Schedule(std::unique_ptr<CircuitSeq> &&sequence,
+           const std::vector<int> &local_qubit,
            const std::vector<int> &global_qubit,
            int num_shared_memory_cacheline_qubits, Context *ctx);
 
@@ -91,8 +92,7 @@ public:
       const std::vector<KernelCostType> &shared_memory_gate_costs = {});
 
   bool compute_kernel_schedule_simple_repeat(
-      int repeat,
-      const KernelCost &kernel_cost,
+      int repeat, const KernelCost &kernel_cost,
       const std::vector<std::vector<int>> &non_insular_qubit_indices = {},
       const std::vector<KernelCostType> &shared_memory_gate_costs = {});
 
@@ -113,8 +113,7 @@ public:
 
 private:
   // The original circuit sequence.
-  // TODO: use unique_ptr
-  CircuitSeq sequence_;
+  std::unique_ptr<CircuitSeq> sequence_;
 
   // The set of local qubits.
   // |local_qubit_[0]| is the least significant bit.

--- a/src/quartz/simulator/schedule.h
+++ b/src/quartz/simulator/schedule.h
@@ -90,6 +90,12 @@ public:
       const std::vector<std::vector<int>> &non_insular_qubit_indices = {},
       const std::vector<KernelCostType> &shared_memory_gate_costs = {});
 
+  bool compute_kernel_schedule_simple_repeat(
+      int repeat,
+      const KernelCost &kernel_cost,
+      const std::vector<std::vector<int>> &non_insular_qubit_indices = {},
+      const std::vector<KernelCostType> &shared_memory_gate_costs = {});
+
   [[nodiscard]] int get_num_kernels() const;
   void print_kernel_info() const;
   void print_kernel_schedule() const;
@@ -107,6 +113,7 @@ public:
 
 private:
   // The original circuit sequence.
+  // TODO: use unique_ptr
   CircuitSeq sequence_;
 
   // The set of local qubits.
@@ -141,7 +148,7 @@ std::vector<Schedule>
 get_schedules(const CircuitSeq &sequence,
               const std::vector<std::vector<int>> &local_qubits,
               const KernelCost &kernel_cost, Context *ctx,
-              bool attach_single_qubit_gates, bool use_simple_dp);
+              bool attach_single_qubit_gates, int use_simple_dp_times);
 
 class PythonInterpreter;
 std::vector<std::vector<int>>

--- a/src/test/test_simulation.cpp
+++ b/src/test/test_simulation.cpp
@@ -192,7 +192,7 @@ int main() {
         std::cout << local_qubits.size() << " stages." << std::endl;
         auto schedules = get_schedules(*seq, local_qubits, kernel_cost, &ctx,
                                        /*attach_single_qubit_gates=*/true,
-                                       /*use_simple_dp_times=*/2);
+                                       /*use_simple_dp_times=*/10);
         for (auto &schedule : schedules) {
           schedule.print_kernel_info();
           // schedule.print_kernel_schedule();

--- a/src/test/test_simulation.cpp
+++ b/src/test/test_simulation.cpp
@@ -192,7 +192,7 @@ int main() {
         std::cout << local_qubits.size() << " stages." << std::endl;
         auto schedules = get_schedules(*seq, local_qubits, kernel_cost, &ctx,
                                        /*attach_single_qubit_gates=*/true,
-                                       /*use_simple_dp=*/true);
+                                       /*use_simple_dp_times=*/2);
         for (auto &schedule : schedules) {
           schedule.print_kernel_info();
           // schedule.print_kernel_schedule();


### PR DESCRIPTION
Global changes:
- Add `CircuitSeq::random_gate_permutation()` to randomly select a valid topological order as the sequence.
- Improve some comments.

Changes specific to the simulator:
- Use `std::unique_ptr` for `CircuitSeq` in `Schedule`

Benchmark: qft, 33 qubits, 28 local qubits:
Before:
```
2 stages.
Kernel info: 11 kernels (8 fusion, 3 shared-memory), cost = 271.5, local qubits 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32
Kernel info: 4 kernels (4 fusion, 0 shared-memory), cost = 25.4, local qubits 5 6 7 8 9 10 11 12 13 28 29 30 31 32 19 20 21 22 23 24 25 26 27 0 1 2 3 4
0 seconds.
```
After (20 random permutations for each stage, taking ~5 seconds to run in total):
```
Kernel info: 16 kernels (11 fusion, 5 shared-memory), cost = 304.2, local qubits 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32
Kernel info: 15 kernels (11 fusion, 4 shared-memory), cost = 299.5, local qubits 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32
Kernel info: 12 kernels (8 fusion, 4 shared-memory), cost = 281, local qubits 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32
Kernel info: 16 kernels (12 fusion, 4 shared-memory), cost = 297.8, local qubits 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32
Kernel info: 15 kernels (11 fusion, 4 shared-memory), cost = 298.2, local qubits 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32
Kernel info: 14 kernels (10 fusion, 4 shared-memory), cost = 293, local qubits 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32
Kernel info: 13 kernels (9 fusion, 4 shared-memory), cost = 287.4, local qubits 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32
Kernel info: 16 kernels (12 fusion, 4 shared-memory), cost = 298.1, local qubits 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32
Kernel info: 15 kernels (10 fusion, 5 shared-memory), cost = 299.3, local qubits 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32
Kernel info: 15 kernels (9 fusion, 6 shared-memory), cost = 299.4, local qubits 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32
Kernel info: 12 kernels (7 fusion, 5 shared-memory), cost = 288.1, local qubits 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32
Kernel info: 13 kernels (9 fusion, 4 shared-memory), cost = 285.6, local qubits 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32
Kernel info: 15 kernels (11 fusion, 4 shared-memory), cost = 299.7, local qubits 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32
Kernel info: 14 kernels (9 fusion, 5 shared-memory), cost = 292.4, local qubits 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32
Kernel info: 16 kernels (12 fusion, 4 shared-memory), cost = 301.3, local qubits 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32
Kernel info: 14 kernels (10 fusion, 4 shared-memory), cost = 291.3, local qubits 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32
Kernel info: 14 kernels (10 fusion, 4 shared-memory), cost = 293.5, local qubits 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32
Kernel info: 15 kernels (12 fusion, 3 shared-memory), cost = 295.1, local qubits 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32
Kernel info: 14 kernels (9 fusion, 5 shared-memory), cost = 296.4, local qubits 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32
Kernel info: 4 kernels (4 fusion, 0 shared-memory), cost = 25.6, local qubits 5 6 7 8 9 10 11 12 13 28 29 30 31 32 19 20 21 22 23 24 25 26 27 0 1 2 3 4
Kernel info: 5 kernels (5 fusion, 0 shared-memory), cost = 31.6, local qubits 5 6 7 8 9 10 11 12 13 28 29 30 31 32 19 20 21 22 23 24 25 26 27 0 1 2 3 4
Kernel info: 4 kernels (4 fusion, 0 shared-memory), cost = 25.6, local qubits 5 6 7 8 9 10 11 12 13 28 29 30 31 32 19 20 21 22 23 24 25 26 27 0 1 2 3 4
Kernel info: 4 kernels (4 fusion, 0 shared-memory), cost = 25.4, local qubits 5 6 7 8 9 10 11 12 13 28 29 30 31 32 19 20 21 22 23 24 25 26 27 0 1 2 3 4
Kernel info: 4 kernels (4 fusion, 0 shared-memory), cost = 25.4, local qubits 5 6 7 8 9 10 11 12 13 28 29 30 31 32 19 20 21 22 23 24 25 26 27 0 1 2 3 4
Kernel info: 4 kernels (4 fusion, 0 shared-memory), cost = 25.4, local qubits 5 6 7 8 9 10 11 12 13 28 29 30 31 32 19 20 21 22 23 24 25 26 27 0 1 2 3 4
Kernel info: 5 kernels (5 fusion, 0 shared-memory), cost = 31.6, local qubits 5 6 7 8 9 10 11 12 13 28 29 30 31 32 19 20 21 22 23 24 25 26 27 0 1 2 3 4
Kernel info: 5 kernels (5 fusion, 0 shared-memory), cost = 31.6, local qubits 5 6 7 8 9 10 11 12 13 28 29 30 31 32 19 20 21 22 23 24 25 26 27 0 1 2 3 4
Kernel info: 5 kernels (5 fusion, 0 shared-memory), cost = 31.6, local qubits 5 6 7 8 9 10 11 12 13 28 29 30 31 32 19 20 21 22 23 24 25 26 27 0 1 2 3 4
Kernel info: 4 kernels (4 fusion, 0 shared-memory), cost = 25.6, local qubits 5 6 7 8 9 10 11 12 13 28 29 30 31 32 19 20 21 22 23 24 25 26 27 0 1 2 3 4
Kernel info: 4 kernels (4 fusion, 0 shared-memory), cost = 25.6, local qubits 5 6 7 8 9 10 11 12 13 28 29 30 31 32 19 20 21 22 23 24 25 26 27 0 1 2 3 4
Kernel info: 4 kernels (4 fusion, 0 shared-memory), cost = 25.4, local qubits 5 6 7 8 9 10 11 12 13 28 29 30 31 32 19 20 21 22 23 24 25 26 27 0 1 2 3 4
Kernel info: 5 kernels (5 fusion, 0 shared-memory), cost = 31.6, local qubits 5 6 7 8 9 10 11 12 13 28 29 30 31 32 19 20 21 22 23 24 25 26 27 0 1 2 3 4
Kernel info: 4 kernels (4 fusion, 0 shared-memory), cost = 25.4, local qubits 5 6 7 8 9 10 11 12 13 28 29 30 31 32 19 20 21 22 23 24 25 26 27 0 1 2 3 4
Kernel info: 4 kernels (4 fusion, 0 shared-memory), cost = 25.6, local qubits 5 6 7 8 9 10 11 12 13 28 29 30 31 32 19 20 21 22 23 24 25 26 27 0 1 2 3 4
Kernel info: 4 kernels (4 fusion, 0 shared-memory), cost = 25.4, local qubits 5 6 7 8 9 10 11 12 13 28 29 30 31 32 19 20 21 22 23 24 25 26 27 0 1 2 3 4
Kernel info: 4 kernels (4 fusion, 0 shared-memory), cost = 25.6, local qubits 5 6 7 8 9 10 11 12 13 28 29 30 31 32 19 20 21 22 23 24 25 26 27 0 1 2 3 4
Kernel info: 4 kernels (4 fusion, 0 shared-memory), cost = 25.4, local qubits 5 6 7 8 9 10 11 12 13 28 29 30 31 32 19 20 21 22 23 24 25 26 27 0 1 2 3 4
Kernel info: 5 kernels (5 fusion, 0 shared-memory), cost = 31.6, local qubits 5 6 7 8 9 10 11 12 13 28 29 30 31 32 19 20 21 22 23 24 25 26 27 0 1 2 3 4
```
Most random permutations are worse than the initial given one. No one is better than the initial given sequence.