### PR TITLE
[Simulation] A better heuristic for permuting gates before the simple DP

### DIFF
--- a/src/quartz/circuitseq/circuitseq.h
+++ b/src/quartz/circuitseq/circuitseq.h
@@ -6,6 +6,7 @@
 #include "circuitgate.h"
 #include "circuitwire.h"
 
+#include <functional>
 #include <istream>
 #include <string>
 
@@ -147,20 +148,25 @@ public:
   bool to_canonical_representation();
 
   /**
-   * Permute the quantum gates randomly. This function topologically sorts
-   * the sequence and uniformly randomly pick one quantum gate among all choices
+   * Permute the quantum gates. This function topologically sorts
+   * the sequence and picks one quantum gate among all choices
    * each time.
-   * @param seed The random seed used for randomness in this function.
-   * Default is 0.
+   * @param gate_chooser The function used to pick the quantum gate to be
+   * placed the first each time, invoked the same number of times as the number
+   * of quantum gates. This function takes as input an std::vector of
+   * potential quantum gates, and returns the index of the quantum gate to be
+   * placed first.
+   * Default (nullptr) is uniformly random.
    * @param result_permutation Store the result permutation in this array
    * if it is not nullptr. Requires the size to be at least the number of
    * quantum gates if not nullptr. The behavior is undefined if there is
    * a non-quantum gate and this parameter is not nullptr. Default is nullptr.
    * @return The permuted circuit sequence.
    */
-  [[nodiscard]] std::unique_ptr<CircuitSeq>
-  random_gate_permutation(size_t seed = 0,
-                          int *result_permutation = nullptr) const;
+  [[nodiscard]] std::unique_ptr<CircuitSeq> get_gate_permutation(
+      const std::function<int(const std::vector<CircuitGate *> &)>
+          &gate_chooser = nullptr,
+      int *result_permutation = nullptr) const;
   /**
    * Permute the qubits and input parameters.
    * @param qubit_permutation The qubit permutation. The size must be the

--- a/src/quartz/simulator/schedule.cpp
+++ b/src/quartz/simulator/schedule.cpp
@@ -1471,6 +1471,7 @@ bool Schedule::compute_kernel_schedule_simple_repeat(
                                       shared_memory_gate_costs)) {
     return false;
   }
+  const int num_qubits = sequence_->get_num_qubits();
   const int num_gates = sequence_->get_num_gates();
   auto best_cost = cost_;
   auto best_kernels = std::move(kernels);
@@ -1485,8 +1486,47 @@ bool Schedule::compute_kernel_schedule_simple_repeat(
       shared_memory_gate_costs;
   // Repeat for |repeat| - 1 times.
   for (int i = 1; i < repeat; i++) {
+    // Permute the gates that is "closer" in qubits to recent gates.
+    std::vector<double> recent_qubit_weight(num_qubits, 0);
+    auto gate_chooser = [&recent_qubit_weight, &num_qubits](
+                            const std::vector<CircuitGate *> &gates) -> int {
+      int gate_location = 0;
+      double max_weight = 0;
+      static std::mt19937 rng(0);
+      std::vector<double> weights(gates.size(), 0);
+      for (int i = 0; i < (int)gates.size(); i++) {
+        weights[i] = 0;
+        for (auto qubit : gates[i]->get_qubit_indices()) {
+          weights[i] += recent_qubit_weight[qubit];
+        }
+        weights[i] /= gates[i]->gate->get_num_qubits();
+        if (weights[i] > max_weight) {
+          max_weight = weights[i];
+          gate_location = i;
+        }
+      }
+      for (int i = 0; i < (int)gates.size(); i++) {
+        // We still have some chance to choose each gate.
+        if (std::uniform_real_distribution<double>(0, 1)(rng) <
+            exp(weights[i] - max_weight) / (int)gates.size()) {
+          gate_location = i;
+        }
+      }
+      // choose |gate_location|, update weights
+      constexpr double kDiscountFactor = 0.9; // discount older weights
+      for (auto &weight : recent_qubit_weight) {
+        weight *= kDiscountFactor;
+      }
+      for (auto qubit : gates[gate_location]->get_qubit_indices()) {
+        // |qubit| gets 1, |qubit - 1| gets 0.5, |qubit +- 2| gets 0.25, ...
+        for (int j = 0; j < num_qubits; j++) {
+          recent_qubit_weight[j] += pow(0.5, abs(qubit - j));
+        }
+      }
+      return gate_location;
+    };
     sequence_ =
-        sequence_->random_gate_permutation(/*seed=*/i, gate_permutation_ptr);
+        sequence_->get_gate_permutation(gate_chooser, gate_permutation_ptr);
     // Permute the corresponding non-insular qubit indices and
     // shared-memory gate costs.
     if (!current_non_insular_qubit_indices.empty()) {
@@ -1513,6 +1553,7 @@ bool Schedule::compute_kernel_schedule_simple_repeat(
                                         current_shared_memory_gate_costs)) {
       return false;
     }
+    // print_kernel_info();
     if (cost_ < best_cost) {
       best_cost = cost_;
       best_kernels = std::move(kernels);

--- a/src/test/test_simulation.cpp
+++ b/src/test/test_simulation.cpp
@@ -192,7 +192,7 @@ int main() {
         std::cout << local_qubits.size() << " stages." << std::endl;
         auto schedules = get_schedules(*seq, local_qubits, kernel_cost, &ctx,
                                        /*attach_single_qubit_gates=*/true,
-                                       /*use_simple_dp_times=*/10);
+                                       /*use_simple_dp_times=*/100);
         for (auto &schedule : schedules) {
           schedule.print_kernel_info();
           // schedule.print_kernel_schedule();


### PR DESCRIPTION
Changes specific to the simulator:
I use the following heuristic to permute the gates before the simple DP:
- Each qubit is assigned a cumulative **weight**, initially 0.
- When doing topological sort, invoke a gate chooser each time we choose a gate (even if there is only one choice), so there are guaranteed to be `num_gates` iterations.
- In each iteration:
  - Compute the *weight* of each gate to be the average of the **weight** of each qubit.
  - Choose a gate with probability proportional to *exp(weight)*.
  - Multiply the **weight** of each qubit by 0.9. (Discounting old weights.)
  - For each qubit `q` the gate operates on, increase the **weight** of each other qubit `j` by `pow(0.5, abs(j - q))`, i.e., `weight[q] += 1, weight[q - 1] += 0.5, weight[q + 1] += 0.5, weight[q - 2] += 0.25, weight[q + 2] += 0.25, ...`. Intuition: people tend to write circuits with space locality (i.e., if we use `q`, it is likely that `q + 1` will be used next).


Benchmark: qft, 33 qubits, 28 local qubits:
Before:
```
2 stages.
Kernel info: 11 kernels (8 fusion, 3 shared-memory), cost = 271.5, local qubits 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32
Kernel info: 4 kernels (4 fusion, 0 shared-memory), cost = 25.4, local qubits 5 6 7 8 9 10 11 12 13 28 29 30 31 32 19 20 21 22 23 24 25 26 27 0 1 2 3 4
0 seconds.
```
After (repeat=10):
```
2 stages.
Kernel info: 10 kernels (7 fusion, 3 shared-memory), cost = 271.3, local qubits 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32
Kernel info: 4 kernels (4 fusion, 0 shared-memory), cost = 25.4, local qubits 5 6 7 8 9 10 11 12 13 28 29 30 31 32 19 20 21 22 23 24 25 26 27 0 1 2 3 4
3 seconds.
```
(each invocation:)
```
Kernel info: 10 kernels (7 fusion, 3 shared-memory), cost = 271.3, local qubits 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32
Kernel info: 14 kernels (9 fusion, 5 shared-memory), cost = 294.6, local qubits 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32
Kernel info: 13 kernels (10 fusion, 3 shared-memory), cost = 282, local qubits 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32
Kernel info: 14 kernels (10 fusion, 4 shared-memory), cost = 290, local qubits 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32
Kernel info: 11 kernels (8 fusion, 3 shared-memory), cost = 273.7, local qubits 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32
Kernel info: 13 kernels (9 fusion, 4 shared-memory), cost = 287.6, local qubits 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32
Kernel info: 13 kernels (9 fusion, 4 shared-memory), cost = 285.4, local qubits 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32
Kernel info: 10 kernels (6 fusion, 4 shared-memory), cost = 277.9, local qubits 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32
Kernel info: 10 kernels (7 fusion, 3 shared-memory), cost = 271.3, local qubits 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32
Kernel info: 4 kernels (4 fusion, 0 shared-memory), cost = 25.4, local qubits 5 6 7 8 9 10 11 12 13 28 29 30 31 32 19 20 21 22 23 24 25 26 27 0 1 2 3 4
Kernel info: 5 kernels (5 fusion, 0 shared-memory), cost = 31.6, local qubits 5 6 7 8 9 10 11 12 13 28 29 30 31 32 19 20 21 22 23 24 25 26 27 0 1 2 3 4
Kernel info: 4 kernels (4 fusion, 0 shared-memory), cost = 25.4, local qubits 5 6 7 8 9 10 11 12 13 28 29 30 31 32 19 20 21 22 23 24 25 26 27 0 1 2 3 4
Kernel info: 4 kernels (4 fusion, 0 shared-memory), cost = 25.6, local qubits 5 6 7 8 9 10 11 12 13 28 29 30 31 32 19 20 21 22 23 24 25 26 27 0 1 2 3 4
Kernel info: 4 kernels (4 fusion, 0 shared-memory), cost = 25.4, local qubits 5 6 7 8 9 10 11 12 13 28 29 30 31 32 19 20 21 22 23 24 25 26 27 0 1 2 3 4
Kernel info: 4 kernels (4 fusion, 0 shared-memory), cost = 25.4, local qubits 5 6 7 8 9 10 11 12 13 28 29 30 31 32 19 20 21 22 23 24 25 26 27 0 1 2 3 4
Kernel info: 5 kernels (5 fusion, 0 shared-memory), cost = 31.6, local qubits 5 6 7 8 9 10 11 12 13 28 29 30 31 32 19 20 21 22 23 24 25 26 27 0 1 2 3 4
Kernel info: 4 kernels (4 fusion, 0 shared-memory), cost = 25.4, local qubits 5 6 7 8 9 10 11 12 13 28 29 30 31 32 19 20 21 22 23 24 25 26 27 0 1 2 3 4
Kernel info: 4 kernels (4 fusion, 0 shared-memory), cost = 25.4, local qubits 5 6 7 8 9 10 11 12 13 28 29 30 31 32 19 20 21 22 23 24 25 26 27 0 1 2 3 4
```
After (repeat=100):
```
2 stages.
Kernel info: 11 kernels (8 fusion, 3 shared-memory), cost = 265.7, local qubits 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32
Kernel info: 4 kernels (4 fusion, 0 shared-memory), cost = 25.4, local qubits 5 6 7 8 9 10 11 12 13 28 29 30 31 32 19 20 21 22 23 24 25 26 27 0 1 2 3 4
29 seconds.
```

Recall the complicated DP:
```
2 stages.
Kernel info: 13 kernels (10 fusion, 3 shared-memory), cost = 268.5, local qubits 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32
Kernel info: 4 kernels (4 fusion, 0 shared-memory), cost = 25.4, local qubits 5 6 7 8 9 10 11 12 13 28 29 30 31 32 19 20 21 22 23 24 25 26 27 0 1 2 3 4
6 seconds.
```