### PR TITLE
[Format] Rename .clang_format to .clang-format to enable it

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -3,8 +3,10 @@ Language:        Cpp
 # BasedOnStyle:  Google
 AccessModifierOffset: -1
 AlignAfterOpenBracket: Align
+AlignArrayOfStructures: None
 AlignConsecutiveMacros: None
 AlignConsecutiveAssignments: None
+AlignConsecutiveBitFields: None
 AlignConsecutiveDeclarations: None
 AlignEscapedNewlines: Left
 AlignOperands:   true
@@ -12,16 +14,19 @@ AlignTrailingComments: true
 AllowAllArgumentsOnNextLine: true
 AllowAllConstructorInitializersOnNextLine: true
 AllowAllParametersOfDeclarationOnNextLine: true
+AllowShortEnumsOnASingleLine: true
 AllowShortBlocksOnASingleLine: Never
 AllowShortCaseLabelsOnASingleLine: false
 AllowShortFunctionsOnASingleLine: All
 AllowShortLambdasOnASingleLine: All
-AllowShortIfStatementsOnASingleLine: Never
+AllowShortIfStatementsOnASingleLine: false
 AllowShortLoopsOnASingleLine: false
 AlwaysBreakAfterDefinitionReturnType: None
 AlwaysBreakAfterReturnType: None
-AlwaysBreakBeforeMultilineStrings: false
+AlwaysBreakBeforeMultilineStrings: true
 AlwaysBreakTemplateDeclarations: MultiLine
+AttributeMacros:
+  - __capability
 BinPackArguments: true
 BinPackParameters: true
 BraceWrapping:
@@ -37,11 +42,14 @@ BraceWrapping:
   AfterExternBlock: false
   BeforeCatch:     false
   BeforeElse:      false
+  BeforeLambdaBody: false
+  BeforeWhile:     false
   IndentBraces:    false
   SplitEmptyFunction: true
   SplitEmptyRecord: true
   SplitEmptyNamespace: true
 BreakBeforeBinaryOperators: None
+BreakBeforeConceptDeclarations: true
 BreakBeforeBraces: Attach
 BreakBeforeInheritanceComma: false
 BreakInheritanceList: BeforeColon
@@ -52,13 +60,14 @@ BreakAfterJavaFieldAnnotations: false
 BreakStringLiterals: true
 ColumnLimit:     80
 CommentPragmas:  '^ IWYU pragma:'
+QualifierAlignment: Leave
 CompactNamespaces: false
 ConstructorInitializerAllOnOneLineOrOnePerLine: false
 ConstructorInitializerIndentWidth: 4
 ContinuationIndentWidth: 4
 Cpp11BracedListStyle: true
 DeriveLineEnding: true
-DerivePointerAlignment: false
+DerivePointerAlignment: true
 DisableFormat:   false
 ExperimentalAutoDetectBinPacking: false
 FixNamespaceComments: true
@@ -66,44 +75,61 @@ ForEachMacros:
   - foreach
   - Q_FOREACH
   - BOOST_FOREACH
+IfMacros:
+  - KJ_IF_MAYBE
 IncludeBlocks:   Preserve
 IncludeCategories:
-  - Regex:           '^"(llvm|llvm-c|clang|clang-c)/'
+  - Regex:           '^<ext/.*\.h>'
     Priority:        2
     SortPriority:    0
-  - Regex:           '^(<|"(gtest|gmock|isl|json)/)'
-    Priority:        3
-    SortPriority:    0
-  - Regex:           '.*'
+    CaseSensitive:   false
+  - Regex:           '^<.*\.h>'
     Priority:        1
     SortPriority:    0
-IncludeIsMainRegex: '(Test)?$'
+    CaseSensitive:   false
+  - Regex:           '^<.*'
+    Priority:        2
+    SortPriority:    0
+    CaseSensitive:   false
+  - Regex:           '.*'
+    Priority:        3
+    SortPriority:    0
+    CaseSensitive:   false
+IncludeIsMainRegex: '([-_](test|unittest))?$'
 IncludeIsMainSourceRegex: ''
+IndentAccessModifiers: false
 IndentCaseLabels: false
+IndentCaseBlocks: false
 IndentGotoLabels: true
 IndentPPDirectives: None
+IndentExternBlock: AfterExternBlock
 IndentWidth:     2
 IndentWrappedFunctionNames: false
+InsertTrailingCommas: None
 JavaScriptQuotes: Leave
 JavaScriptWrapImports: true
-KeepEmptyLinesAtTheStartOfBlocks: true
+KeepEmptyLinesAtTheStartOfBlocks: false
+LambdaBodyIndentation: Signature
 MacroBlockBegin: ''
 MacroBlockEnd:   ''
 MaxEmptyLinesToKeep: 1
 NamespaceIndentation: None
-ObjCBinPackProtocolList: Auto
+ObjCBinPackProtocolList: Never
 ObjCBlockIndentWidth: 2
+ObjCBreakBeforeNestedBlockParam: true
 ObjCSpaceAfterProperty: false
 ObjCSpaceBeforeProtocolList: true
 PenaltyBreakAssignment: 2
-PenaltyBreakBeforeFirstCallParameter: 19
+PenaltyBreakBeforeFirstCallParameter: 1
 PenaltyBreakComment: 300
 PenaltyBreakFirstLessLess: 120
+PenaltyBreakOpenParenthesis: 0
 PenaltyBreakString: 1000
 PenaltyBreakTemplateDeclaration: 10
 PenaltyExcessCharacter: 1000000
-PenaltyReturnTypeOnItsOwnLine: 60
+PenaltyReturnTypeOnItsOwnLine: 200
 PointerAlignment: Right
+PPIndentWidth: -1
 RawStringFormats:
   - Language:        Cpp
     Delimiters:
@@ -134,13 +160,19 @@ RawStringFormats:
       - ParsePartialTestProto
     CanonicalDelimiter: pb
     BasedOnStyle:    google
+ReferenceAlignment: Pointer
 ReflowComments:  true
-SortIncludes: CaseSensitive
+RemoveBracesLLVM: false
+SeparateDefinitionBlocks: Leave
+ShortNamespaceLines: 1
+SortIncludes:    CaseSensitive
+SortJavaStaticImport: Before
 SortUsingDeclarations: true
 SpaceAfterCStyleCast: false
 SpaceAfterLogicalNot: false
 SpaceAfterTemplateKeyword: true
 SpaceBeforeAssignmentOperators: true
+SpaceBeforeCaseColon: false
 SpaceBeforeCpp11BracedList: false
 SpaceBeforeCtorInitializerColon: true
 SpaceBeforeInheritanceColon: true
@@ -153,15 +185,26 @@ SpacesInAngles:  false
 SpacesInConditionalStatement: false
 SpacesInContainerLiterals: true
 SpacesInCStyleCastParentheses: false
+SpacesInLineCommentPrefix:
+  Minimum:         1
+  Maximum:         -1
 SpacesInParentheses: false
 SpacesInSquareBrackets: false
 SpaceBeforeSquareBrackets: false
-Standard:        Latest
+BitFieldColonSpacing: Both
+Standard:        Auto
+StatementAttributeLikeMacros:
+  - Q_EMIT
 StatementMacros:
   - Q_UNUSED
   - QT_REQUIRE_VERSION
 TabWidth:        8
 UseCRLF:         false
 UseTab:          Never
+WhitespaceSensitiveMacros:
+  - STRINGIZE
+  - PP_STRINGIZE
+  - BOOST_PP_STRINGIZE
+  - NS_SWIFT_NAME
+  - CF_SWIFT_NAME
 ...
-

--- a/.clang-format
+++ b/.clang-format
@@ -23,7 +23,7 @@ AllowShortIfStatementsOnASingleLine: false
 AllowShortLoopsOnASingleLine: false
 AlwaysBreakAfterDefinitionReturnType: None
 AlwaysBreakAfterReturnType: None
-AlwaysBreakBeforeMultilineStrings: true
+AlwaysBreakBeforeMultilineStrings: false
 AlwaysBreakTemplateDeclarations: Yes
 AttributeMacros:
   - __capability
@@ -84,19 +84,21 @@ IncludeCategories:
   - Regex:           '^<ext/.*\.h>'
     Priority:        2
     SortPriority:    0
-    CaseSensitive:   false
+  - Regex:           '^"(llvm|llvm-c|clang|clang-c)/'
+    Priority:        2
+    SortPriority:    0
+  - Regex:           '^(<|"(gtest|gmock|isl|json)/)'
+    Priority:        3
+    SortPriority:    0
   - Regex:           '^<.*\.h>'
     Priority:        1
     SortPriority:    0
-    CaseSensitive:   false
   - Regex:           '^<.*'
     Priority:        2
     SortPriority:    0
-    CaseSensitive:   false
   - Regex:           '.*'
     Priority:        3
     SortPriority:    0
-    CaseSensitive:   false
 IncludeIsMainRegex: '([-_](test|unittest))?$'
 IncludeIsMainSourceRegex: ''
 IndentAccessModifiers: false
@@ -121,7 +123,7 @@ ObjCBlockIndentWidth: 2
 ObjCBreakBeforeNestedBlockParam: true
 ObjCSpaceAfterProperty: false
 ObjCSpaceBeforeProtocolList: true
-PackConstructorInitializers: NextLine
+PackConstructorInitializers: BinPack
 PenaltyBreakAssignment: 2
 PenaltyBreakBeforeFirstCallParameter: 19
 PenaltyBreakComment: 300

--- a/.clang-format
+++ b/.clang-format
@@ -3,29 +3,25 @@ Language:        Cpp
 # BasedOnStyle:  Google
 AccessModifierOffset: -1
 AlignAfterOpenBracket: Align
-AlignArrayOfStructures: None
 AlignConsecutiveMacros: None
 AlignConsecutiveAssignments: None
-AlignConsecutiveBitFields: None
 AlignConsecutiveDeclarations: None
 AlignEscapedNewlines: Left
-AlignOperands:   Align
+AlignOperands:   true
 AlignTrailingComments: true
 AllowAllArgumentsOnNextLine: true
+AllowAllConstructorInitializersOnNextLine: true
 AllowAllParametersOfDeclarationOnNextLine: true
-AllowShortEnumsOnASingleLine: true
 AllowShortBlocksOnASingleLine: Never
 AllowShortCaseLabelsOnASingleLine: false
 AllowShortFunctionsOnASingleLine: All
 AllowShortLambdasOnASingleLine: All
-AllowShortIfStatementsOnASingleLine: WithoutElse
-AllowShortLoopsOnASingleLine: true
+AllowShortIfStatementsOnASingleLine: Never
+AllowShortLoopsOnASingleLine: false
 AlwaysBreakAfterDefinitionReturnType: None
 AlwaysBreakAfterReturnType: None
-AlwaysBreakBeforeMultilineStrings: true
-AlwaysBreakTemplateDeclarations: Yes
-AttributeMacros:
-  - __capability
+AlwaysBreakBeforeMultilineStrings: false
+AlwaysBreakTemplateDeclarations: MultiLine
 BinPackArguments: true
 BinPackParameters: true
 BraceWrapping:
@@ -41,14 +37,11 @@ BraceWrapping:
   AfterExternBlock: false
   BeforeCatch:     false
   BeforeElse:      false
-  BeforeLambdaBody: false
-  BeforeWhile:     false
   IndentBraces:    false
   SplitEmptyFunction: true
   SplitEmptyRecord: true
   SplitEmptyNamespace: true
 BreakBeforeBinaryOperators: None
-BreakBeforeConceptDeclarations: true
 BreakBeforeBraces: Attach
 BreakBeforeInheritanceComma: false
 BreakInheritanceList: BeforeColon
@@ -59,83 +52,58 @@ BreakAfterJavaFieldAnnotations: false
 BreakStringLiterals: true
 ColumnLimit:     80
 CommentPragmas:  '^ IWYU pragma:'
-QualifierAlignment: Leave
 CompactNamespaces: false
+ConstructorInitializerAllOnOneLineOrOnePerLine: false
 ConstructorInitializerIndentWidth: 4
 ContinuationIndentWidth: 4
 Cpp11BracedListStyle: true
 DeriveLineEnding: true
-DerivePointerAlignment: true
+DerivePointerAlignment: false
 DisableFormat:   false
-EmptyLineAfterAccessModifier: Never
-EmptyLineBeforeAccessModifier: LogicalBlock
 ExperimentalAutoDetectBinPacking: false
-PackConstructorInitializers: NextLine
-BasedOnStyle:    ''
-ConstructorInitializerAllOnOneLineOrOnePerLine: false
-AllowAllConstructorInitializersOnNextLine: true
 FixNamespaceComments: true
 ForEachMacros:
   - foreach
   - Q_FOREACH
   - BOOST_FOREACH
-IfMacros:
-  - KJ_IF_MAYBE
-IncludeBlocks:   Regroup
+IncludeBlocks:   Preserve
 IncludeCategories:
-  - Regex:           '^<ext/.*\.h>'
+  - Regex:           '^"(llvm|llvm-c|clang|clang-c)/'
     Priority:        2
     SortPriority:    0
-    CaseSensitive:   false
-  - Regex:           '^<.*\.h>'
-    Priority:        1
-    SortPriority:    0
-    CaseSensitive:   false
-  - Regex:           '^<.*'
-    Priority:        2
-    SortPriority:    0
-    CaseSensitive:   false
-  - Regex:           '.*'
+  - Regex:           '^(<|"(gtest|gmock|isl|json)/)'
     Priority:        3
     SortPriority:    0
-    CaseSensitive:   false
-IncludeIsMainRegex: '([-_](test|unittest))?$'
+  - Regex:           '.*'
+    Priority:        1
+    SortPriority:    0
+IncludeIsMainRegex: '(Test)?$'
 IncludeIsMainSourceRegex: ''
-IndentAccessModifiers: false
-IndentCaseLabels: true
-IndentCaseBlocks: false
+IndentCaseLabels: false
 IndentGotoLabels: true
 IndentPPDirectives: None
-IndentExternBlock: AfterExternBlock
-IndentRequires:  false
 IndentWidth:     2
 IndentWrappedFunctionNames: false
-InsertTrailingCommas: None
 JavaScriptQuotes: Leave
 JavaScriptWrapImports: true
-KeepEmptyLinesAtTheStartOfBlocks: false
-LambdaBodyIndentation: Signature
+KeepEmptyLinesAtTheStartOfBlocks: true
 MacroBlockBegin: ''
 MacroBlockEnd:   ''
 MaxEmptyLinesToKeep: 1
 NamespaceIndentation: None
-ObjCBinPackProtocolList: Never
+ObjCBinPackProtocolList: Auto
 ObjCBlockIndentWidth: 2
-ObjCBreakBeforeNestedBlockParam: true
 ObjCSpaceAfterProperty: false
 ObjCSpaceBeforeProtocolList: true
 PenaltyBreakAssignment: 2
-PenaltyBreakBeforeFirstCallParameter: 1
+PenaltyBreakBeforeFirstCallParameter: 19
 PenaltyBreakComment: 300
 PenaltyBreakFirstLessLess: 120
-PenaltyBreakOpenParenthesis: 0
 PenaltyBreakString: 1000
 PenaltyBreakTemplateDeclaration: 10
 PenaltyExcessCharacter: 1000000
-PenaltyReturnTypeOnItsOwnLine: 200
-PenaltyIndentedWhitespace: 0
-PointerAlignment: Left
-PPIndentWidth:   -1
+PenaltyReturnTypeOnItsOwnLine: 60
+PointerAlignment: Right
 RawStringFormats:
   - Language:        Cpp
     Delimiters:
@@ -166,60 +134,34 @@ RawStringFormats:
       - ParsePartialTestProto
     CanonicalDelimiter: pb
     BasedOnStyle:    google
-ReferenceAlignment: Pointer
 ReflowComments:  true
-RemoveBracesLLVM: false
-SeparateDefinitionBlocks: Leave
-ShortNamespaceLines: 1
-SortIncludes:    CaseSensitive
-SortJavaStaticImport: Before
+SortIncludes: CaseSensitive
 SortUsingDeclarations: true
 SpaceAfterCStyleCast: false
 SpaceAfterLogicalNot: false
 SpaceAfterTemplateKeyword: true
 SpaceBeforeAssignmentOperators: true
-SpaceBeforeCaseColon: false
 SpaceBeforeCpp11BracedList: false
 SpaceBeforeCtorInitializerColon: true
 SpaceBeforeInheritanceColon: true
 SpaceBeforeParens: ControlStatements
-SpaceBeforeParensOptions:
-  AfterControlStatements: true
-  AfterForeachMacros: true
-  AfterFunctionDefinitionName: false
-  AfterFunctionDeclarationName: false
-  AfterIfMacros:   true
-  AfterOverloadedOperator: false
-  BeforeNonEmptyParentheses: false
-SpaceAroundPointerQualifiers: Default
 SpaceBeforeRangeBasedForLoopColon: true
 SpaceInEmptyBlock: false
 SpaceInEmptyParentheses: false
-SpacesBeforeTrailingComments: 2
-SpacesInAngles:  Never
+SpacesBeforeTrailingComments: 1
+SpacesInAngles:  false
 SpacesInConditionalStatement: false
 SpacesInContainerLiterals: true
 SpacesInCStyleCastParentheses: false
-SpacesInLineCommentPrefix:
-  Minimum:         1
-  Maximum:         -1
 SpacesInParentheses: false
 SpacesInSquareBrackets: false
 SpaceBeforeSquareBrackets: false
-BitFieldColonSpacing: Both
-Standard:        Auto
-StatementAttributeLikeMacros:
-  - Q_EMIT
+Standard:        Latest
 StatementMacros:
   - Q_UNUSED
   - QT_REQUIRE_VERSION
 TabWidth:        8
 UseCRLF:         false
 UseTab:          Never
-WhitespaceSensitiveMacros:
-  - STRINGIZE
-  - PP_STRINGIZE
-  - BOOST_PP_STRINGIZE
-  - NS_SWIFT_NAME
-  - CF_SWIFT_NAME
 ...
+

--- a/.clang-format
+++ b/.clang-format
@@ -183,7 +183,7 @@ SpaceBeforeParens: ControlStatements
 SpaceBeforeRangeBasedForLoopColon: true
 SpaceInEmptyBlock: false
 SpaceInEmptyParentheses: false
-SpacesBeforeTrailingComments: 2
+SpacesBeforeTrailingComments: 1
 SpacesInAngles:  Never
 SpacesInConditionalStatement: false
 SpacesInContainerLiterals: true

--- a/.clang-format
+++ b/.clang-format
@@ -79,7 +79,7 @@ ForEachMacros:
   - BOOST_FOREACH
 IfMacros:
   - KJ_IF_MAYBE
-IncludeBlocks:   Preserve
+IncludeBlocks:   Preserve  # Regroup
 IncludeCategories:
   - Regex:           '^<ext/.*\.h>'
     Priority:        2
@@ -123,14 +123,14 @@ ObjCSpaceAfterProperty: false
 ObjCSpaceBeforeProtocolList: true
 PackConstructorInitializers: NextLine
 PenaltyBreakAssignment: 2
-PenaltyBreakBeforeFirstCallParameter: 1
+PenaltyBreakBeforeFirstCallParameter: 19
 PenaltyBreakComment: 300
 PenaltyBreakFirstLessLess: 120
 PenaltyBreakOpenParenthesis: 0
 PenaltyBreakString: 1000
 PenaltyBreakTemplateDeclaration: 10
 PenaltyExcessCharacter: 1000000
-PenaltyReturnTypeOnItsOwnLine: 200
+PenaltyReturnTypeOnItsOwnLine: 60
 PointerAlignment: Right
 PPIndentWidth: -1
 RawStringFormats:
@@ -180,10 +180,19 @@ SpaceBeforeCpp11BracedList: false
 SpaceBeforeCtorInitializerColon: true
 SpaceBeforeInheritanceColon: true
 SpaceBeforeParens: ControlStatements
+SpaceBeforeParensOptions:
+  AfterControlStatements: true
+  AfterForeachMacros: true
+  AfterFunctionDefinitionName: false
+  AfterFunctionDeclarationName: false
+  AfterIfMacros:   true
+  AfterOverloadedOperator: false
+  BeforeNonEmptyParentheses: false
+SpaceAroundPointerQualifiers: Default
 SpaceBeforeRangeBasedForLoopColon: true
 SpaceInEmptyBlock: false
 SpaceInEmptyParentheses: false
-SpacesBeforeTrailingComments: 1
+SpacesBeforeTrailingComments: 1  # 2
 SpacesInAngles:  Never
 SpacesInConditionalStatement: false
 SpacesInContainerLiterals: true

--- a/.clang-format
+++ b/.clang-format
@@ -9,7 +9,7 @@ AlignConsecutiveAssignments: None
 AlignConsecutiveBitFields: None
 AlignConsecutiveDeclarations: None
 AlignEscapedNewlines: Left
-AlignOperands:   true
+AlignOperands:   Align
 AlignTrailingComments: true
 AllowAllArgumentsOnNextLine: true
 AllowAllConstructorInitializersOnNextLine: true
@@ -69,7 +69,10 @@ Cpp11BracedListStyle: true
 DeriveLineEnding: true
 DerivePointerAlignment: true
 DisableFormat:   false
+EmptyLineAfterAccessModifier: Never
+EmptyLineBeforeAccessModifier: LogicalBlock
 ExperimentalAutoDetectBinPacking: false
+PackConstructorInitializers: NextLine
 FixNamespaceComments: true
 ForEachMacros:
   - foreach
@@ -180,8 +183,8 @@ SpaceBeforeParens: ControlStatements
 SpaceBeforeRangeBasedForLoopColon: true
 SpaceInEmptyBlock: false
 SpaceInEmptyParentheses: false
-SpacesBeforeTrailingComments: 1
-SpacesInAngles:  false
+SpacesBeforeTrailingComments: 2
+SpacesInAngles:  Never
 SpacesInConditionalStatement: false
 SpacesInContainerLiterals: true
 SpacesInCStyleCastParentheses: false

--- a/.clang-format
+++ b/.clang-format
@@ -24,7 +24,7 @@ AllowShortLoopsOnASingleLine: false
 AlwaysBreakAfterDefinitionReturnType: None
 AlwaysBreakAfterReturnType: None
 AlwaysBreakBeforeMultilineStrings: true
-AlwaysBreakTemplateDeclarations: MultiLine
+AlwaysBreakTemplateDeclarations: Yes
 AttributeMacros:
   - __capability
 BinPackArguments: true
@@ -72,7 +72,6 @@ DisableFormat:   false
 EmptyLineAfterAccessModifier: Never
 EmptyLineBeforeAccessModifier: LogicalBlock
 ExperimentalAutoDetectBinPacking: false
-PackConstructorInitializers: NextLine
 FixNamespaceComments: true
 ForEachMacros:
   - foreach
@@ -122,6 +121,7 @@ ObjCBlockIndentWidth: 2
 ObjCBreakBeforeNestedBlockParam: true
 ObjCSpaceAfterProperty: false
 ObjCSpaceBeforeProtocolList: true
+PackConstructorInitializers: NextLine
 PenaltyBreakAssignment: 2
 PenaltyBreakBeforeFirstCallParameter: 1
 PenaltyBreakComment: 300

--- a/.clang-format
+++ b/.clang-format
@@ -24,7 +24,7 @@ AllowShortLoopsOnASingleLine: false
 AlwaysBreakAfterDefinitionReturnType: None
 AlwaysBreakAfterReturnType: None
 AlwaysBreakBeforeMultilineStrings: false
-AlwaysBreakTemplateDeclarations: Yes
+AlwaysBreakTemplateDeclarations: MultiLine
 AttributeMacros:
   - __capability
 BinPackArguments: true

--- a/.clang-format
+++ b/.clang-format
@@ -8,7 +8,7 @@ AlignConsecutiveMacros: None
 AlignConsecutiveAssignments: None
 AlignConsecutiveBitFields: None
 AlignConsecutiveDeclarations: None
-AlignEscapedNewlines: Left
+AlignEscapedNewlines: Right
 AlignOperands:   Align
 AlignTrailingComments: true
 AllowAllArgumentsOnNextLine: true

--- a/.gitignore
+++ b/.gitignore
@@ -48,9 +48,6 @@ Makefile
 # Dataset
 *.json
 
-# Clang format
-.clang-format
-
 # Cython
 python/quartz/_cython/*.cpp
 python/build/*

--- a/src/benchmark/dp.cpp
+++ b/src/benchmark/dp.cpp
@@ -41,7 +41,8 @@ int main() {
   }
   std::vector<int> num_local_qubits = {28};
   KernelCost kernel_cost(
-      /*fusion_kernel_costs=*/{0, 6.4, 6.2, 6.5, 6.4, 6.4, 25.8, 32.4},
+      /*fusion_kernel_costs=*/
+      {0, 6.4, 6.2, 6.5, 6.4, 6.4, 25.8, 32.4},
       /*shared_memory_init_cost=*/6,
       /*shared_memory_gate_cost=*/
       [](quartz::GateType type) {

--- a/src/benchmark/nam_middle_circuits.cpp
+++ b/src/benchmark/nam_middle_circuits.cpp
@@ -1,6 +1,7 @@
 #include "quartz/parser/qasm_parser.h"
 #include "quartz/tasograph/substitution.h"
 #include "test/gen_ecc_set.h"
+
 #include <cmath>
 #include <filesystem>
 #include <sstream>

--- a/src/quartz/circuitseq/circuitgate.h
+++ b/src/quartz/circuitseq/circuitgate.h
@@ -15,7 +15,7 @@ class Context;
  * Stores the gate type, input and output information.
  */
 class CircuitGate {
-public:
+ public:
   // Get the minimum qubit index of the gate.
   [[nodiscard]] int get_min_qubit_index() const;
   // Get the qubit indices of the gate.

--- a/src/quartz/circuitseq/circuitseq.cpp
+++ b/src/quartz/circuitseq/circuitseq.cpp
@@ -13,8 +13,10 @@
 
 namespace quartz {
 CircuitSeq::CircuitSeq(int num_qubits, int num_input_parameters)
-    : num_qubits(num_qubits), num_input_parameters(num_input_parameters),
-      hash_value_(0), hash_value_valid_(false) {
+    : num_qubits(num_qubits),
+      num_input_parameters(num_input_parameters),
+      hash_value_(0),
+      hash_value_valid_(false) {
   wires.reserve(num_qubits + num_input_parameters);
   outputs.reserve(num_qubits);
   parameters.reserve(num_input_parameters);

--- a/src/quartz/circuitseq/circuitseq.cpp
+++ b/src/quartz/circuitseq/circuitseq.cpp
@@ -13,10 +13,8 @@
 
 namespace quartz {
 CircuitSeq::CircuitSeq(int num_qubits, int num_input_parameters)
-    : num_qubits(num_qubits),
-      num_input_parameters(num_input_parameters),
-      hash_value_(0),
-      hash_value_valid_(false) {
+    : num_qubits(num_qubits), num_input_parameters(num_input_parameters),
+      hash_value_(0), hash_value_valid_(false) {
   wires.reserve(num_qubits + num_input_parameters);
   outputs.reserve(num_qubits);
   parameters.reserve(num_input_parameters);

--- a/src/quartz/circuitseq/circuitseq.cpp
+++ b/src/quartz/circuitseq/circuitseq.cpp
@@ -722,11 +722,11 @@ CircuitSeqHashType CircuitSeq::hash(Context *ctx) {
     for (int i = 0; i < num_total_params; i++) {
       const auto &param = all_parameters[i];
       ComplexType shifted =
-          dot_product * ComplexType{std::cos(param), std::sin(param)};
+          dot_product * (ComplexType{std::cos(param), std::sin(param)});
       generate_hash_values(ctx, shifted, i, all_parameters, &tmp,
                            &other_hash_values_);
       other_hash_values_.emplace_back(tmp, i);
-      shifted = dot_product * ComplexType{std::cos(param), -std::sin(param)};
+      shifted = dot_product * (ComplexType{std::cos(param), -std::sin(param)});
       generate_hash_values(ctx, shifted, i + num_total_params, all_parameters,
                            &tmp, &other_hash_values_);
       other_hash_values_.emplace_back(tmp, i + num_total_params);
@@ -735,8 +735,8 @@ CircuitSeqHashType CircuitSeq::hash(Context *ctx) {
       // Check phase shift of pi/4, 2pi/4, ..., 7pi/4.
       for (int i = 1; i < 8; i++) {
         const double pi = std::acos(-1.0);
-        ComplexType shifted = dot_product * ComplexType{std::cos(pi / 4 * i),
-                                                        std::sin(pi / 4 * i)};
+        ComplexType shifted = dot_product * (ComplexType{std::cos(pi / 4 * i),
+                                                         std::sin(pi / 4 * i)});
         generate_hash_values(ctx, shifted, i, all_parameters, &tmp,
                              &other_hash_values_);
         other_hash_values_.emplace_back(tmp,
@@ -1227,7 +1227,7 @@ bool CircuitSeq::canonical_representation(
   }
 
   class CompareByMinQubitIndex {
-  public:
+   public:
     bool operator()(CircuitGate *gate1, CircuitGate *gate2) const {
       // std::priority_queue maintains the largest element,
       // so we use ">" to get the gate with minimum qubit index.

--- a/src/quartz/circuitseq/circuitseq.h
+++ b/src/quartz/circuitseq/circuitseq.h
@@ -16,7 +16,7 @@ namespace quartz {
 class Context;
 
 class CircuitSeq {
-public:
+ public:
   // TODO: Input parameters should be handled in Context instead of here
   CircuitSeq(int num_qubits, int num_input_parameters);
   CircuitSeq(const CircuitSeq &other); // clone a CircuitSeq
@@ -212,7 +212,7 @@ public:
 
   static bool same_gate(CircuitGate *gate1, CircuitGate *gate2);
 
-private:
+ private:
   void clone_from(const CircuitSeq &other,
                   const std::vector<int> &qubit_permutation,
                   const std::vector<int> &param_permutation);
@@ -243,13 +243,13 @@ private:
       const std::vector<ParamType> &param_values, CircuitSeqHashType *main_hash,
       std::vector<std::pair<CircuitSeqHashType, PhaseShiftIdType>> *other_hash);
 
-public:
+ public:
   std::vector<std::unique_ptr<CircuitWire>> wires;
   std::vector<std::unique_ptr<CircuitGate>> gates;
   std::vector<CircuitWire *> outputs;
   std::vector<CircuitWire *> parameters;
 
-private:
+ private:
   int num_qubits, num_input_parameters;
   CircuitSeqHashType hash_value_;
   // For both floating-point error tolerance
@@ -271,7 +271,7 @@ private:
 };
 
 class UniquePtrCircuitSeqComparator {
-public:
+ public:
   bool operator()(const std::unique_ptr<CircuitSeq> &seq1,
                   const std::unique_ptr<CircuitSeq> &seq2) const {
     if (!seq1 || !seq2) {

--- a/src/quartz/circuitseq/circuitwire.h
+++ b/src/quartz/circuitseq/circuitwire.h
@@ -11,7 +11,7 @@ class CircuitGate;
  * Can be a qubit or a parameter (see comment below).
  */
 class CircuitWire {
-public:
+ public:
   enum Type {
     internal_qubit,
     input_qubit,

--- a/src/quartz/context/context.h
+++ b/src/quartz/context/context.h
@@ -15,7 +15,7 @@ namespace quartz {
 class CircuitSeq;
 
 class Context {
-public:
+ public:
   explicit Context(const std::vector<GateType> &supported_gates);
   Context(const std::vector<GateType> &supported_gates, const int num_qubits,
           const int num_params);
@@ -62,7 +62,7 @@ public:
   // ranging [0, 1].
   double random_number();
 
-private:
+ private:
   bool insert_gate(GateType tp);
 
   size_t global_unique_id;

--- a/src/quartz/context/rule_parser.h
+++ b/src/quartz/context/rule_parser.h
@@ -13,7 +13,7 @@
 namespace quartz {
 
 class Command {
-public:
+ public:
   Command() {}
   Command(const Command &cmd) {
     tp = cmd.tp;
@@ -77,7 +77,7 @@ public:
 };
 
 class RuleParser {
-public:
+ public:
   RuleParser(std::vector<std::string> rules_) {
     for (auto rule : rules_) {
       std::string gate_name;
@@ -151,7 +151,7 @@ public:
     return false;
   }
 
-public:
+ public:
   static std::pair<RuleParser *, RuleParser *> ccz_cx_rz_rules() {
     RuleParser *rule_0 =
         new RuleParser({"ccz q0 q1 q2 = cx q1 q2; rz q2 -0.25pi; cx q0 q2; rz "
@@ -194,7 +194,7 @@ public:
     return std::make_pair(rule_0, rule_1);
   }
 
-private:
+ private:
   std::map<GateType,
            std::vector<std::pair<
                Command, std::pair<std::vector<Command>, std::set<GateType>>>>>

--- a/src/quartz/dataset/dataset.h
+++ b/src/quartz/dataset/dataset.h
@@ -8,7 +8,7 @@
 namespace quartz {
 
 class Dataset {
-public:
+ public:
   bool save_json(Context *ctx, const std::string &file_name) const;
 
   // Return the number of DAGs removed.

--- a/src/quartz/dataset/equivalence_set.h
+++ b/src/quartz/dataset/equivalence_set.h
@@ -15,7 +15,7 @@ namespace quartz {
 class EquivalenceSet;
 
 class EquivalenceClass {
-public:
+ public:
   // Returns all DAGs in this equivalence class.
   [[nodiscard]] std::vector<CircuitSeq *> get_all_dags() const;
 
@@ -68,12 +68,12 @@ public:
   static bool less_than(const EquivalenceClass &ecc1,
                         const EquivalenceClass &ecc2);
 
-private:
+ private:
   std::vector<std::unique_ptr<CircuitSeq>> dags_;
 };
 
 class UniquePtrEquivalenceClassComparator {
-public:
+ public:
   bool operator()(const std::unique_ptr<EquivalenceClass> &ecc1,
                   const std::unique_ptr<EquivalenceClass> &ecc2) const {
     if (!ecc1 || !ecc2) {
@@ -86,7 +86,7 @@ public:
 
 // This class stores all equivalence classes.
 class EquivalenceSet {
-public:
+ public:
   // |new_representatives| is for Generator::generate().
   // It will be pushed back all representatives previously not in
   // the equivalence set.
@@ -180,7 +180,7 @@ public:
   [[nodiscard]] std::vector<EquivalenceClass *>
   get_containing_class(Context *ctx, CircuitSeq *dag) const;
 
-private:
+ private:
   void set_possible_class(const CircuitSeqHashType &hash_value,
                           EquivalenceClass *equiv_class);
   void remove_possible_class(const CircuitSeqHashType &hash_value,

--- a/src/quartz/dataset/representative_set.h
+++ b/src/quartz/dataset/representative_set.h
@@ -6,7 +6,7 @@
 namespace quartz {
 
 class RepresentativeSet {
-public:
+ public:
   bool load_json(Context *ctx, const std::string &file_name);
 
   bool save_json(const std::string &file_name) const;
@@ -31,7 +31,7 @@ public:
   // Sort the circuits in this equivalence class by CircuitSeq::less_than().
   void sort();
 
-private:
+ private:
   std::vector<std::unique_ptr<CircuitSeq>> dags_;
 };
 

--- a/src/quartz/gate/add.h
+++ b/src/quartz/gate/add.h
@@ -6,7 +6,7 @@
 
 namespace quartz {
 class AddGate : public Gate {
-public:
+ public:
   AddGate() : Gate(GateType::add, 0 /*num_qubits*/, 2 /*num_parameters*/) {}
   ParamType compute(const std::vector<ParamType> &input_params) override {
     assert(input_params.size() == 2);

--- a/src/quartz/gate/ccx.h
+++ b/src/quartz/gate/ccx.h
@@ -6,7 +6,7 @@
 
 namespace quartz {
 class CCXGate : public Gate {
-public:
+ public:
   CCXGate()
       : Gate(GateType::ccx, 3 /*num_qubits*/, 0 /*num_parameters*/),
         mat({{1, 0, 0, 0, 0, 0, 0, 0},

--- a/src/quartz/gate/ccz.h
+++ b/src/quartz/gate/ccz.h
@@ -6,7 +6,7 @@
 
 namespace quartz {
 class CCZGate : public Gate {
-public:
+ public:
   CCZGate()
       : Gate(GateType::ccz, 3 /*num_qubits*/, 0 /*num_parameters*/),
         mat({{1, 0, 0, 0, 0, 0, 0, 0},

--- a/src/quartz/gate/ch.h
+++ b/src/quartz/gate/ch.h
@@ -6,7 +6,7 @@
 
 namespace quartz {
 class CHGate : public Gate {
-public:
+ public:
   CHGate()
       : Gate(GateType::ch, 2 /*num_qubits*/, 0 /*num_parameters*/),
         mat({{1, 0, 0, 0},

--- a/src/quartz/gate/cp.h
+++ b/src/quartz/gate/cp.h
@@ -6,7 +6,7 @@
 
 namespace quartz {
 class CPGate : public Gate {
-public:
+ public:
   CPGate() : Gate(GateType::cp, 2 /*num_qubits*/, 1 /*num_parameters*/) {}
   MatrixBase *get_matrix(const std::vector<ParamType> &params) override {
     assert(params.size() == 1);

--- a/src/quartz/gate/cu1.h
+++ b/src/quartz/gate/cu1.h
@@ -6,7 +6,7 @@
 
 namespace quartz {
 class CU1Gate : public Gate {
-public:
+ public:
   CU1Gate() : Gate(GateType::cu1, 2 /*num_qubits*/, 1 /*num_parameters*/) {}
   MatrixBase *get_matrix(const std::vector<ParamType> &params) override {
     assert(params.size() == 1);

--- a/src/quartz/gate/cx.h
+++ b/src/quartz/gate/cx.h
@@ -6,7 +6,7 @@
 
 namespace quartz {
 class CXGate : public Gate {
-public:
+ public:
   CXGate()
       : Gate(GateType::cx, 2 /*num_qubits*/, 0 /*num_parameters*/),
         mat({{ComplexType(1), ComplexType(0), ComplexType(0), ComplexType(0)},

--- a/src/quartz/gate/cz.h
+++ b/src/quartz/gate/cz.h
@@ -6,7 +6,7 @@
 
 namespace quartz {
 class CZGate : public Gate {
-public:
+ public:
   CZGate()
       : Gate(GateType::cz, 2 /*num_qubits*/, 0 /*num_parameters*/),
         mat({{1, 0, 0, 0}, {0, 1, 0, 0}, {0, 0, 1, 0}, {0, 0, 0, -1}}) {}

--- a/src/quartz/gate/gate.h
+++ b/src/quartz/gate/gate.h
@@ -10,7 +10,7 @@
 
 namespace quartz {
 class Gate {
-public:
+ public:
   Gate(GateType tp, int num_qubits, int num_parameters);
   virtual MatrixBase *get_matrix();
   virtual MatrixBase *get_matrix(const std::vector<ParamType> &params);

--- a/src/quartz/gate/general_controlled_gate.h
+++ b/src/quartz/gate/general_controlled_gate.h
@@ -6,7 +6,7 @@
 
 namespace quartz {
 class GeneralControlledGate : public Gate {
-public:
+ public:
   GeneralControlledGate(Gate *controlled_gate, const std::vector<bool> &state)
       : controlled_gate_(controlled_gate), state_(state),
         Gate(controlled_gate->tp, controlled_gate->num_qubits,

--- a/src/quartz/gate/h.h
+++ b/src/quartz/gate/h.h
@@ -4,7 +4,7 @@
 
 namespace quartz {
 class HGate : public Gate {
-public:
+ public:
   HGate()
       : Gate(GateType::h, 1 /*num_qubits*/, 0 /*num_parameters*/),
         mat({{ComplexType(1 / std::sqrt(2)), ComplexType(1 / std::sqrt(2))},

--- a/src/quartz/gate/input_param.h
+++ b/src/quartz/gate/input_param.h
@@ -8,7 +8,7 @@ namespace quartz {
 // Only used as a wrapper of input qubit in TASO graph
 // TODO
 class InputParamGate : public Gate {
-public:
+ public:
   InputParamGate()
       : Gate(GateType::input_param, 0 /*num_qubits*/, 0 /*num_parameters*/),
         mat() {}

--- a/src/quartz/gate/input_qubit.h
+++ b/src/quartz/gate/input_qubit.h
@@ -9,7 +9,7 @@ namespace quartz {
 // Only used as a wrapper of input qubit in TASO graph
 // TODO
 class InputQubitGate : public Gate {
-public:
+ public:
   InputQubitGate()
       : Gate(GateType::input_qubit, 0 /*num_qubits*/, 0 /*num_parameters*/),
         mat() {}

--- a/src/quartz/gate/neg.h
+++ b/src/quartz/gate/neg.h
@@ -5,7 +5,7 @@
 
 namespace quartz {
 class NegGate : public Gate {
-public:
+ public:
   NegGate() : Gate(GateType::neg, 0 /*num_qubits*/, 1 /*num_parameters*/) {}
   ParamType compute(const std::vector<ParamType> &input_params) override {
     assert(input_params.size() == 1);

--- a/src/quartz/gate/p.h
+++ b/src/quartz/gate/p.h
@@ -6,7 +6,7 @@
 
 namespace quartz {
 class PGate : public Gate {
-public:
+ public:
   PGate() : Gate(GateType::p, 1 /*num_qubits*/, 1 /*num_parameters*/) {}
   MatrixBase *get_matrix(const std::vector<ParamType> &params) override {
     assert(params.size() == 1);

--- a/src/quartz/gate/pdg.h
+++ b/src/quartz/gate/pdg.h
@@ -6,7 +6,7 @@
 
 namespace quartz {
 class PDGGate : public Gate {
-public:
+ public:
   PDGGate() : Gate(GateType::pdg, 1 /*num_qubits*/, 1 /*num_parameters*/) {}
   MatrixBase *get_matrix(const std::vector<ParamType> &params) override {
     assert(params.size() == 1);

--- a/src/quartz/gate/rx.h
+++ b/src/quartz/gate/rx.h
@@ -6,7 +6,7 @@
 
 namespace quartz {
 class RXGate : public Gate {
-public:
+ public:
   RXGate() : Gate(GateType::rx, 1 /*num_qubits*/, 1 /*num_parameters*/) {}
   MatrixBase *get_matrix(const std::vector<ParamType> &params) override {
     assert(params.size() == 1);

--- a/src/quartz/gate/rx1.h
+++ b/src/quartz/gate/rx1.h
@@ -4,7 +4,7 @@
 
 namespace quartz {
 class RX1Gate : public Gate {
-public:
+ public:
   RX1Gate()
       : Gate(GateType::rx1, 1 /*num_qubits*/, 0 /*num_parameters*/),
         mat({{ComplexType(1 / std::sqrt(2)), ComplexType(-1.0i / std::sqrt(2))},

--- a/src/quartz/gate/rx3.h
+++ b/src/quartz/gate/rx3.h
@@ -4,7 +4,7 @@
 
 namespace quartz {
 class RX3Gate : public Gate {
-public:
+ public:
   RX3Gate()
       : Gate(GateType::rx3, 1 /*num_qubits*/, 0 /*num_parameters*/),
         mat({{ComplexType(1 / std::sqrt(2)), ComplexType(1.0i / std::sqrt(2))},

--- a/src/quartz/gate/rxx1.h
+++ b/src/quartz/gate/rxx1.h
@@ -6,7 +6,7 @@
 
 namespace quartz {
 class RXX1Gate : public Gate {
-public:
+ public:
   RXX1Gate()
       : Gate(GateType::rxx1, 2 /*num_qubits*/, 0 /*num_parameters*/),
         mat({{ComplexType(1 / std::sqrt(2)), ComplexType(0), ComplexType(0),

--- a/src/quartz/gate/rxx3.h
+++ b/src/quartz/gate/rxx3.h
@@ -6,7 +6,7 @@
 
 namespace quartz {
 class RXX3Gate : public Gate {
-public:
+ public:
   RXX3Gate()
       : Gate(GateType::rxx3, 2 /*num_qubits*/, 0 /*num_parameters*/),
         mat({{ComplexType(-1 / std::sqrt(2)), ComplexType(0), ComplexType(0),

--- a/src/quartz/gate/ry.h
+++ b/src/quartz/gate/ry.h
@@ -5,7 +5,7 @@
 
 namespace quartz {
 class RYGate : public Gate {
-public:
+ public:
   RYGate() : Gate(GateType::ry, 1 /*num_qubits*/, 1 /*num_parameters*/) {}
   MatrixBase *get_matrix(const std::vector<ParamType> &params) override {
     assert(params.size() == 1);

--- a/src/quartz/gate/ry1.h
+++ b/src/quartz/gate/ry1.h
@@ -4,7 +4,7 @@
 
 namespace quartz {
 class RY1Gate : public Gate {
-public:
+ public:
   RY1Gate()
       : Gate(GateType::ry1, 1 /*num_qubits*/, 0 /*num_parameters*/),
         mat({{ComplexType(1 / std::sqrt(2)), ComplexType(-1 / std::sqrt(2))},

--- a/src/quartz/gate/ry3.h
+++ b/src/quartz/gate/ry3.h
@@ -4,7 +4,7 @@
 
 namespace quartz {
 class RY3Gate : public Gate {
-public:
+ public:
   RY3Gate()
       : Gate(GateType::ry3, 1 /*num_qubits*/, 0 /*num_parameters*/),
         mat({{ComplexType(-1 / std::sqrt(2)), ComplexType(-1 / std::sqrt(2))},

--- a/src/quartz/gate/rz.h
+++ b/src/quartz/gate/rz.h
@@ -5,7 +5,7 @@
 
 namespace quartz {
 class RZGate : public Gate {
-public:
+ public:
   RZGate() : Gate(GateType::rz, 1 /*num_qubits*/, 1 /*num_parameters*/) {}
   MatrixBase *get_matrix(const std::vector<ParamType> &params) override {
     assert(params.size() == 1);

--- a/src/quartz/gate/s.h
+++ b/src/quartz/gate/s.h
@@ -4,7 +4,7 @@
 namespace quartz {
 
 class SGate : public Gate {
-public:
+ public:
   SGate()
       : Gate(GateType::s, 1 /*num_qubits*/, 0 /*num_parameters*/),
         mat({{1, 0}, {0, 1.0i}}) {}

--- a/src/quartz/gate/sdg.h
+++ b/src/quartz/gate/sdg.h
@@ -5,7 +5,7 @@
 namespace quartz {
 
 class SDGGate : public Gate {
-public:
+ public:
   SDGGate()
       : Gate(GateType::sdg, 1 /*num_qubits*/, 0 /*num_parameters*/),
         mat({{1, 0}, {0, -1.0i}}) {}

--- a/src/quartz/gate/swap.h
+++ b/src/quartz/gate/swap.h
@@ -6,7 +6,7 @@
 
 namespace quartz {
 class SWAPGate : public Gate {
-public:
+ public:
   SWAPGate()
       : Gate(GateType::swap, 2 /*num_qubits*/, 0 /*num_parameters*/),
         mat({{1, 0, 0, 0}, {0, 0, 1, 0}, {0, 1, 0, 0}, {0, 0, 0, 1}}) {}

--- a/src/quartz/gate/sx.h
+++ b/src/quartz/gate/sx.h
@@ -4,7 +4,7 @@
 
 namespace quartz {
 class SXGate : public Gate {
-public:
+ public:
   SXGate()
       : Gate(GateType::sx, 1 /*num_qubits*/, 0 /*num_parameters*/),
         mat({{ComplexType(0.5 + 0.5i), ComplexType(0.5 - 0.5i)},

--- a/src/quartz/gate/t.h
+++ b/src/quartz/gate/t.h
@@ -4,7 +4,7 @@
 
 namespace quartz {
 class TGate : public Gate {
-public:
+ public:
   TGate()
       : Gate(GateType::t, 1 /*num_qubits*/, 0 /*num_parameters*/),
         mat({{1, 0}, {0, std::sqrt(2) / 2 * (1.0 + 1.0i)}}) {}

--- a/src/quartz/gate/tdg.h
+++ b/src/quartz/gate/tdg.h
@@ -4,7 +4,7 @@
 
 namespace quartz {
 class TDGGate : public Gate {
-public:
+ public:
   TDGGate()
       : Gate(GateType::tdg, 1 /*num_qubits*/, 0 /*num_parameters*/),
         mat({{1, 0}, {0, std::sqrt(2) / 2 * (1.0 - 1.0i)}}) {}

--- a/src/quartz/gate/u1.h
+++ b/src/quartz/gate/u1.h
@@ -6,7 +6,7 @@
 
 namespace quartz {
 class U1Gate : public Gate {
-public:
+ public:
   U1Gate() : Gate(GateType::u1, 1 /*num_qubits*/, 1 /*num_parameters*/) {}
   MatrixBase *get_matrix(const std::vector<ParamType> &params) override {
     assert(params.size() == 1);

--- a/src/quartz/gate/u2.h
+++ b/src/quartz/gate/u2.h
@@ -6,7 +6,7 @@
 
 namespace quartz {
 class U2Gate : public Gate {
-public:
+ public:
   U2Gate() : Gate(GateType::u2, 1 /*num_qubits*/, 2 /*num_parameters*/) {}
   MatrixBase *get_matrix(const std::vector<ParamType> &params) override {
     assert(params.size() == 2);

--- a/src/quartz/gate/u3.h
+++ b/src/quartz/gate/u3.h
@@ -6,7 +6,7 @@
 
 namespace quartz {
 class U3Gate : public Gate {
-public:
+ public:
   U3Gate() : Gate(GateType::u3, 1 /*num_qubits*/, 3 /*num_parameters*/) {}
   MatrixBase *get_matrix(const std::vector<ParamType> &params) override {
     assert(params.size() == 3);

--- a/src/quartz/gate/x.h
+++ b/src/quartz/gate/x.h
@@ -4,7 +4,7 @@
 
 namespace quartz {
 class XGate : public Gate {
-public:
+ public:
   XGate()
       : Gate(GateType::x, 1 /*num_qubits*/, 0 /*num_parameters*/),
         mat({{ComplexType(0), ComplexType(1)},

--- a/src/quartz/gate/y.h
+++ b/src/quartz/gate/y.h
@@ -4,7 +4,7 @@
 
 namespace quartz {
 class YGate : public Gate {
-public:
+ public:
   YGate()
       : Gate(GateType::y, 1 /*num_qubits*/, 0 /*num_parameters*/),
         mat({{ComplexType(0), ComplexType(-1.0i)},

--- a/src/quartz/gate/z.h
+++ b/src/quartz/gate/z.h
@@ -4,7 +4,7 @@
 
 namespace quartz {
 class ZGate : public Gate {
-public:
+ public:
   ZGate()
       : Gate(GateType::z, 1 /*num_qubits*/, 0 /*num_parameters*/),
         mat({{1, 0}, {0, -1}}) {}

--- a/src/quartz/generator/generator.h
+++ b/src/quartz/generator/generator.h
@@ -11,7 +11,7 @@
 
 namespace quartz {
 class Generator {
-public:
+ public:
   explicit Generator(Context *ctx) : context(ctx) {}
 
   // Use DFS to generate all equivalent DAGs with |num_qubits| qubits,
@@ -70,7 +70,7 @@ public:
                std::chrono::steady_clock::now()) *record_verification_time =
           nullptr);
 
-private:
+ private:
   void initialize_supported_quantum_gates();
 
   void dfs(int gate_idx, int max_num_gates, int max_remaining_param_gates,

--- a/src/quartz/math/matrix.h
+++ b/src/quartz/math/matrix.h
@@ -7,7 +7,7 @@
 
 namespace quartz {
 class MatrixBase {
-public:
+ public:
   virtual void clear() {}
   virtual ComplexType *operator[](int x) { return nullptr; }
   virtual const ComplexType *operator[](int x) const { return nullptr; }
@@ -25,7 +25,7 @@ public:
 };
 
 template <int kSize> class Matrix : public MatrixBase {
-public:
+ public:
   void clear() { memset(data_, 0, sizeof(data_)); }
   Matrix() = default;
   Matrix(ComplexType data[kSize][kSize]) : data_(data) {}
@@ -94,7 +94,7 @@ public:
     return flattened_mat;
   }
 
-private:
+ private:
   ComplexType data_[kSize][kSize];
 };
 

--- a/src/quartz/math/vector.cpp
+++ b/src/quartz/math/vector.cpp
@@ -84,7 +84,7 @@ Vector Vector::random_generate(int num_qubits, std::mt19937 *gen) {
 #ifdef USE_ARBLIB
   constexpr slong kRandPrec = 64;
   class FlintRandWrapper {
-  public:
+   public:
     FlintRandWrapper() { flint_randinit(state); }
     ~FlintRandWrapper() { flint_randclear(state); }
     flint_rand_t state{};

--- a/src/quartz/math/vector.h
+++ b/src/quartz/math/vector.h
@@ -8,7 +8,7 @@
 namespace quartz {
 // An std::vector<ComplexType> to store the distributions.
 class Vector {
-public:
+ public:
   Vector() = default;
   explicit Vector(int sz) : data_(sz) {}
   explicit Vector(const std::vector<ComplexType> &data) : data_(data) {}
@@ -24,7 +24,7 @@ public:
   // Otherwise, use a static mt19937 generator for this function.
   static Vector random_generate(int num_qubits, std::mt19937 *gen = nullptr);
 
-private:
+ private:
   std::vector<ComplexType> data_;
 };
 

--- a/src/quartz/parser/qasm_parser.cpp
+++ b/src/quartz/parser/qasm_parser.cpp
@@ -41,7 +41,6 @@ int string_to_number(const std::string &input) {
 }
 
 bool is_gate_string(const std::string &token, GateType &type) {
-
 #define PER_GATE(x, XGate)                                                     \
   if (token == std::string(#x)) {                                              \
     type = GateType::x;                                                        \

--- a/src/quartz/parser/qasm_parser.h
+++ b/src/quartz/parser/qasm_parser.h
@@ -25,7 +25,7 @@ bool is_gate_string(const std::string &token, GateType &type);
 std::string strip(const std::string &input);
 
 class QASMParser {
-public:
+ public:
   QASMParser(Context *ctx) : context(ctx) {}
 
   template <class _CharT, class _Traits>
@@ -49,7 +49,7 @@ public:
     return res;
   }
 
-private:
+ private:
   Context *context;
 };
 

--- a/src/quartz/pybind/pybind.h
+++ b/src/quartz/pybind/pybind.h
@@ -11,7 +11,7 @@ void init_python_interpreter();
 
 // There can only be one alive PythonInterpreter object at any time.
 class PythonInterpreter {
-public:
+ public:
   std::vector<std::vector<int>>
   solve_ilp(const std::vector<std::vector<int>> &circuit_gate_qubits,
             const std::vector<int> &circuit_gate_executable_type,
@@ -19,7 +19,7 @@ public:
             int num_local_qubits, int num_iterations,
             bool print_solution = false);
 
-private:
+ private:
   pybind11::scoped_interpreter guard_;
   pybind11::function solve_ilp_;
 };

--- a/src/quartz/simulator/kernel.h
+++ b/src/quartz/simulator/kernel.h
@@ -16,7 +16,7 @@ std::string kernel_type_name(KernelType tp);
  * A kernel used in the output of schedule.
  */
 class Kernel {
-public:
+ public:
   Kernel(const CircuitSeq &gates, const std::vector<int> &qubits,
          KernelType type)
       : gates(gates), qubits(qubits), type(type) {}
@@ -65,7 +65,7 @@ public:
  * schedule.
  */
 struct KernelInDP {
-public:
+ public:
   // It is unspecified what the kernel type is if the default constructor
   // is called.
   KernelInDP() {}

--- a/src/quartz/simulator/kernel_cost.h
+++ b/src/quartz/simulator/kernel_cost.h
@@ -13,7 +13,7 @@ using KernelCostType = double;
  * A class for the cost function of kernels.
  */
 class KernelCost {
-public:
+ public:
   /**
    * The cost function of kernels.
    * @param fusion_kernel_costs An array of costs for fusion kernels.

--- a/src/quartz/simulator/schedule.cpp
+++ b/src/quartz/simulator/schedule.cpp
@@ -301,7 +301,7 @@ bool Schedule::compute_kernel_schedule(
 
   // A state for dynamic programming.
   struct Status {
-  public:
+   public:
     static size_t get_hash(const std::vector<int> &s) {
       size_t result = 5381;
       for (const auto &i : s) {
@@ -463,11 +463,11 @@ bool Schedule::compute_kernel_schedule(
     size_t hash;
   };
   class StatusHash {
-  public:
+   public:
     size_t operator()(const Status &s) const { return s.hash; }
   };
   struct LocalSchedule {
-  public:
+   public:
     [[nodiscard]] std::string to_string() const {
       std::string result;
       result += "{";

--- a/src/quartz/simulator/schedule.h
+++ b/src/quartz/simulator/schedule.h
@@ -16,7 +16,7 @@ namespace quartz {
  * A simulation schedule of a circuit sequence on one device.
  */
 class Schedule {
-public:
+ public:
   Schedule(std::unique_ptr<CircuitSeq> &&sequence,
            const std::vector<int> &local_qubit,
            const std::vector<int> &global_qubit,
@@ -111,7 +111,7 @@ public:
   std::vector<Kernel> kernels;
   KernelCostType cost_;
 
-private:
+ private:
   // The original circuit sequence.
   std::unique_ptr<CircuitSeq> sequence_;
 

--- a/src/quartz/tasograph/substitution.h
+++ b/src/quartz/tasograph/substitution.h
@@ -40,7 +40,7 @@ struct TensorXCompare {
 };
 
 class TensorXHash {
-public:
+ public:
   size_t operator()(const TensorX &a) const {
     std::hash<size_t> hash_fn;
     return hash_fn(a.idx) * 17 + hash_fn((size_t)(a.op));
@@ -48,20 +48,20 @@ public:
 };
 
 class OpX {
-public:
+ public:
   OpX(const OpX &_op);
   OpX(GateType _type);
   void add_input(const TensorX &input);
   void add_output(const TensorX &output);
 
-public:
+ public:
   GateType type;
   Op mapOp;
   std::vector<TensorX> inputs, outputs;
 };
 
 class GraphCompare {
-public:
+ public:
   GraphCompare() {
     cost_function_ = [](Graph *graph) { return graph->total_cost(); };
   }
@@ -72,12 +72,12 @@ public:
     return cost_function_(lhs.get()) > cost_function_(rhs.get());
   }
 
-private:
+ private:
   std::function<float(Graph *)> cost_function_;
 };
 
 class GraphXfer {
-public:
+ public:
   GraphXfer(Context *_context);
   GraphXfer(Context *_context, const CircuitSeq *src_graph,
             const CircuitSeq *dst_graph);
@@ -106,7 +106,7 @@ public:
   // TODO: not implemented
   //   std::string to_qasm(std::vector<OpX *> const &v) const;
 
-public:
+ public:
   static GraphXfer *create_GraphXfer(Context *_context,
                                      const CircuitSeq *src_graph,
                                      const CircuitSeq *dst_graph,
@@ -121,7 +121,7 @@ public:
   static std::pair<GraphXfer *, GraphXfer *> ccz_cx_u1_xfer(Context *ctx);
   static std::pair<GraphXfer *, GraphXfer *> ccz_cx_t_xfer(Context *ctx);
 
-public:
+ public:
   Context *context;
   int tensorId;
   std::unordered_map<Op, OpX *, OpHash> mappedOps;

--- a/src/quartz/tasograph/tasograph.cpp
+++ b/src/quartz/tasograph/tasograph.cpp
@@ -1589,7 +1589,6 @@ std::shared_ptr<Graph> Graph::from_qasm_str(Context *ctx,
 
 void Graph::draw_circuit(const std::string &src_file_name,
                          const std::string &save_filename) {
-
   system(("python python/draw_graph.py " + src_file_name + " " + save_filename)
              .c_str());
 }

--- a/src/quartz/tasograph/tasograph.h
+++ b/src/quartz/tasograph/tasograph.h
@@ -24,7 +24,7 @@ namespace quartz {
 bool equal_to_2k_pi(double d);
 
 class Op {
-public:
+ public:
   Op(void);
   Op(size_t _guid, Gate *_ptr) : guid(_guid), ptr(_ptr) {}
   inline bool operator==(const Op &b) const {
@@ -62,13 +62,13 @@ public:
   }
   static const Op INVALID_OP;
 
-public:
+ public:
   size_t guid;
   Gate *ptr;
 };
 
 class OpCompare {
-public:
+ public:
   bool operator()(const Op &a, const Op &b) const {
     if (a.guid != b.guid)
       return a.guid < b.guid;
@@ -77,7 +77,7 @@ public:
 };
 
 class OpHash {
-public:
+ public:
   size_t operator()(const Op &a) const {
     std::hash<size_t> hash_fn;
     return hash_fn(a.guid) * 17 + hash_fn((size_t)(a.ptr));
@@ -85,7 +85,7 @@ public:
 };
 
 class Pos {
-public:
+ public:
   Pos() {
     op = Op();
     idx = 0;
@@ -127,7 +127,7 @@ inline bool operator!=(const Pos &a, const Pos &b) {
 }
 
 class PosHash {
-public:
+ public:
   size_t operator()(const Pos &a) const {
     std::hash<size_t> hash_fn;
     OpHash op_hash;
@@ -136,7 +136,7 @@ public:
 };
 
 class PosCompare {
-public:
+ public:
   bool operator()(const Pos &a, const Pos &b) const {
     if (a.op != b.op)
       return a.op < b.op;
@@ -145,7 +145,7 @@ public:
 };
 
 class Tensor {
-public:
+ public:
   Tensor(void);
   int idx;
   Op op;
@@ -176,7 +176,7 @@ class GraphXfer;
 class OpX;
 
 class Graph {
-public:
+ public:
   Graph(Context *ctx);
   Graph(Context *ctx, const CircuitSeq *seq);
   Graph(const Graph &graph);
@@ -311,7 +311,7 @@ public:
   std::vector<std::shared_ptr<Graph>>
   topology_partition(const int partition_gate_count) const;
 
-private:
+ private:
   void replace_node(Op oldOp, Op newOp);
   void remove_edge(Op srcOp, Op dstOp);
   uint64_t xor_bitmap(uint64_t src_bitmap, int src_idx, uint64_t dst_bitmap,
@@ -335,7 +335,7 @@ private:
       GraphXfer *xfer, Op op,
       std::deque<std::pair<OpX *, Op>> &matched_opx_op_pairs_dq) const;
 
-public:
+ public:
   size_t special_op_guid;
   Context *context;
   std::map<Op, std::set<Edge, EdgeCompare>, OpCompare> inEdges, outEdges;

--- a/src/quartz/utils/arb_complex.h
+++ b/src/quartz/utils/arb_complex.h
@@ -12,7 +12,7 @@ namespace quartz {
 constexpr slong kArbPrec = 64;
 
 class ArbComplex {
-public:
+ public:
   using value_type = arb_t;
   ArbComplex() {
     arb_init(re);
@@ -100,7 +100,7 @@ public:
     std::cout << ")";
   }
 
-private:
+ private:
   arb_t re, im;
 };
 

--- a/src/quartz/utils/utils.h
+++ b/src/quartz/utils/utils.h
@@ -31,7 +31,7 @@ constexpr bool kCheckPhaseShiftOfPiOver4 = true;
 constexpr int kCheckPhaseShiftOfPiOver4Index = 10000; // not used now
 
 struct PairHash {
-public:
+ public:
   template <typename T, typename U>
   std::size_t operator()(const std::pair<T, U> &x) const {
     return std::hash<T>()(x.first) ^ std::hash<U>()(x.second);

--- a/src/quartz/verifier/verifier.h
+++ b/src/quartz/verifier/verifier.h
@@ -7,7 +7,7 @@
 namespace quartz {
 // Verify if two circuits are equivalent and other things about DAGs.
 class Verifier {
-public:
+ public:
   bool equivalent(Context *ctx, CircuitSeq *circuit1, CircuitSeq *circuit2);
   // On-the-fly equivalence checking while generating circuits
   bool equivalent_on_the_fly(Context *ctx, CircuitSeq *circuit1,

--- a/src/test/test_appliable_xfer.cpp
+++ b/src/test/test_appliable_xfer.cpp
@@ -70,7 +70,6 @@ int main() {
   const int idx = 7;
 
   for (int _t = 0; _t < 1e5; _t++) {
-
     const auto t1_start = std::chrono::high_resolution_clock::now();
     const auto ans_ref = graph.appliable_xfers(all_ops[idx], xfers);
     const auto t1_end = std::chrono::high_resolution_clock::now();

--- a/src/test/test_context_shift.h
+++ b/src/test/test_context_shift.h
@@ -8,7 +8,6 @@ using namespace quartz;
 
 void test_context_shift(const std::string &filename, Context *src_ctx,
                         Context *dst_ctx, RuleParser *rule_parser) {
-
   QASMParser qasm_parser(src_ctx);
   CircuitSeq *dag = nullptr;
   if (!qasm_parser.load_qasm(filename, dag)) {

--- a/src/test/test_simulation.cpp
+++ b/src/test/test_simulation.cpp
@@ -141,7 +141,8 @@ int main() {
     num_local_qubits.push_back(i);
   }
   quartz::KernelCost kernel_cost(
-      /*fusion_kernel_costs=*/{0, 6.4, 6.2, 6.5, 6.4, 6.4, 25.8, 32.4},
+      /*fusion_kernel_costs=*/
+      {0, 6.4, 6.2, 6.5, 6.4, 6.4, 25.8, 32.4},
       /*shared_memory_init_cost=*/6,
       /*shared_memory_gate_cost=*/
       [](quartz::GateType type) {


### PR DESCRIPTION
I think `.clang-format` should not be in `.gitignore` so we can configure the same code format. See [.clang_format → .clang-format](https://github.com/quantum-compiler/quartz/pull/136/files#diff-1026e0038b722990204a42bed8a6f7c0ec2302aa79e3fad1959d62ba968edfa2) for the nominal changes.

Actual code format change in this commit:
- Access modifiers:
Before: not specified
After:
```C++
class A {
 public:
  int a;
};
```
instead of
```C++
class A {
public:
  int a;
};
```

Some suggestions in the future:
- IncludeBlocks: Preserve -> Regroup
- SpacesBeforeTrailingComments: 1 -> 2