### PR TITLE
[Simulator] Do the simple DP in reversed order and update the benchmark for DP

### DIFF
--- a/src/benchmark/dp.cpp
+++ b/src/benchmark/dp.cpp
@@ -19,21 +19,13 @@ int main() {
   Context ctx({GateType::input_qubit, GateType::input_param, GateType::h,
                GateType::x, GateType::ry, GateType::u2, GateType::u3,
                GateType::cx, GateType::cz, GateType::cp, GateType::swap,
-               GateType::rz});
-  std::vector<std::string> circuit_names = {"ae",
-                                            "dj",
-                                            "ghz",
-                                            "graphstate",
-                                            "qft",
-                                            "qftentangled",
-                                            "qpeexact",
-                                            "qpeinexact",
-                                            "realamprandom",
-                                            "su2random",
-                                            "twolocalrandom",
-                                            "wstate"};
+               GateType::rz, GateType::p, GateType::ccx, GateType::rx});
+  std::vector<std::string> circuit_names = {
+      "ae",           "dj",       "ghz",       "graphstate", "qft",
+      "qftentangled", "qpeexact", "su2random", "wstate"};
 
-  std::vector<std::string> circuit_names_nwq = {"bv", "ising"};
+  std::vector<std::string> circuit_names_nwq = {"bv", "hhl", "ising", "qsvm",
+                                                "vqc"};
   // 28-34 total qubits, 28 local qubits
   std::vector<int> num_qubits;
   for (int i = 28; i <= 34; i++) {
@@ -53,34 +45,56 @@ int main() {
       },
       /*shared_memory_total_qubits=*/10, /*shared_memory_cacheline_qubits=*/3);
   FILE *fout = fopen("../dp_result.csv", "w");
-  for (auto circuit : circuit_names) {
-    // nwq:
-    //  for (auto circuit : circuit_names_nwq) {
+  constexpr bool run_nwq = false;
+  for (auto circuit : (run_nwq ? circuit_names_nwq : circuit_names)) {
     fprintf(fout, "%s\n", circuit.c_str());
     std::cout << circuit << std::endl;
     for (int num_q : num_qubits) {
+      if (circuit == std::string("hhl")) {
+        if (num_q == 28) {
+          num_q = 4;
+        } else if (num_q == 29) {
+          num_q = 7;
+        } else if (num_q == 30) {
+          num_q = 9;
+        } else if (num_q == 31) {
+          num_q = 10;
+        } else {
+          break;
+        }
+      }
       // requires running test_remove_swap first
       auto seq = CircuitSeq::from_qasm_file(
-          &ctx, std::string("../circuit/MQTBench_") + std::to_string(num_q) +
-                    "q/" + circuit + "_indep_qiskit_" + std::to_string(num_q) +
-                    "_no_swap.qasm");
-      // nwq:
-      //      auto seq = CircuitSeq::from_qasm_file(
-      //          &ctx,
-      //          std::string("../../../PycharmProjects/nwqbench/NWQ_Bench/") +
-      //                    circuit + "/qasm/" + circuit + "_n" +
-      //                    std::to_string(num_q) + ".qasm");
-
+          &ctx, (run_nwq ? (std::string("../circuit/NWQBench/") + circuit +
+                            "_" + (circuit == std::string("hhl") ? "" : "n") +
+                            std::to_string(num_q) + ".qasm")
+                         : (std::string("../circuit/MQTBench_") +
+                            std::to_string(num_q) + "q/" + circuit +
+                            "_indep_qiskit_" + std::to_string(num_q) +
+                            "_no_swap.qasm")));
       fprintf(fout, "%d, ", num_q);
       int answer_start_with = 1;
+      bool has_local_q_at_least_num_q = false;
       for (int local_q : num_local_qubits) {
-        if (local_q > num_q) {
-          continue;
+        if (local_q >= num_q) {
+          if (has_local_q_at_least_num_q) {
+            break;
+          }
+          local_q = num_q;
+          has_local_q_at_least_num_q = true;
         }
         auto t0 = std::chrono::steady_clock::now();
         std::vector<std::vector<int>> local_qubits;
-        local_qubits = compute_local_qubits_with_ilp(
-            *seq, local_q, &ctx, &interpreter, answer_start_with);
+        if (local_q == num_q) {
+          std::vector<int> stage(num_q);
+          for (int i = 0; i < num_q; i++) {
+            stage[i] = i;
+          }
+          local_qubits.push_back(stage);
+        } else {
+          local_qubits = compute_local_qubits_with_ilp(
+              *seq, local_q, &ctx, &interpreter, answer_start_with);
+        }
         int ilp_result = (int)local_qubits.size();
         std::cout << local_qubits.size() << " stages." << std::endl;
         auto t1 = std::chrono::steady_clock::now();
@@ -105,28 +119,6 @@ int main() {
         }
         fprintf(fout, "%.1f, ", total_cost);
         fflush(fout);
-        auto t3 = std::chrono::steady_clock::now();
-        schedules = get_schedules(*seq, local_qubits, kernel_cost, &ctx,
-                                  /*attach_single_qubit_gates=*/true,
-                                  /*use_simple_dp_times=*/10);
-        total_cost = 0;
-        for (auto &schedule : schedules) {
-          // schedule.print_kernel_info();
-          total_cost += schedule.cost_;
-        }
-        fprintf(fout, "%.1f, ", total_cost);
-        fflush(fout);
-        auto t4 = std::chrono::steady_clock::now();
-        schedules = get_schedules(*seq, local_qubits, kernel_cost, &ctx,
-                                  /*attach_single_qubit_gates=*/true,
-                                  /*use_simple_dp_times=*/100);
-        total_cost = 0;
-        for (auto &schedule : schedules) {
-          // schedule.print_kernel_info();
-          total_cost += schedule.cost_;
-        }
-        fprintf(fout, "%.1f, ", total_cost);
-        fflush(fout);
         auto t5 = std::chrono::steady_clock::now();
         schedules = get_schedules(*seq, local_qubits, kernel_cost, &ctx,
                                   /*attach_single_qubit_gates=*/true,
@@ -139,21 +131,13 @@ int main() {
         fprintf(fout, "%.1f, ", total_cost);
         fflush(fout);
         auto t6 = std::chrono::steady_clock::now();
-        fprintf(fout, "%.3f, %.3f, %.3f, %.3f, %.3f",
+        fprintf(fout, "%.3f, %.3f, %.3f",
                 (double)std::chrono::duration_cast<std::chrono::milliseconds>(
                     t2 - t1)
                         .count() /
                     1000.0,
                 (double)std::chrono::duration_cast<std::chrono::milliseconds>(
-                    t3 - t2)
-                        .count() /
-                    1000.0,
-                (double)std::chrono::duration_cast<std::chrono::milliseconds>(
-                    t4 - t3)
-                        .count() /
-                    1000.0,
-                (double)std::chrono::duration_cast<std::chrono::milliseconds>(
-                    t5 - t4)
+                    t5 - t2)
                         .count() /
                     1000.0,
                 (double)std::chrono::duration_cast<std::chrono::milliseconds>(

--- a/src/quartz/simulator/schedule.h
+++ b/src/quartz/simulator/schedule.h
@@ -93,7 +93,7 @@ class Schedule {
 
   /**
    * Similar to above, but compute in a reversed order.
-   * The memory complexity becomes linear.
+   * The space complexity becomes linear.
    */
   bool compute_kernel_schedule_simple_reversed(
       const KernelCost &kernel_cost,

--- a/src/quartz/simulator/schedule.h
+++ b/src/quartz/simulator/schedule.h
@@ -75,7 +75,7 @@ class Schedule {
 
   /**
    * Compute the schedule using a simple quadratic dynamic programming
-   * algorithm.
+   * algorithm. The memory complexity is also quadratic.
    * @param kernel_cost The cost function of kernels.
    * @param non_insular_qubit_indices The set of non-insular qubit indices
    * for each gate, if any of them should be considered differently from
@@ -87,6 +87,15 @@ class Schedule {
    * the member variables |kernels| and |cost_|.
    */
   bool compute_kernel_schedule_simple(
+      const KernelCost &kernel_cost,
+      const std::vector<std::vector<int>> &non_insular_qubit_indices = {},
+      const std::vector<KernelCostType> &shared_memory_gate_costs = {});
+
+  /**
+   * Similar to above, but compute in a reversed order.
+   * The memory complexity becomes linear.
+   */
+  bool compute_kernel_schedule_simple_reversed(
       const KernelCost &kernel_cost,
       const std::vector<std::vector<int>> &non_insular_qubit_indices = {},
       const std::vector<KernelCostType> &shared_memory_gate_costs = {});

--- a/src/test/test_remove_swap.cpp
+++ b/src/test/test_remove_swap.cpp
@@ -12,7 +12,7 @@ int main() {
   Context ctx({GateType::input_qubit, GateType::input_param, GateType::h,
                GateType::x, GateType::ry, GateType::u2, GateType::u3,
                GateType::cx, GateType::cz, GateType::cp, GateType::swap,
-               GateType::rz});
+               GateType::rz, GateType::rx, GateType::p});
   std::vector<std::string> circuit_names = {"ae",
                                             "dj",
                                             "ghz",
@@ -50,5 +50,49 @@ int main() {
                                   "_no_swap.qasm");
     }
   }
+  /*
+std::vector<std::string> circuit_names = {"bv", "hhl", "ising", "qsvm",
+                                          "vqc"};
+
+std::filesystem::path this_file_path(__FILE__);
+auto circuit_folder =
+    this_file_path.parent_path().parent_path().parent_path().append(
+        "circuit");
+std::vector<int> num_qubits;
+for (int i = 28; i <= 34; i++) {
+  num_qubits.push_back(i);
+}
+for (int num_q1 : num_qubits) {
+  std::cout << num_q1 << " qubits:" << std::endl;
+  for (const auto &circuit : circuit_names) {
+    int num_q = num_q1;
+    if (circuit == std::string("hhl")) {
+      if (num_q == 28) {
+        num_q = 4;
+      } else if (num_q == 29) {
+        num_q = 7;
+      } else if (num_q == 30) {
+        num_q = 9;
+      } else if (num_q == 31) {
+        num_q = 10;
+      } else {
+        continue;
+      }
+    }
+    auto seq = CircuitSeq::from_qasm_file(
+        &ctx, circuit_folder.string() +
+                  (std::string("/NWQBench/") + circuit + "_" +
+                   (circuit == std::string("hhl") ? "" : "n") +
+                   std::to_string(num_q) + ".qasm"));
+    int num_swap = seq->remove_swap_gates();
+    std::cout << circuit << ": " << num_swap << " swap gates removed."
+              << std::endl;
+    seq->to_qasm_file(&ctx, circuit_folder.string() +
+                                (std::string("/NWQBench/") + circuit + "_" +
+                                 (circuit == std::string("hhl") ? "" : "n") +
+                                 std::to_string(num_q) + "_no_swap.qasm"));
+  }
+}
+   */
   return 0;
 }


### PR DESCRIPTION
Previously the simple DP had both time and space complexity O(n^2) where n is the number of gates. This PR reduces the space complexity to O(n) by doing the DP in reversed order.

Also removed the randomized part in benchmark_dp and added some code for NWQBench.