### PR TITLE
[Simulator] Cache the kernel schedules

### DIFF
--- a/src/benchmark/dp.cpp
+++ b/src/benchmark/dp.cpp
@@ -46,7 +46,7 @@ int main() {
       /*shared_memory_total_qubits=*/10, /*shared_memory_cacheline_qubits=*/3);
   FILE *fout = fopen("../dp_result.csv", "w");
   constexpr bool run_nwq = false;
-  for (auto circuit : (run_nwq ? circuit_names_nwq : circuit_names)) {
+  for (const auto &circuit : (run_nwq ? circuit_names_nwq : circuit_names)) {
     fprintf(fout, "%s\n", circuit.c_str());
     std::cout << circuit << std::endl;
     for (int num_q : num_qubits) {
@@ -100,7 +100,10 @@ int main() {
         auto t1 = std::chrono::steady_clock::now();
         auto schedules = get_schedules(*seq, local_qubits, kernel_cost, &ctx,
                                        /*attach_single_qubit_gates=*/true,
-                                       /*use_simple_dp_times=*/1);
+                                       /*use_simple_dp_times=*/1,
+                                       /*cache_file_name_prefix=*/circuit +
+                                           std::to_string(num_q) + "_" +
+                                           std::to_string(local_q) + "_simple");
         KernelCostType total_cost = 0;
         for (auto &schedule : schedules) {
           // schedule.print_kernel_info();
@@ -111,7 +114,10 @@ int main() {
         auto t2 = std::chrono::steady_clock::now();
         schedules = get_schedules(*seq, local_qubits, kernel_cost, &ctx,
                                   /*attach_single_qubit_gates=*/true,
-                                  /*use_simple_dp_times=*/-1);
+                                  /*use_simple_dp_times=*/-1,
+                                  /*cache_file_name_prefix=*/circuit +
+                                      std::to_string(num_q) + "_" +
+                                      std::to_string(local_q) + "_max_weight");
         total_cost = 0;
         for (auto &schedule : schedules) {
           // schedule.print_kernel_info();
@@ -122,7 +128,10 @@ int main() {
         auto t5 = std::chrono::steady_clock::now();
         schedules = get_schedules(*seq, local_qubits, kernel_cost, &ctx,
                                   /*attach_single_qubit_gates=*/true,
-                                  /*use_simple_dp_times=*/0);
+                                  /*use_simple_dp_times=*/0,
+                                  /*cache_file_name_prefix=*/circuit +
+                                      std::to_string(num_q) + "_" +
+                                      std::to_string(local_q) + "_complicated");
         total_cost = 0;
         for (auto &schedule : schedules) {
           // schedule.print_kernel_info();

--- a/src/quartz/circuitseq/circuitgate.cpp
+++ b/src/quartz/circuitseq/circuitgate.cpp
@@ -190,7 +190,13 @@ std::string CircuitGate::to_qasm_style_string(Context *ctx,
         assert(ctx->param_has_value(input_wires[j]->index));
         std::ostringstream out;
         out.precision(param_precision);
-        out << std::fixed << ctx->get_param_value(input_wires[j]->index);
+        const auto &param_value = ctx->get_param_value(input_wires[j]->index);
+        if (param_value == 0) {
+          // optimization: if a parameter is 0, do not output that many digits
+          out << "0";
+        } else {
+          out << std::fixed << param_value;
+        }
         result += std::move(out).str();
         num_remaining_parameters--;
         if (num_remaining_parameters != 0) {

--- a/src/quartz/circuitseq/circuitseq.h
+++ b/src/quartz/circuitseq/circuitseq.h
@@ -122,8 +122,13 @@ class CircuitSeq {
   static std::unique_ptr<CircuitSeq> read_json(Context *ctx, std::istream &fin);
   static std::unique_ptr<CircuitSeq>
   from_qasm_file(Context *ctx, const std::string &filename);
+  static std::unique_ptr<CircuitSeq>
+  from_qasm_style_string(Context *ctx, const std::string &str);
+  std::string
+  to_qasm_style_string(Context *ctx,
+                       int param_precision = kDefaultQASMParamPrecision) const;
   bool to_qasm_file(Context *ctx, const std::string &filename,
-                    int param_precision = 15) const;
+                    int param_precision = kDefaultQASMParamPrecision) const;
 
   /**
    * Canonical representation is a sequence representation of a

--- a/src/quartz/simulator/schedule.h
+++ b/src/quartz/simulator/schedule.h
@@ -114,6 +114,9 @@ class Schedule {
    * @return The number of empty kernels removed.
    */
   int remove_empty_kernels(const KernelCost &kernel_cost);
+  static Schedule from_file(Context *ctx, const std::string &filename);
+  bool save_to_file(Context *ctx, const std::string &filename,
+                    int param_precision = 15) const;
 
   // The result simulation schedule. We will execute the kernels one by one,
   // and each kernel contains a sequence of gates.
@@ -150,17 +153,33 @@ class Schedule {
  * @param ctx The Context object.
  * @param attach_single_qubit_gates An optimization to reduce the running
  * time of this function. Requires the input circuit to be fully entangled.
+ * @param use_simple_dp_times Temporary. If this variable is 0,
+ * use the complicated DP algorithm. If this variable is positive, use
+ * the simple DP algorithm.
+ * @param cache_file_name_prefix If this variable is not empty,
+ * use the cached files if possible (in this case, no other variables are used),
+ * and compute the schedules and cache them into files otherwise.
  * @return The kernel schedule for each stage.
  */
 std::vector<Schedule>
 get_schedules(const CircuitSeq &sequence,
               const std::vector<std::vector<int>> &local_qubits,
               const KernelCost &kernel_cost, Context *ctx,
-              bool attach_single_qubit_gates, int use_simple_dp_times);
+              bool attach_single_qubit_gates, int use_simple_dp_times = 0,
+              const std::string &cache_file_name_prefix = "");
 
 class PythonInterpreter;
 std::vector<std::vector<int>>
 compute_local_qubits_with_ilp(const CircuitSeq &sequence, int num_local_qubits,
                               Context *ctx, PythonInterpreter *interpreter,
                               int answer_start_with = 1);
+
+/**
+ * Call the above two functions sequentially, use the cached files if possible.
+ */
+std::vector<Schedule> get_schedules_with_ilp(
+    const CircuitSeq &sequence, int num_local_qubits,
+    const KernelCost &kernel_cost, Context *ctx, PythonInterpreter *interpreter,
+    bool attach_single_qubit_gates, int use_simple_dp_times = 0,
+    const std::string &cache_file_name_prefix = "", int answer_start_with = 1);
 }  // namespace quartz

--- a/src/quartz/utils/string_utils.h
+++ b/src/quartz/utils/string_utils.h
@@ -1,0 +1,80 @@
+#pragma once
+
+#include <cctype>
+#include <sstream>
+#include <string>
+#include <vector>
+
+namespace quartz {
+template <typename T>
+std::string to_json_style_string(const std::vector<T> &vec) {
+  std::string result = "[";
+  result += std::to_string(vec.size());  // store the size for faster recovery
+  for (const auto &item : vec) {
+    result += ", ";
+    result += std::to_string(item);
+  }
+  result += "]";
+  return result;
+}
+
+/**
+ * Read a json array from a stringstream into a vector.
+ * @tparam T The type of the item in the vector.
+ * @param ss The stringstream with a json array at the beginning, created by
+ * to_json_style_string(vec) above.
+ * @param vec The returned vector. The original content is deleted.
+ * @return True iff the read is successful.
+ */
+template <typename T>
+bool read_json_style_vector(std::stringstream &ss, std::vector<T> &vec) {
+  char c;
+  while (ss >> c) {
+    if (c == '[') {
+      // start of a vector
+      break;
+    } else if (!std::isspace(c)) {
+      // not a vector, input corrupted
+      return false;
+    }
+  }
+  if (ss.eof()) {
+    return false;
+  }
+  int vec_size;
+  ss >> vec_size;
+  vec.reserve(vec_size);
+  vec.clear();
+  for (int i = 0; i < vec_size; i++) {
+    while (ss >> c) {
+      if (c == ',') {
+        // separation of two items
+        break;
+      } else if (!std::isspace(c)) {
+        // not a vector, input corrupted
+        return false;
+      }
+    }
+    if (ss.eof()) {
+      return false;
+    }
+    T item;
+    ss >> item;
+    vec.push_back(std::move(item));
+  }
+  while (ss >> c) {
+    if (c == ']') {
+      // end of a vector
+      break;
+    } else if (!std::isspace(c)) {
+      // not a vector, input corrupted
+      return false;
+    }
+  }
+  if (ss.eof()) {
+    return false;
+  }
+  return true;
+}
+
+}  // namespace quartz

--- a/src/quartz/utils/utils.h
+++ b/src/quartz/utils/utils.h
@@ -30,6 +30,8 @@ constexpr PhaseShiftIdType kNoPhaseShift = -1;
 constexpr bool kCheckPhaseShiftOfPiOver4 = true;
 constexpr int kCheckPhaseShiftOfPiOver4Index = 10000;  // not used now
 
+constexpr int kDefaultQASMParamPrecision = 15;
+
 struct PairHash {
  public:
   template <typename T, typename U>

--- a/src/test/test_simulation.cpp
+++ b/src/test/test_simulation.cpp
@@ -184,16 +184,11 @@ int main() {
 
       // fprintf(fout, "%d", num_q);
       for (int local_q : num_local_qubits) {
-        std::vector<std::vector<int>> local_qubits;
-        // int result =
-        // num_iterations_by_heuristics(seq.get(), local_q, local_qubits);
-        // fprintf(fout, " %d", result);
-        local_qubits =
-            compute_local_qubits_with_ilp(*seq, local_q, &ctx, &interpreter);
-        std::cout << local_qubits.size() << " stages." << std::endl;
-        auto schedules = get_schedules(*seq, local_qubits, kernel_cost, &ctx,
-                                       /*attach_single_qubit_gates=*/true,
-                                       /*use_simple_dp_times=*/100);
+        auto schedules = get_schedules_with_ilp(
+            *seq, local_q, kernel_cost, &ctx, &interpreter,
+            /*attach_single_qubit_gates=*/true,
+            /*use_simple_dp_times=*/10,
+            circuit + std::to_string(num_q) + "_" + std::to_string(local_q));
         for (auto &schedule : schedules) {
           schedule.print_kernel_info();
           // schedule.print_kernel_schedule();


### PR DESCRIPTION
Changes to the simulator:
- Cache the kernel schedules to avoid running DP multiple times for an unchanged circuit, adding functions `Schedule::from_file` and `Schedule::save_to_file` (`benchmark_dp` now caches the schedules)
- Add a function to run ILP and DP together to also avoid running ILP multiple times (`test_simulation` now calls this)
- Add functions `Kernel::to_qasm_style_string` and `Kernel::from_qasm_style_string` to serialize/deserialize kernels
- Wrap `Kernel::gates` with `std::unique_ptr` for better memory management

Changes in general parts:
- Add functions `CircuitSeq::to_qasm_style_string` and `CircuitSeq::from_qasm_style_string` to serialize/deserialize from QASM-style strings in addition to QASM files
- If a parameter is 0, output `0` instead of `0.000000000000000` into the QASM file
- Add a file `quartz/utils/string_utils.h` to serialize vectors
- Add a constant `constexpr int kDefaultQASMParamPrecision = 15;` in `quartz/utils/utils.h`

The cache file structure:
- If the file `cache_file_name_prefix + ".schedule"` exists, we have the schedule cached. This file stores a single number `num_stages`.
- For each `0 <= i < num_stages`, the file `cache_file_name_prefix + ".stage" + std::to_string(i) + ".schedule"` stores the schedule for the i-th stage. `Schedule::from_file(ctx, cache_file_name_prefix + ".stage" + std::to_string(i) + ".schedule")` reads the schedule from the file.