### PR TITLE
[Simulator] Verify schedule for small circuits and preserve order when attaching gates

### DIFF
--- a/src/quartz/circuitseq/circuitgate.cpp
+++ b/src/quartz/circuitseq/circuitgate.cpp
@@ -1,7 +1,8 @@
 #include "circuitgate.h"
 
-#include "circuitwire.h"
-#include "context/context.h"
+#include "quartz/circuitseq/circuitwire.h"
+#include "quartz/context/context.h"
+#include "quartz/utils/string_utils.h"
 
 #include <algorithm>
 #include <cassert>
@@ -128,12 +129,15 @@ std::string CircuitGate::to_string() const {
   std::string result;
   if (output_wires.size() == 1) {
     result += output_wires[0]->to_string();
-  } else if (output_wires.size() == 2) {
-    result += "[" + output_wires[0]->to_string();
-    result += ", " + output_wires[1]->to_string();
-    result += "]";
   } else {
-    assert(false && "A circuit gate should have 1 or 2 outputs.");
+    result += "[";
+    for (int i = 0; i < (int)output_wires.size(); i++) {
+      result += output_wires[i]->to_string();
+      if (i != (int)output_wires.size() - 1) {
+        result += ", ";
+      }
+    }
+    result += "]";
   }
   result += " = ";
   result += gate_type_name(gate->tp);
@@ -169,6 +173,7 @@ std::string CircuitGate::to_qasm_style_string(Context *ctx,
     if (!std::all_of(control_state.begin(), control_state.end(),
                      [](bool v) { return v; })) {
       // Not a simple controlled gate
+      result += "//ctrl\n";
       auto control_qubits = get_control_qubit_indices();
       for (int i = 0; i < (int)control_state.size(); i++) {
         if (!control_state[i]) {

--- a/src/quartz/context/context.cpp
+++ b/src/quartz/context/context.cpp
@@ -223,6 +223,10 @@ void Context::set_param_value(int id, const ParamType &param) {
   parameters_[id] = param;
 }
 
+std::vector<ParamType> Context::get_all_param_values() const {
+  return parameters_;
+}
+
 int Context::get_new_param_id(bool is_symbolic) {
   assert(is_parameter_symbolic_.size() == num_parameters_);
   is_parameter_symbolic_.push_back(is_symbolic);

--- a/src/quartz/context/context.h
+++ b/src/quartz/context/context.h
@@ -17,8 +17,8 @@ class CircuitSeq;
 class Context {
  public:
   explicit Context(const std::vector<GateType> &supported_gates);
-  Context(const std::vector<GateType> &supported_gates, const int num_qubits,
-          const int num_params);
+  Context(const std::vector<GateType> &supported_gates, int num_qubits,
+          int num_params);
   Gate *get_gate(GateType tp);
   Gate *get_general_controlled_gate(GateType tp,
                                     const std::vector<bool> &state);
@@ -31,13 +31,13 @@ class Context {
   const Vector &get_and_gen_input_dis(int num_qubits);
   const Vector &get_and_gen_hashing_dis(int num_qubits);
   std::vector<ParamType> get_and_gen_parameters(int num_params);
-  const Vector &get_generated_input_dis(int num_qubits) const;
-  const Vector &get_generated_hashing_dis(int num_qubits) const;
-  std::vector<ParamType> get_generated_parameters(int num_params) const;
-  std::vector<ParamType> get_all_generated_parameters() const;
+  [[nodiscard]] const Vector &get_generated_input_dis(int num_qubits) const;
+  [[nodiscard]] const Vector &get_generated_hashing_dis(int num_qubits) const;
+  [[nodiscard]] std::vector<ParamType> get_generated_parameters(int num_params) const;
+  [[nodiscard]] std::vector<ParamType> get_all_generated_parameters() const;
   size_t next_global_unique_id();
 
-  bool has_parameterized_gate() const;
+  [[nodiscard]] bool has_parameterized_gate() const;
 
   // A hacky function: set a generated parameter.
   void set_generated_parameter(int id, ParamType param);
@@ -49,8 +49,9 @@ class Context {
   bool get_possible_representative(const CircuitSeqHashType &hash_value,
                                    CircuitSeq *&representative) const;
 
-  ParamType get_param_value(int id) const;
+  [[nodiscard]] ParamType get_param_value(int id) const;
   void set_param_value(int id, const ParamType &param);
+  [[nodiscard]] std::vector<ParamType> get_all_param_values() const;
   // TODO: Use this function when generating symbolic parameters
   int get_new_param_id(bool is_symbolic);
   // TODO: This function should not be needed

--- a/src/quartz/context/context.h
+++ b/src/quartz/context/context.h
@@ -33,7 +33,8 @@ class Context {
   std::vector<ParamType> get_and_gen_parameters(int num_params);
   [[nodiscard]] const Vector &get_generated_input_dis(int num_qubits) const;
   [[nodiscard]] const Vector &get_generated_hashing_dis(int num_qubits) const;
-  [[nodiscard]] std::vector<ParamType> get_generated_parameters(int num_params) const;
+  [[nodiscard]] std::vector<ParamType>
+  get_generated_parameters(int num_params) const;
   [[nodiscard]] std::vector<ParamType> get_all_generated_parameters() const;
   size_t next_global_unique_id();
 

--- a/src/quartz/math/vector.cpp
+++ b/src/quartz/math/vector.cpp
@@ -78,8 +78,9 @@ Vector Vector::random_generate(int num_qubits, std::mt19937 *gen) {
     gen = &static_gen;
   }
   static std::uniform_int_distribution<int> dis_int(0, 1);
+  assert(num_qubits <= 30);
   Vector result(1 << num_qubits);
-  int remaining_numbers = (2 << num_qubits);
+  unsigned int remaining_numbers = (2u << num_qubits);
 
 #ifdef USE_ARBLIB
   constexpr slong kRandPrec = 64;

--- a/src/quartz/parser/qasm_parser.h
+++ b/src/quartz/parser/qasm_parser.h
@@ -88,9 +88,9 @@ bool QASMParser::load_qasm_stream(
     if (command == std::string("u")) {
       command = std::string("u3");
     }
-    if (command == "//") {
+    if (command.length() >= 2 && command.substr(0, 2) == "//") {
       continue;  // comment, ignore this line
-    } else if (command == "") {
+    } else if (command.empty()) {
       continue;  // empty line, ignore this line
     } else if (command == "OPENQASM" || command == "OpenQASM") {
       continue;  // header, ignore this line

--- a/src/quartz/simulator/schedule.h
+++ b/src/quartz/simulator/schedule.h
@@ -182,4 +182,18 @@ std::vector<Schedule> get_schedules_with_ilp(
     const KernelCost &kernel_cost, Context *ctx, PythonInterpreter *interpreter,
     bool attach_single_qubit_gates, int use_simple_dp_times = 0,
     const std::string &cache_file_name_prefix = "", int answer_start_with = 1);
+
+/**
+ * Verify the schedule by random testing an input state and running the
+ * simulation.
+ * Requires the sequence to have no more than 30 qubits.
+ * Requires an exponential amount of memory to the number of qubits (~48 GiB
+ * for 30 qubits).
+ * The time complexity is O(2^(number of qubits) * (number of gates)).
+ * @return True iff simulating the sequence itself and running the simulation
+ * on the schedules yield the same result for each input state tested.
+ */
+bool verify_schedule(Context *ctx, const CircuitSeq &sequence,
+                     const std::vector<Schedule> &schedules,
+                     int random_test_times = 1);
 }  // namespace quartz


### PR DESCRIPTION
Changes to the simulator:
- Add a function to verify the correctness of a schedule by random testing
- Preserve the order of single-qubit gates when attaching them to multi-qubit gates in the DP (bug fix)

Changes in general parts:
- Support printing gates (`CircuitGate::to_string()`) for any number of qubits (previously only supported <= 2 qubits)
- Add a comment `//ctrl` when printing circuits for restoring generalized controlled gates in the future
- Add a function `Context::get_all_param_values()` to get all input parameter values
- Add an assertion `num_qubits <= 30` in vector.cpp to avoid integer overflow