### PR TITLE
[gate] Support parsing general controlled gates

### DIFF
--- a/src/quartz/parser/qasm_parser.h
+++ b/src/quartz/parser/qasm_parser.h
@@ -67,8 +67,30 @@ bool QASMParser::load_qasm_stream(
   std::map<std::string, int> index_offset;
   std::unordered_map<ParamType, int> parameters;
   int num_total_params = context->get_num_parameters();
+  bool in_general_controlled_gate_block = false;
+  std::vector<bool> general_control_flipped_qubits;
+  int num_flipped_qubits;
 
   while (std::getline(qasm_stream, line, ';')) {
+    if (line.find("//ctrl") != std::string::npos) {
+      // Quartz's specific comment to enter a general control gate block
+      assert(!in_general_controlled_gate_block);
+      in_general_controlled_gate_block = true;
+      general_control_flipped_qubits.clear();
+      num_flipped_qubits = 0;
+    }
+    // Remove comments
+    auto comment_position = line.find("//");
+    while (comment_position != std::string::npos) {
+      auto newline_position = line.find('\n', comment_position + 2 /*"//"*/);
+      if (newline_position == std::string::npos) {
+        // remove until the end
+        line.resize(comment_position);
+        break;
+      }
+      line.replace(comment_position, newline_position - comment_position, "");
+      comment_position = line.find("//", comment_position);
+    }
     // Replace comma with space
     find_and_replace_all(line, ",", " ");
     // Replace parentheses for parameterized gate with space
@@ -88,9 +110,7 @@ bool QASMParser::load_qasm_stream(
     if (command == std::string("u")) {
       command = std::string("u3");
     }
-    if (command.length() >= 2 && command.substr(0, 2) == "//") {
-      continue;  // comment, ignore this line
-    } else if (command.empty()) {
+    if (command.empty()) {
       continue;  // empty line, ignore this line
     } else if (command == "OPENQASM" || command == "OpenQASM") {
       continue;  // header, ignore this line
@@ -177,21 +197,21 @@ bool QASMParser::load_qasm_stream(
             }
           }
         } else if (token.find("pi") != std::string::npos) {
-          if (token.find("(") != std::string::npos) {
-            assert(token.find("/") != std::string::npos);
-            auto left_parenthesis_pos = token.find("(");
+          if (token.find('(') != std::string::npos) {
+            assert(token.find('/') != std::string::npos);
+            auto left_parenthesis_pos = token.find('(');
             // 0.123/(2*pi)
-            p = std::stod(token.substr(0, token.find("/"))) / PI;
+            p = std::stod(token.substr(0, token.find('/'))) / PI;
             p /= std::stod(
                 token.substr(left_parenthesis_pos + 1,
-                             token.find("*") - left_parenthesis_pos - 1));
+                             token.find('*') - left_parenthesis_pos - 1));
           } else {
             // 0.123*pi
-            auto d = token.substr(0, token.find("*"));
+            auto d = token.substr(0, token.find('*'));
             p = std::stod(d) * PI;
-            if (token.find("/") != std::string::npos) {
+            if (token.find('/') != std::string::npos) {
               // 0.123*pi/2
-              p = p / std::stod(token.substr(token.find("/") + 1));
+              p = p / std::stod(token.substr(token.find('/') + 1));
             }
           }
         } else {
@@ -228,9 +248,49 @@ bool QASMParser::load_qasm_stream(
         }
         qubit_indices[i] = index_offset[name] + index;
       }
-      seq->add_gate(qubit_indices, param_indices, gate, nullptr);
+      if (in_general_controlled_gate_block) {
+        if (gate_type == GateType::x) {
+          // Flip a qubit.
+          if (qubit_indices[0] >= (int)general_control_flipped_qubits.size()) {
+            general_control_flipped_qubits.resize(qubit_indices[0] + 1);
+          }
+          if (general_control_flipped_qubits[qubit_indices[0]]) {
+            // Already flipped, now flip it back.
+            general_control_flipped_qubits[qubit_indices[0]] = false;
+            num_flipped_qubits--;
+            if (!num_flipped_qubits) {
+              // Exit this general controlled gate block.
+              in_general_controlled_gate_block = false;
+            }
+          } else {
+            num_flipped_qubits++;
+            general_control_flipped_qubits[qubit_indices[0]] = true;
+          }
+        } else if (gate->get_num_control_qubits() > 0) {
+          // The general controlled gate.
+          int num_control = gate->get_num_control_qubits();
+          assert(num_control <= (int)qubit_indices.size());
+          std::vector<bool> state(num_control, true);
+          for (int i = 0; i < num_control; i++) {
+            if (qubit_indices[i] < (int)general_control_flipped_qubits.size()) {
+              // If flipped, set to 0 (default is 1).
+              state[i] = !general_control_flipped_qubits[qubit_indices[i]];
+            }
+          }
+          auto general_controlled_gate =
+              context->get_general_controlled_gate(gate_type, state);
+          seq->add_gate(qubit_indices, param_indices, general_controlled_gate,
+                        nullptr);
+        } else {
+          std::cerr << "Unexpected gate " << command
+                    << " in general controlled gate block." << std::endl;
+          assert(false);
+        }
+      } else {
+        seq->add_gate(qubit_indices, param_indices, gate, nullptr);
+      }
     } else {
-      std::cout << "Unknown gate: " << command << std::endl;
+      std::cerr << "Unknown gate: " << command << std::endl;
       assert(false);
     }
   }


### PR DESCRIPTION
Close #105

Now we can read and write general controlled gates.

In OpenQASM 2 (the format we write to and read from):
```qasm
//ctrl
x q[5];
ccz q[5],q[6],q[8];
x q[5];
```
In `CircuitSeq::to_string()`:
```
[Q5, Q6, Q8] = ccz[01](Q5, Q6, Q8)
```

OpenQASM 3 equivalent _(not supported)_:
```qasm
negctrl @ ctrl @ z q[5],q[6],q[8];
```

Compare with common controlled gates:
In OpenQASM 2 (the format we write to and read from):
```qasm
ccz q[5],q[6],q[8];
```
In `CircuitSeq::to_string()`:
```
[Q5, Q6, Q8] = ccz(Q5, Q6, Q8)
```

OpenQASM 3 equivalent _(not supported)_:
```qasm
ctrl(2) @ z q[5],q[6],q[8];
```