### PR TITLE
[simulator] Disable attaching CX gates and fix a bug in reversed simple DP

### DIFF
--- a/src/benchmark/dp.cpp
+++ b/src/benchmark/dp.cpp
@@ -156,6 +156,7 @@ int main() {
         answer_start_with = ilp_result;
       }
       fprintf(fout, "\n");
+      fflush(fout);
     }
   }
   fclose(fout);


### PR DESCRIPTION
Changes to the simulator:
- Disable attaching CX/CCX gates to other gates (so we should not see warnings about them)
- Fix a bug causing infeasible shared-memory kernels in reversed simple DP
- Minor fixes to compiler warnings