### PR TITLE
[Simulator] Consider which qubits are local in simple DP and verify the schedule

### DIFF
--- a/src/benchmark/dp.cpp
+++ b/src/benchmark/dp.cpp
@@ -44,8 +44,9 @@ int main() {
           return 0.5;
       },
       /*shared_memory_total_qubits=*/10, /*shared_memory_cacheline_qubits=*/3);
-  std::vector<int> dp_t = {-5,  0,   2,   4,   10,  20,   50,   100, 200,
-                           300, 400, 500, 600, 800, 1000, 2000, 3000};
+  std::vector<int> dp_t = {-5,  0,   2,    4,    10,   16,   20,  32,
+                           50,  70,  100,  150,  200,  300,  400, 500,
+                           650, 800, 1000, 1500, 2000, 3000, 4000};
   FILE *fout = fopen("../dp_result.csv", "w");
   for (int run_nwq = 0; run_nwq <= 1; run_nwq++) {
     for (const auto &circuit : (run_nwq ? circuit_names_nwq : circuit_names)) {

--- a/src/benchmark/dp.cpp
+++ b/src/benchmark/dp.cpp
@@ -125,6 +125,7 @@ int main() {
             std::cout << "Stage " << i << ": layout ";
             schedules[i].print_qubit_layout(global_q);
           }
+          verify_schedule(&ctx, *seq, schedules, /*random_test_times=*/0);
           std::vector<double> ts;
           for (int t : dp_t) {
             auto t2 = std::chrono::steady_clock::now();

--- a/src/quartz/gate/general_controlled_gate.h
+++ b/src/quartz/gate/general_controlled_gate.h
@@ -51,31 +51,25 @@ class GeneralControlledGate : public Gate {
     // return result;
     return controlled_gate_->get_matrix(params);
   }
-  bool is_symmetric() const override {
-    if (std::find(state_.begin(), state_.end(), false) == state_.end()) {
-      // Same as the original gate
-      return controlled_gate_->is_symmetric();
-    }
-    // Otherwise, no guarantee
-    return false;
+  [[nodiscard]] bool is_symmetric() const override {
+    // Same as the original gate
+    return controlled_gate_->is_symmetric();
   }
-  bool is_sparse() const override {
+  [[nodiscard]] bool is_sparse() const override {
     // Same as the original gate
     return controlled_gate_->is_sparse();
   }
-  bool is_diagonal() const override {
-    if (std::find(state_.begin(), state_.end(), false) == state_.end()) {
-      // Same as the original gate
-      return controlled_gate_->is_diagonal();
-    }
-    // Otherwise, no guarantee
-    return false;
+  [[nodiscard]] bool is_diagonal() const override {
+    // Same as the original gate
+    return controlled_gate_->is_diagonal();
   }
-  int get_num_control_qubits() const override {
+  [[nodiscard]] int get_num_control_qubits() const override {
     // Same as the original gate
     return controlled_gate_->get_num_control_qubits();
   }
-  std::vector<bool> get_control_state() const override { return state_; }
+  [[nodiscard]] std::vector<bool> get_control_state() const override {
+    return state_;
+  }
   Gate *controlled_gate_;
   std::vector<bool> state_;
 };

--- a/src/quartz/simulator/kernel.cpp
+++ b/src/quartz/simulator/kernel.cpp
@@ -158,15 +158,28 @@ bool Kernel::add_gate(CircuitGate *gate,
 
 bool Kernel::verify(const std::function<bool(int)> &is_local_qubit) const {
   for (auto &gate : gates->gates) {
-    auto gate_qubits = (type == KernelType::shared_memory
-                            ? gate->get_non_insular_qubit_indices()
-                            : gate->get_qubit_indices());
+    const auto &gate_qubits = (type == KernelType::shared_memory
+                                   ? gate->get_non_insular_qubit_indices()
+                                   : gate->get_qubit_indices());
+    const auto &insular_qubits = gate->get_insular_qubit_indices();
     for (auto qubit : gate_qubits) {
       if (is_local_qubit(qubit) &&
           std::find(qubits.begin(), qubits.end(), qubit) == qubits.end()) {
         std::cerr << "Qubit " << qubit << " of gate " << gate->to_string()
-                  << " cannot be executed." << std::endl;
+                  << " not active in kernel." << std::endl;
         return false;
+      }
+      if (!is_local_qubit(qubit)) {
+        if (type == KernelType::shared_memory) {
+          std::cerr << "Non-insular non-local qubit " << qubit
+                    << " detected in a shared-memory kernel." << std::endl;
+          return false;
+        } else if (std::find(insular_qubits.begin(), insular_qubits.end(),
+                             qubit) == insular_qubits.end()) {
+          std::cerr << "Non-insular non-local qubit " << qubit
+                    << " detected in a fusion kernel." << std::endl;
+          return false;
+        }
       }
     }
   }

--- a/src/quartz/simulator/kernel.h
+++ b/src/quartz/simulator/kernel.h
@@ -60,7 +60,17 @@ class Kernel {
    * @return True iff the gate is successfully added.
    */
   bool add_gate(CircuitGate *gate,
+                const std::function<bool(int)> &is_local_qubit,
                 const std::vector<int> &customized_non_insular_qubits = {});
+
+  /**
+   * Verify if the kernel is executable.
+   * @return True iff the qubits of each gate are in the |qubits| set
+   * if this is a fusion kernel, or iff the non-insular qubits of each gate
+   * are in the |qubits| set if this is a shared-memory kernel.
+   */
+  [[nodiscard]] bool
+  verify(const std::function<bool(int)> &is_local_qubit) const;
 
   std::unique_ptr<CircuitSeq> gates;
   std::vector<int> qubits;

--- a/src/quartz/simulator/kernel.h
+++ b/src/quartz/simulator/kernel.h
@@ -53,6 +53,8 @@ class Kernel {
   /**
    * Add a gate and update the |qubits| set.
    * @param gate The gate to be added, calling |CircuitGate::add_gate(gate)|.
+   * @param is_local_qubit An oracle to return if a qubit is local, assumed to
+   * run in constant time.
    * @param customized_non_insular_qubits Sometimes we may want to customize
    * the set of non-insular qubits in a shared-memory kernel.
    * If this variable is not empty and if the kernel type is shared-memory,
@@ -65,9 +67,12 @@ class Kernel {
 
   /**
    * Verify if the kernel is executable.
-   * @return True iff the qubits of each gate are in the |qubits| set
-   * if this is a fusion kernel, or iff the non-insular qubits of each gate
-   * are in the |qubits| set if this is a shared-memory kernel.
+   * @param is_local_qubit An oracle to return if a qubit is local, assumed to
+   * run in constant time.
+   * @return True iff all non-insular qubits are local and:
+   * the qubits of each gate are in the |qubits| set if this is a fusion kernel,
+   * or the non-insular qubits of each gate are in the |qubits| set if this is a
+   * shared-memory kernel.
    */
   [[nodiscard]] bool
   verify(const std::function<bool(int)> &is_local_qubit) const;

--- a/src/quartz/simulator/schedule.h
+++ b/src/quartz/simulator/schedule.h
@@ -81,6 +81,8 @@ class Schedule {
    * Compute the schedule using a simple quadratic dynamic programming
    * algorithm. The memory complexity is also quadratic.
    * @param kernel_cost The cost function of kernels.
+   * @param is_local_qubit An oracle to return if a qubit is local, assumed to
+   * run in constant time.
    * @param non_insular_qubit_indices The set of non-insular qubit indices
    * for each gate, if any of them should be considered differently from
    * what we would have computed from the gate itself.

--- a/src/quartz/simulator/schedule.h
+++ b/src/quartz/simulator/schedule.h
@@ -92,6 +92,7 @@ class Schedule {
    */
   bool compute_kernel_schedule_simple(
       const KernelCost &kernel_cost,
+      const std::function<bool(int)> &is_local_qubit,
       const std::vector<std::vector<int>> &non_insular_qubit_indices = {},
       const std::vector<KernelCostType> &shared_memory_gate_costs = {});
 
@@ -101,16 +102,19 @@ class Schedule {
    */
   bool compute_kernel_schedule_simple_reversed(
       const KernelCost &kernel_cost,
+      const std::function<bool(int)> &is_local_qubit,
       const std::vector<std::vector<int>> &non_insular_qubit_indices = {},
       const std::vector<KernelCostType> &shared_memory_gate_costs = {});
 
   bool compute_kernel_schedule_simple_repeat(
       int repeat, const KernelCost &kernel_cost,
+      const std::function<bool(int)> &is_local_qubit,
       const std::vector<std::vector<int>> &non_insular_qubit_indices = {},
       const std::vector<KernelCostType> &shared_memory_gate_costs = {});
 
-  bool compute_kernel_schedule_greedy_pack_fusion(const KernelCost &kernel_cost,
-                                                  int num_qubits_to_pack);
+  bool compute_kernel_schedule_greedy_pack_fusion(
+      const KernelCost &kernel_cost,
+      const std::function<bool(int)> &is_local_qubit, int num_qubits_to_pack);
 
   [[nodiscard]] int get_num_kernels() const;
   void print_kernel_info() const;
@@ -228,12 +232,12 @@ std::vector<Schedule> get_schedules_with_ilp(
     const std::string &cache_file_name_prefix = "", int answer_start_with = 1);
 
 /**
- * Verify the schedule by random testing an input state and running the
- * simulation.
- * Requires the sequence to have no more than 30 qubits.
- * Requires an exponential amount of memory to the number of qubits (~48 GiB
- * for 30 qubits).
- * The time complexity is O(2^(number of qubits) * (number of gates)).
+ * Verify the schedule by checking the well-formedness of each kernel and then
+ * random testing an input state and running the simulation.
+ * If |random_test_times| > 0:
+ * Requires the sequence to have no more than 30 qubits. Requires an exponential
+ * amount of memory to the number of qubits (~48 GiB for 30 qubits). The time
+ * complexity is O(2^(number of qubits) * (number of gates)).
  * @return True iff simulating the sequence itself and running the simulation
  * on the schedules yield the same result for each input state tested.
  */


### PR DESCRIPTION
Changes to the simulator:
- Track which qubits are local in the simple DP, do not add non-local qubits to kernels
- Verify the schedule to be executable in benchmark_dp
- Added more data points in benchmark_dp

Changes in general:
- Generalized controlled gates now take the underlying controlled gate's `is_symmetric()` and `is_diagonal()` directly. I believe changing control indices will not affect these two properties.