### PR TITLE
[simulator] Fix a bug of attaching to previous stages incorrectly

### DIFF
--- a/src/test/test_simulation.cpp
+++ b/src/test/test_simulation.cpp
@@ -189,7 +189,7 @@ int main() {
             get_schedules_with_ilp(*seq, local_q, std::min(2, num_q - local_q),
                                    kernel_cost, &ctx, &interpreter,
                                    /*attach_single_qubit_gates=*/true,
-                                   /*use_simple_dp_times=*/0, "tmp");
+                                   /*max_num_dp_states=*/500, "tmp");
         for (auto &schedule : schedules) {
           schedule.print_kernel_info();
           // schedule.print_kernel_schedule();


### PR DESCRIPTION
When we attach single-qubit gates to previous stages, we must make sure that they are still "single-qubit" in these stages. This PR fixes the bug of attaching gates that are single-qubit in this stage but multi-qubit in some previous stages because some global qubits are local in the previous stage.