### PR TITLE
[bug] Fix test_optimize and CircuitSeq::read_json

### DIFF
--- a/src/quartz/circuitseq/circuitseq.cpp
+++ b/src/quartz/circuitseq/circuitseq.cpp
@@ -816,9 +816,9 @@ std::unique_ptr<CircuitSeq> CircuitSeq::read_json(Context *ctx,
         break;
       }
     }
+    fin.ignore(std::numeric_limits<std::streamsize>::max(), ']');
   }
 
-  fin.ignore(std::numeric_limits<std::streamsize>::max(), ']');
   fin.ignore(std::numeric_limits<std::streamsize>::max(), ',');
 
   auto result = std::make_unique<CircuitSeq>(num_qubits);

--- a/src/test/test_optimize.cpp
+++ b/src/test/test_optimize.cpp
@@ -6,7 +6,8 @@ using namespace quartz;
 
 int main() {
   Context ctx({GateType::input_qubit, GateType::input_param, GateType::cx,
-               GateType::h, GateType::rz, GateType::x, GateType::add});
+               GateType::h, GateType::rz, GateType::x, GateType::add},
+              /*num_qubits=*/3, /*num_input_symbolic_params=*/2);
 
   auto graph = Graph::from_qasm_file(
       &ctx, "experiment/circs/nam_circs/barenco_tof_3.qasm");


### PR DESCRIPTION
Fix a bug caused by the Json format change in #159 and also a place missing the parameter specification when constructing the context.