### PR TITLE
[bug] Shift the context when applying xfers

### DIFF
--- a/src/benchmark/nam_middle_circuits.cpp
+++ b/src/benchmark/nam_middle_circuits.cpp
@@ -28,7 +28,7 @@ void benchmark_nam(const std::string &circuit_name) {
                   &param_info);
   auto union_ctx = union_contexts(&src_ctx, &dst_ctx);
 
-  auto xfer_pair = GraphXfer::ccz_cx_rz_xfer(&union_ctx);
+  auto xfer_pair = GraphXfer::ccz_cx_rz_xfer(&src_ctx, &dst_ctx, &union_ctx);
   // Load qasm file
   QASMParser qasm_parser(&src_ctx);
   CircuitSeq *dag = nullptr;

--- a/src/benchmark/nam_small_circuits.cpp
+++ b/src/benchmark/nam_small_circuits.cpp
@@ -28,7 +28,7 @@ void benchmark_nam(const std::string &circuit_name) {
                   &param_info);
   auto union_ctx = union_contexts(&src_ctx, &dst_ctx);
 
-  auto xfer_pair = GraphXfer::ccz_cx_rz_xfer(&union_ctx);
+  auto xfer_pair = GraphXfer::ccz_cx_rz_xfer(&src_ctx, &dst_ctx, &union_ctx);
   // Load qasm file
   QASMParser qasm_parser(&src_ctx);
   CircuitSeq *dag = nullptr;

--- a/src/quartz/context/context.cpp
+++ b/src/quartz/context/context.cpp
@@ -420,10 +420,10 @@ bool Context::has_parameterized_gate() const {
 Context union_contexts(Context *ctx_0, Context *ctx_1) {
   assert(ctx_0->get_param_info() == ctx_1->get_param_info());
   std::vector<GateType> union_vector;
-  std::set<GateType> gate_set_0(ctx_0->get_supported_gates().begin(),
-                                ctx_0->get_supported_gates().end());
-  std::set<GateType> gate_set_1(ctx_1->get_supported_gates().begin(),
-                                ctx_1->get_supported_gates().end());
+  const auto &ctx_0_gates = ctx_0->get_supported_gates();
+  const auto &ctx_1_gates = ctx_1->get_supported_gates();
+  std::set<GateType> gate_set_0(ctx_0_gates.begin(), ctx_0_gates.end());
+  std::set<GateType> gate_set_1(ctx_1_gates.begin(), ctx_1_gates.end());
   for (auto tp : gate_set_0)
     union_vector.push_back(tp);
   for (auto tp : gate_set_1) {

--- a/src/quartz/parser/qasm_parser.h
+++ b/src/quartz/parser/qasm_parser.h
@@ -160,7 +160,6 @@ bool QASMParser::load_qasm_stream(
       int num_params = ctx_->get_gate(gate_type)->num_parameters;
       std::vector<int> qubit_indices(num_qubits);
       std::vector<int> param_indices(num_params);
-      std::cout << "num_param " << num_params << std::endl;
       for (int i = 0; i < num_params; ++i) {
         assert(ss.good());
         std::string token;

--- a/src/quartz/tasograph/substitution.h
+++ b/src/quartz/tasograph/substitution.h
@@ -79,9 +79,9 @@ class GraphCompare {
 
 class GraphXfer {
  public:
-  GraphXfer(Context *_context);
-  GraphXfer(Context *_context, const CircuitSeq *src_graph,
-            const CircuitSeq *dst_graph);
+  GraphXfer(Context *src_ctx, Context *dst_ctx, Context *union_ctx);
+  GraphXfer(Context *src_ctx, Context *dst_ctx, Context *union_ctx,
+            const CircuitSeq *src_graph, const CircuitSeq *dst_graph);
   bool src_graph_connected(CircuitSeq *src_graph);
   TensorX new_tensor(void);
   bool is_input_qubit(const OpX *opx, int idx) const;
@@ -115,15 +115,22 @@ class GraphXfer {
   static GraphXfer *create_GraphXfer_from_qasm_str(Context *_context,
                                                    const std::string &src_str,
                                                    const std::string &dst_str);
-  static GraphXfer *create_single_gate_GraphXfer(Context *union_ctx,
+  static GraphXfer *create_single_gate_GraphXfer(Context *src_ctx,
+                                                 Context *dst_ctx,
+                                                 Context *union_ctx,
                                                  Command src_cmd,
                                                  std::vector<Command> dst_cmds);
-  static std::pair<GraphXfer *, GraphXfer *> ccz_cx_rz_xfer(Context *ctx);
-  static std::pair<GraphXfer *, GraphXfer *> ccz_cx_u1_xfer(Context *ctx);
-  static std::pair<GraphXfer *, GraphXfer *> ccz_cx_t_xfer(Context *ctx);
+  static std::pair<GraphXfer *, GraphXfer *>
+  ccz_cx_rz_xfer(Context *src_ctx, Context *dst_ctx, Context *union_ctx);
+  static std::pair<GraphXfer *, GraphXfer *>
+  ccz_cx_u1_xfer(Context *src_ctx, Context *dst_ctx, Context *union_ctx);
+  static std::pair<GraphXfer *, GraphXfer *>
+  ccz_cx_t_xfer(Context *src_ctx, Context *dst_ctx, Context *union_ctx);
 
  public:
-  Context *context;
+  Context *src_ctx_;
+  Context *dst_ctx_;
+  Context *union_ctx_;
   int tensorId;
   std::unordered_map<Op, OpX *, OpHash> mappedOps;
   std::unordered_map<int, std::pair<Op, int>> mappedInputs;

--- a/src/quartz/tasograph/tasograph.cpp
+++ b/src/quartz/tasograph/tasograph.cpp
@@ -445,8 +445,8 @@ std::shared_ptr<Graph> Graph::context_shift(Context *src_ctx, Context *dst_ctx,
       assert(
           rule_parser->find_convert_commands(dst_ctx, gate_tp, src_cmd, cmds));
 
-      tp_2_xfer[gate_tp] =
-          GraphXfer::create_single_gate_GraphXfer(src_ctx, dst_ctx, union_ctx, src_cmd, cmds);
+      tp_2_xfer[gate_tp] = GraphXfer::create_single_gate_GraphXfer(
+          src_ctx, dst_ctx, union_ctx, src_cmd, cmds);
     }
   }
   std::shared_ptr<Graph> src_graph(new Graph(*this));

--- a/src/quartz/tasograph/tasograph.cpp
+++ b/src/quartz/tasograph/tasograph.cpp
@@ -446,7 +446,7 @@ std::shared_ptr<Graph> Graph::context_shift(Context *src_ctx, Context *dst_ctx,
           rule_parser->find_convert_commands(dst_ctx, gate_tp, src_cmd, cmds));
 
       tp_2_xfer[gate_tp] =
-          GraphXfer::create_single_gate_GraphXfer(union_ctx, src_cmd, cmds);
+          GraphXfer::create_single_gate_GraphXfer(src_ctx, dst_ctx, union_ctx, src_cmd, cmds);
     }
   }
   std::shared_ptr<Graph> src_graph(new Graph(*this));
@@ -457,6 +457,7 @@ std::shared_ptr<Graph> Graph::context_shift(Context *src_ctx, Context *dst_ctx,
       src_graph = dst_graph;
     }
   }
+  src_graph->context = dst_ctx;
   return src_graph;
 }
 
@@ -720,14 +721,15 @@ void Graph::constant_and_rotation_elimination() {
           if (result < 0)
             result += 2 * PI;
 
-          assert(outEdges[op].size() == 1);
-          auto output_dst_op = (*outEdges[op].begin()).dstOp;
-          auto output_dst_idx = (*outEdges[op].begin()).dstIdx;
-          remove_node(op);
-
           Op merged_op(context->next_global_unique_id(),
                        context->get_gate(GateType::input_param));
-          add_edge(merged_op, output_dst_op, 0, output_dst_idx);
+          int srcIdx = 0;
+          for (auto &outEdge : outEdges[op]) {
+            auto output_dst_op = outEdge.dstOp;
+            auto output_dst_idx = outEdge.dstIdx;
+            add_edge(merged_op, output_dst_op, srcIdx++, output_dst_idx);
+          }
+          remove_node(op);
           param_idx[merged_op] = context->get_new_param_id(result);
         } else if (op.ptr->tp == GateType::neg) {
           ParamType param = 0, result = 0;
@@ -982,6 +984,8 @@ void Graph::rotation_merging(GateType target_rotation) {
       pos_to_qubits[Pos(it.first, 0)] = qubit_idx;
     } else if (it.first.ptr->tp == GateType::input_param) {
       todos.push(it.first);
+      assert(param_idx.find(it.first) != param_idx.end());
+      assert(context->param_has_value(param_idx[it.first]));
     }
   }
 
@@ -1120,7 +1124,6 @@ void Graph::rotation_merging(GateType target_rotation) {
             //           << pos.op.guid << ")" << std::endl;
           }
         }
-        std::cout << __LINE__ << std::endl;
 
         auto op = first.op;
         auto in_edges = inEdges[op];
@@ -2086,7 +2089,7 @@ Graph::optimize(const std::vector<GraphXfer *> &xfers, double cost_upper_bound,
 std::shared_ptr<Graph> Graph::ccz_flip_t(Context *ctx) {
   // Transform ccz to t, an naive solution
   // Simply 1 normal 1 inverse
-  auto xfers = GraphXfer::ccz_cx_t_xfer(ctx);
+  auto xfers = GraphXfer::ccz_cx_t_xfer(ctx, ctx, ctx);
   Graph *graph = this;
   bool flip = false;
   while (true) {
@@ -2112,11 +2115,13 @@ std::shared_ptr<Graph> Graph::toffoli_flip_greedy(GateType target_rotation,
                                                   GraphXfer *xfer,
                                                   GraphXfer *inverse_xfer) {
   std::shared_ptr<Graph> temp_graph(new Graph(*this));
+  temp_graph->context = xfer->union_ctx_;
   while (true) {
     auto new_graph_0 = xfer->run_1_time(0, temp_graph.get());
     auto new_graph_1 = inverse_xfer->run_1_time(0, temp_graph.get());
     if (new_graph_0.get() == nullptr) {
       assert(new_graph_1.get() == nullptr);
+      temp_graph->context = xfer->dst_ctx_;
       return temp_graph;
     }
     new_graph_0->rotation_merging(target_rotation);
@@ -2225,7 +2230,7 @@ Graph::toffoli_flip_by_instruction(GateType target_rotation, GraphXfer *xfer,
 }
 
 std::shared_ptr<Graph> Graph::ccz_flip_greedy_rz() {
-  auto xfer_pair = GraphXfer::ccz_cx_rz_xfer(context);
+  auto xfer_pair = GraphXfer::ccz_cx_rz_xfer(context, context, context);
   std::vector<int> trace;
   toffoli_flip_greedy_with_trace(GateType::rz, xfer_pair.first,
                                  xfer_pair.second, trace);

--- a/src/test/test_generator.cpp
+++ b/src/test/test_generator.cpp
@@ -24,7 +24,7 @@ int main() {
         first_dag = dag.get();
         is_first = false;
       } else {
-        GraphXfer xfer(&ctx, first_dag, dag.get());
+        GraphXfer xfer(&ctx, &ctx, &ctx, first_dag, dag.get());
       }
     }
   }

--- a/src/test/test_ibmq.cpp
+++ b/src/test/test_ibmq.cpp
@@ -47,7 +47,7 @@ int main(int argc, char **argv) {
   auto union_ctx = union_contexts(&src_ctx, &dst_ctx);
 
   // Construct GraphXfers for toffoli flip
-  auto xfer_pair = GraphXfer::ccz_cx_u1_xfer(&union_ctx);
+  auto xfer_pair = GraphXfer::ccz_cx_u1_xfer(&src_ctx, &dst_ctx, &union_ctx);
   // Load qasm file
   QASMParser qasm_parser(&src_ctx);
   CircuitSeq *dag = nullptr;

--- a/src/test/test_ibmq_td_disabled.cpp
+++ b/src/test/test_ibmq_td_disabled.cpp
@@ -36,7 +36,7 @@ int main(int argc, char **argv) {
   auto union_ctx = union_contexts(&src_ctx, &dst_ctx);
 
   // Construct GraphXfers for toffoli flip
-  auto xfer_pair = GraphXfer::ccz_cx_u1_xfer(&union_ctx);
+  auto xfer_pair = GraphXfer::ccz_cx_u1_xfer(&src_ctx, &dst_ctx, &union_ctx);
   // Load qasm file
   QASMParser qasm_parser(&src_ctx);
   CircuitSeq *dag = nullptr;

--- a/src/test/test_nam.cpp
+++ b/src/test/test_nam.cpp
@@ -47,7 +47,7 @@ int main(int argc, char **argv) {
                   &param_info);
   auto union_ctx = union_contexts(&src_ctx, &dst_ctx);
 
-  auto xfer_pair = GraphXfer::ccz_cx_rz_xfer(&union_ctx);
+  auto xfer_pair = GraphXfer::ccz_cx_rz_xfer(&src_ctx, &dst_ctx, &union_ctx);
   // Load qasm file
   QASMParser qasm_parser(&src_ctx);
   CircuitSeq *dag = nullptr;

--- a/src/test/test_nam_td_disabled.cpp
+++ b/src/test/test_nam_td_disabled.cpp
@@ -36,7 +36,7 @@ int main(int argc, char **argv) {
                   &param_info);
   auto union_ctx = union_contexts(&src_ctx, &dst_ctx);
 
-  auto xfer_pair = GraphXfer::ccz_cx_rz_xfer(&union_ctx);
+  auto xfer_pair = GraphXfer::ccz_cx_rz_xfer(&src_ctx, &dst_ctx, &union_ctx);
   // Load qasm file
   QASMParser qasm_parser(&src_ctx);
   CircuitSeq *dag = nullptr;

--- a/src/test/test_quartz.cpp
+++ b/src/test/test_quartz.cpp
@@ -57,7 +57,7 @@ int main(int argc, char **argv) {
   // Use this for voqc gate set(h, rz, x, cx)
   //   auto xfer_pair = TASOGraph::GraphXfer::ccz_cx_rz_xfer(&union_ctx);
   // Use this for ibmq gate set(u1, u2, u3, cx)
-  auto xfer_pair = GraphXfer::ccz_cx_rz_xfer(&union_ctx);
+  auto xfer_pair = GraphXfer::ccz_cx_rz_xfer(&src_ctx, &dst_ctx, &union_ctx);
   // Load qasm file
   QASMParser qasm_parser(&src_ctx);
   CircuitSeq *dag = nullptr;

--- a/src/test/test_rigetti.cpp
+++ b/src/test/test_rigetti.cpp
@@ -48,7 +48,7 @@ int main(int argc, char **argv) {
   auto union_ctx = union_contexts(&src_ctx, &dst_ctx);
 
   // Construct GraphXfers for toffoli flip
-  auto xfer_pair = GraphXfer::ccz_cx_rz_xfer(&union_ctx);
+  auto xfer_pair = GraphXfer::ccz_cx_rz_xfer(&src_ctx, &dst_ctx, &union_ctx);
   // Load qasm file
   QASMParser qasm_parser(&src_ctx);
   CircuitSeq *dag = nullptr;

--- a/src/test/test_rigetti_td_disabled.cpp
+++ b/src/test/test_rigetti_td_disabled.cpp
@@ -38,7 +38,7 @@ int main(int argc, char **argv) {
   auto union_ctx = union_contexts(&src_ctx, &dst_ctx);
 
   // Construct GraphXfers for toffoli flip
-  auto xfer_pair = GraphXfer::ccz_cx_rz_xfer(&union_ctx);
+  auto xfer_pair = GraphXfer::ccz_cx_rz_xfer(&src_ctx, &dst_ctx, &union_ctx);
   // Load qasm file
   QASMParser qasm_parser(&src_ctx);
   CircuitSeq *dag = nullptr;


### PR DESCRIPTION
Now each `GraphXfer` object stores `src_ctx, dst_ctx, union_ctx` so that it can transform a circuit from one context to another.

This PR also allows each parameter to be used multiple times in rotation merging.

It also removes some debug outputs introduced in previous PRs.
