### PR TITLE
[Optimizer] Change the timeout type from int to double

### DIFF
--- a/src/quartz/tasograph/tasograph.cpp
+++ b/src/quartz/tasograph/tasograph.cpp
@@ -1895,13 +1895,13 @@ std::shared_ptr<Graph> Graph::optimize_legacy(
   //   }
   bestGraph->constant_and_rotation_elimination();
   return bestGraph;
-}  // namespace quartz
+}
 
 std::shared_ptr<Graph>
 Graph::optimize(Context *ctx, const std::string &equiv_file_name,
                 const std::string &circuit_name, bool print_message,
                 std::function<float(Graph *)> cost_function,
-                double cost_upper_bound, int timeout) {
+                double cost_upper_bound, double timeout) {
   if (cost_function == nullptr) {
     cost_function = [](Graph *graph) { return graph->total_cost(); };
   }
@@ -1964,7 +1964,7 @@ std::shared_ptr<Graph>
 Graph::optimize(const std::vector<GraphXfer *> &xfers, double cost_upper_bound,
                 const std::string &circuit_name,
                 const std::string &log_file_name, bool print_message,
-                std::function<float(Graph *)> cost_function, int timeout) {
+                std::function<float(Graph *)> cost_function, double timeout) {
   if (cost_function == nullptr) {
     cost_function = [](Graph *graph) { return graph->total_cost(); };
   }
@@ -2041,8 +2041,8 @@ Graph::optimize(const std::vector<GraphXfer *> &xfers, double cost_upper_bound,
         auto new_graph =
             graph->apply_xfer(xfer, node, context->has_parameterized_gate());
         auto end = std::chrono::steady_clock::now();
-        if ((int)std::chrono::duration_cast<std::chrono::milliseconds>(end -
-                                                                       start)
+        if ((double)std::chrono::duration_cast<std::chrono::milliseconds>(end -
+                                                                          start)
                     .count() /
                 1000.0 >
             timeout) {

--- a/src/quartz/tasograph/tasograph.h
+++ b/src/quartz/tasograph/tasograph.h
@@ -240,7 +240,7 @@ class Graph {
            const std::string &circuit_name, bool print_message,
            std::function<float(Graph *)> cost_function = nullptr,
            double cost_upper_bound = -1 /*default = current cost * 1.05*/,
-           int timeout = 3600 /*1 hour*/);
+           double timeout = 3600 /*1 hour*/);
   /**
    * Optimize this circuit.
    * @param xfers The circuit transformations.
@@ -258,7 +258,7 @@ class Graph {
            const std::string &circuit_name, const std::string &log_file_name,
            bool print_message,
            std::function<float(Graph *)> cost_function = nullptr,
-           int timeout = 3600 /*1 hour*/);
+           double timeout = 3600 /*1 hour*/);
   void constant_and_rotation_elimination();
   void rotation_merging(GateType target_rotation);
   std::string to_qasm(bool print_result = false, bool print_id = false) const;


### PR DESCRIPTION
So that we can set timeout values that are not multiples of 1s.

Also removes an incorrect `// namespace quartz` comment.