### PR TITLE
[Generator] Use row representation in RepGen

### DIFF
--- a/src/quartz/circuitseq/circuitseq.h
+++ b/src/quartz/circuitseq/circuitseq.h
@@ -29,6 +29,14 @@ class CircuitSeq {
    */
   [[nodiscard]] bool fully_equivalent(const CircuitSeq &other) const;
   /**
+   * Compare if two circuits are topologically equivalent.
+   * X(Q0) X(Q1) and X(Q1) X(Q0) are topologically equivalent but not
+   * fully equivalent.
+   * @param other The other circuit sequence to be compared.
+   * @return True iff two circuit sequences are topologically equivalent.
+   */
+  [[nodiscard]] bool topologically_equivalent(const CircuitSeq &other) const;
+  /**
    * Compute the hash value and compare if two circuit sequences are fully
    * equivalent including the hash value.
    * @param ctx The context to compute the hash value.
@@ -99,7 +107,13 @@ class CircuitSeq {
 
   /**
    * Remove a quantum gate.
-   * @param circuit_gate the gate to be removed.
+   * @param gate_position The position of the gate to be removed (0-indexed).
+   * @return True iff the removal is successful.
+   */
+  bool remove_gate(int gate_position);
+  /**
+   * Remove a quantum gate.
+   * @param circuit_gate The gate to be removed.
    * @return True iff the removal is successful.
    */
   bool remove_gate(CircuitGate *circuit_gate);
@@ -281,11 +295,23 @@ class CircuitSeq {
    */
   std::unique_ptr<CircuitSeq> get_ccz_to_cx_rz(Context *ctx) const;
 
-  // Returns quantum gates which do not topologically depend on any other
-  // quantum gates.
+  /**
+   * Returns quantum gates which do not topologically depend on any other
+   * quantum gates.
+   * @return The pointers to the first quantum gates.
+   */
   [[nodiscard]] std::vector<CircuitGate *> first_quantum_gates() const;
-  // Returns quantum gates which can appear at last in some topological
-  // order of the CircuitSeq.
+  /**
+   * Returns quantum gates which do not topologically depend on any other
+   * quantum gates.
+   * @return The positions (0-indexed) of the first quantum gates.
+   */
+  [[nodiscard]] std::vector<int> first_quantum_gate_positions() const;
+  /**
+   * Returns quantum gates which can appear at last in some topological
+   * order of the CircuitSeq.
+   * @return The pointers to the last quantum gates.
+   */
   [[nodiscard]] std::vector<CircuitGate *> last_quantum_gates() const;
 
   static bool same_gate(const CircuitSeq &seq1, int index1,

--- a/src/quartz/circuitseq/circuitseq.h
+++ b/src/quartz/circuitseq/circuitseq.h
@@ -37,10 +37,10 @@ class CircuitSeq {
    */
   [[nodiscard]] bool fully_equivalent(Context *ctx, CircuitSeq &other);
   /**
-   * Compare two circuit sequences first by the qubit count (smaller is true),
-   * then by the gate count (smaller is true), then by the gate sequence.
+   * Compare two circuit sequences first by the qubit count (fewer is less),
+   * then by the gate count (fewer is less), then by the gate sequence.
    * If |kUseRowRepresentationToCompare| is true, compare the gates on qubit 0
-   * first, then qubit 1, ...
+   * first (fewer is less, then compare by the content), then qubit 1, ...
    * @param other The other circuit sequence to compare with.
    * @return True iff this circuit sequence is strictly less than the other
    * circuit sequence.

--- a/src/quartz/circuitseq/circuitseq.h
+++ b/src/quartz/circuitseq/circuitseq.h
@@ -36,6 +36,15 @@ class CircuitSeq {
    * @return True iff two circuit sequences are fully equivalent.
    */
   [[nodiscard]] bool fully_equivalent(Context *ctx, CircuitSeq &other);
+  /**
+   * Compare two circuit sequences first by the qubit count (smaller is true),
+   * then by the gate count (smaller is true), then by the gate sequence.
+   * If |kUseRowRepresentationToCompare| is true, compare the gates on qubit 0
+   * first, then qubit 1, ...
+   * @param other The other circuit sequence to compare with.
+   * @return True iff this circuit sequence is strictly less than the other
+   * circuit sequence.
+   */
   [[nodiscard]] bool less_than(const CircuitSeq &other) const;
 
   /**

--- a/src/quartz/dataset/dataset.cpp
+++ b/src/quartz/dataset/dataset.cpp
@@ -161,6 +161,13 @@ int Dataset::normalize_to_canonical_representations(Context *ctx) {
   return num_removed;
 }
 
+void Dataset::sort() {
+  for (auto &it : dataset) {
+    std::sort(it.second.begin(), it.second.end(),
+              UniquePtrCircuitSeqComparator());
+  }
+}
+
 bool Dataset::insert(Context *ctx, std::unique_ptr<CircuitSeq> dag) {
   const auto hash_value = dag->hash(ctx);
   bool ret = dataset.count(hash_value) == 0;

--- a/src/quartz/dataset/dataset.h
+++ b/src/quartz/dataset/dataset.h
@@ -24,6 +24,11 @@ class Dataset {
   // Return the number of DAGs removed.
   int normalize_to_canonical_representations(Context *ctx);
 
+  /**
+   * Sort the circuits with the same hash value by CircuitSeq::less_than().
+   */
+  void sort();
+
   // This function runs in O(1).
   [[nodiscard]] int num_hash_values() const;
 

--- a/src/quartz/generator/generator.cpp
+++ b/src/quartz/generator/generator.cpp
@@ -71,8 +71,9 @@ bool Generator::generate(
       }
       std::string command_string =
           std::string("python ") + quartz_root_path.string() +
-          "/src/python/verifier/verify_equivalences.py "
-          "tmp_before_verify.json tmp_after_verify.json";
+          "/src/python/verifier/verify_equivalences.py " +
+          quartz_root_path.string() + "/tmp_before_verify.json " +
+          quartz_root_path.string() + "/tmp_after_verify.json";
       system(command_string.c_str());
       if (record_verification_time) {
         auto end = std::chrono::steady_clock::now();

--- a/src/quartz/generator/generator.cpp
+++ b/src/quartz/generator/generator.cpp
@@ -1,6 +1,7 @@
 #include "generator.h"
 
 #include <cassert>
+#include <filesystem>
 
 namespace quartz {
 
@@ -9,6 +10,10 @@ bool Generator::generate(
     bool invoke_python_verifier, EquivalenceSet *equiv_set,
     bool unique_parameters, bool verbose,
     std::chrono::steady_clock::duration *record_verification_time) {
+  std::filesystem::path this_file_path(__FILE__);
+  auto quartz_root_path =
+      this_file_path.parent_path().parent_path().parent_path().parent_path();
+
   auto empty_dag = std::make_unique<CircuitSeq>(num_qubits);
   empty_dag->hash(ctx_);  // generate other hash values
   std::vector<CircuitSeq *> dags_to_search(1, empty_dag.get());
@@ -56,24 +61,28 @@ bool Generator::generate(
       if (num_gates == max_num_quantum_gates) {
         break;
       }
-      bool ret = dataset->save_json(ctx_, "tmp_before_verify.json");
+      bool ret = dataset->save_json(ctx_, quartz_root_path.string() +
+                                              "/tmp_before_verify.json");
       assert(ret);
 
       decltype(std::chrono::steady_clock::now()) start;
       if (record_verification_time) {
         start = std::chrono::steady_clock::now();
       }
-      // Assume working directory is cmake-build-debug/ here.
-      system("python src/python/verifier/verify_equivalences.py "
-             "tmp_before_verify.json tmp_after_verify.json");
+      std::string command_string =
+          std::string("python ") + quartz_root_path.string() +
+          "/src/python/verifier/verify_equivalences.py "
+          "tmp_before_verify.json tmp_after_verify.json";
+      system(command_string.c_str());
       if (record_verification_time) {
         auto end = std::chrono::steady_clock::now();
         *record_verification_time += end - start;
       }
 
       dags_to_search.clear();
-      ret = equiv_set->load_json(ctx_, "tmp_after_verify.json",
-                                 /*from_verifier=*/true, &dags_to_search);
+      ret = equiv_set->load_json(
+          ctx_, quartz_root_path.string() + "/tmp_after_verify.json",
+          /*from_verifier=*/true, &dags_to_search);
       assert(ret);
       for (auto &dag : dags_to_search) {
         auto new_dag = std::make_unique<CircuitSeq>(*dag);

--- a/src/quartz/utils/utils.h
+++ b/src/quartz/utils/utils.h
@@ -17,6 +17,7 @@ using namespace std::complex_literals;  // so that we can write stuff like 1.0i
 
 namespace quartz {
 const ParamType PI = std::acos((ParamType)-1);
+
 // Constants for CircuitSeq::hash()
 constexpr double kCircuitSeqHashMaxError = 1e-15;
 constexpr bool kFingerprintInvariantUnderPhaseShift = true;
@@ -29,6 +30,8 @@ static_assert(!(kFingerprintInvariantUnderPhaseShift &&
 constexpr PhaseShiftIdType kNoPhaseShift = -1;
 constexpr bool kCheckPhaseShiftOfPiOver4 = true;
 constexpr int kCheckPhaseShiftOfPiOver4Index = 10000;  // not used now
+
+constexpr bool kUseRowRepresentationToCompare = true;
 
 constexpr int kDefaultQASMParamPrecision = 15;
 

--- a/src/quartz/verifier/verifier.cpp
+++ b/src/quartz/verifier/verifier.cpp
@@ -1,5 +1,7 @@
 #include "verifier.h"
 
+#include "quartz/utils/utils.h"
+
 #include <algorithm>
 #include <cassert>
 
@@ -19,6 +21,7 @@ bool Verifier::redundant(Context *ctx, CircuitSeq *dag) {
   if (!dag->is_canonical_representation()) {
     return true;
   }
+  assert(!kUseRowRepresentationToCompare);  // not implemented otherwise
   // We have already known that DropLast(circuitseq) is a representative.
   // Check if canonicalize(DropFirst(circuitseq)) is a representative.
   auto dropfirst = std::make_unique<CircuitSeq>(*dag);
@@ -51,35 +54,77 @@ bool Verifier::redundant(Context *ctx, const EquivalenceSet *eqs,
   if (!dag->is_canonical_representation()) {
     return true;
   }
-  // We have already known that DropLast(circuitseq) is a representative.
-  // Check if canonicalize(DropFirst(circuitseq)) is a representative.
-  auto dropfirst = std::make_unique<CircuitSeq>(*dag);
-  dropfirst->remove_first_quantum_gate();
-  CircuitSeqHashType hash_value = dropfirst->hash(ctx);
-  auto possible_classes = eqs->get_possible_classes(hash_value);
-  for (const auto &other_hash : dropfirst->other_hash_values()) {
-    auto more_possible_classes = eqs->get_possible_classes(other_hash);
-    possible_classes.insert(possible_classes.end(),
-                            more_possible_classes.begin(),
-                            more_possible_classes.end());
-  }
-  std::sort(possible_classes.begin(), possible_classes.end());
-  auto last = std::unique(possible_classes.begin(), possible_classes.end());
-  possible_classes.erase(last, possible_classes.end());
-  for (const auto &equiv_class : possible_classes) {
-    if (equiv_class->contains(*dropfirst)) {
-      if (!dropfirst->fully_equivalent(*equiv_class->get_representative())) {
-        // |dropfirst| already exists and is not the
-        // representative. So the whole |circuitseq| is redundant.
+  if (kUseRowRepresentationToCompare) {
+    // We have already known that DropLast(circuitseq) is a representative.
+    // Check if canonicalize(DropFirst(circuitseq)) is a representative.
+    auto first_gates = dag->first_quantum_gate_positions();
+    for (auto &gate_position : first_gates) {
+      auto dropfirst = std::make_unique<CircuitSeq>(*dag);
+      dropfirst->remove_gate(gate_position);
+      CircuitSeqHashType hash_value = dropfirst->hash(ctx);
+      auto possible_classes = eqs->get_possible_classes(hash_value);
+      for (const auto &other_hash : dropfirst->other_hash_values()) {
+        auto more_possible_classes = eqs->get_possible_classes(other_hash);
+        possible_classes.insert(possible_classes.end(),
+                                more_possible_classes.begin(),
+                                more_possible_classes.end());
+      }
+      std::sort(possible_classes.begin(), possible_classes.end());
+      auto last = std::unique(possible_classes.begin(), possible_classes.end());
+      possible_classes.erase(last, possible_classes.end());
+      bool found = false;
+      for (const auto &equiv_class : possible_classes) {
+        if (equiv_class->contains(*dropfirst)) {
+          if (!dropfirst->topologically_equivalent(
+                  *equiv_class->get_representative())) {
+            // |dropfirst| already exists and is not the
+            // representative. So the whole |circuitseq| is redundant.
+            return true;
+          } else {
+            // |dropfirst| already exists and is the representative.
+            found = true;
+            break;
+          }
+        }
+      }
+      if (!found) {
+        // |dropfirst| is not found and therefore is not a representative.
         return true;
-      } else {
-        // |dropfirst| already exists and is the representative.
-        return false;
       }
     }
+    // All |dropfirst|s are representatives.
+    return false;
+  } else {
+    // We have already known that DropLast(circuitseq) is a representative.
+    // Check if canonicalize(DropFirst(circuitseq)) is a representative.
+    auto dropfirst = std::make_unique<CircuitSeq>(*dag);
+    dropfirst->remove_first_quantum_gate();
+    CircuitSeqHashType hash_value = dropfirst->hash(ctx);
+    auto possible_classes = eqs->get_possible_classes(hash_value);
+    for (const auto &other_hash : dropfirst->other_hash_values()) {
+      auto more_possible_classes = eqs->get_possible_classes(other_hash);
+      possible_classes.insert(possible_classes.end(),
+                              more_possible_classes.begin(),
+                              more_possible_classes.end());
+    }
+    std::sort(possible_classes.begin(), possible_classes.end());
+    auto last = std::unique(possible_classes.begin(), possible_classes.end());
+    possible_classes.erase(last, possible_classes.end());
+    for (const auto &equiv_class : possible_classes) {
+      if (equiv_class->contains(*dropfirst)) {
+        if (!dropfirst->fully_equivalent(*equiv_class->get_representative())) {
+          // |dropfirst| already exists and is not the
+          // representative. So the whole |circuitseq| is redundant.
+          return true;
+        } else {
+          // |dropfirst| already exists and is the representative.
+          return false;
+        }
+      }
+    }
+    // |dropfirst| is not found and therefore is not a representative.
+    return true;
   }
-  // |dropfirst| is not found and therefore is not a representative.
-  return true;
 }
 
 }  // namespace quartz

--- a/src/test/gen_ecc_set.cpp
+++ b/src/test/gen_ecc_set.cpp
@@ -24,20 +24,21 @@ int main() {
   // gen_ecc_set({GateType::u1, GateType::u2, GateType::u3, GateType::cx,
   //              GateType::add},
   //             "IBM_4_3_", true, 3, 4, 4);
-  // for (int n = 2; n <= 4; n++) {
-  //   for (int q = 3; q <= 3; q++) {
-  //     std::string file_prefix = "Nam_";
-  //     file_prefix += std::to_string(n);
-  //     file_prefix += "_";
-  //     file_prefix += std::to_string(q);
-  //     file_prefix += "_";
-  //     gen_ecc_set(
-  //         {GateType::rz, GateType::h, GateType::cx, GateType::x,
-  //         GateType::add}, file_prefix, true, true, q, 2, n);
-  //   }
-  // }
   gen_ecc_set({GateType::t, GateType::tdg, GateType::h, GateType::x,
                GateType::cx, GateType::add},
               "eccset/Clifford_T_5_3_", true, false, 3, 0, 5);
+
+  for (int n = 2; n <= 4; n++) {
+    for (int q = 3; q <= 3; q++) {
+      std::string file_prefix = "eccset/Nam_";
+      file_prefix += std::to_string(n);
+      file_prefix += "_";
+      file_prefix += std::to_string(q);
+      file_prefix += "_";
+      gen_ecc_set(
+          {GateType::rz, GateType::h, GateType::cx, GateType::x, GateType::add},
+          file_prefix, true, true, q, 2, n);
+    }
+  }
   return 0;
 }

--- a/src/test/gen_ecc_set.cpp
+++ b/src/test/gen_ecc_set.cpp
@@ -9,10 +9,14 @@
 using namespace quartz;
 
 int main() {
+  std::filesystem::path this_file_path(__FILE__);
+  auto quartz_root_path =
+      this_file_path.parent_path().parent_path().parent_path();
   // gen_ecc_set({GateType::u1, GateType::u2, GateType::u3, GateType::cx,
   //              GateType::add},
   //             "IBM_3_3_", true, 3, 4, 3);
-  gen_ecc_set({GateType::h, GateType::cz}, "eccset/H_CZ_2_2_", true, false, 2,
+  gen_ecc_set({GateType::h, GateType::cz},
+              quartz_root_path.string() + "/eccset/H_CZ_2_2_", true, false, 2,
               0, 2);
   // for (int n = 5; n <= 8; n++) {
   //   std::string file_prefix = "Rigetti_";
@@ -26,11 +30,12 @@ int main() {
   //             "IBM_4_3_", true, 3, 4, 4);
   gen_ecc_set({GateType::t, GateType::tdg, GateType::h, GateType::x,
                GateType::cx, GateType::add},
-              "eccset/Clifford_T_5_3_", true, false, 3, 0, 5);
+              quartz_root_path.string() + "/eccset/Clifford_T_5_3_", true,
+              false, 3, 0, 5);
 
   for (int n = 2; n <= 4; n++) {
     for (int q = 3; q <= 3; q++) {
-      std::string file_prefix = "eccset/Nam_";
+      std::string file_prefix = quartz_root_path.string() + "/eccset/Nam_";
       file_prefix += std::to_string(n);
       file_prefix += "_";
       file_prefix += std::to_string(q);

--- a/src/test/gen_ecc_set.h
+++ b/src/test/gen_ecc_set.h
@@ -3,6 +3,8 @@
 #include "quartz/context/context.h"
 #include "quartz/generator/generator.h"
 
+#include <filesystem>
+
 namespace quartz {
 void gen_ecc_set(const std::vector<GateType> &supported_gates,
                  const std::string &file_prefix, bool unique_parameters,
@@ -13,6 +15,10 @@ void gen_ecc_set(const std::vector<GateType> &supported_gates,
                  const std::string &file_prefix, bool unique_parameters,
                  bool generate_representative_set, int num_qubits,
                  int num_input_parameters, int max_num_quantum_gates) {
+  std::filesystem::path this_file_path(__FILE__);
+  auto quartz_root_path =
+      this_file_path.parent_path().parent_path().parent_path();
+
   ParamInfo param_info(/*num_input_symbolic_params=*/num_input_parameters);
   Context ctx(supported_gates, num_qubits, &param_info);
   Generator gen(&ctx);
@@ -52,7 +58,8 @@ void gen_ecc_set(const std::vector<GateType> &supported_gates,
     dataset1.save_json(&ctx, file_prefix + "pruning_unverified.json");
 
     auto start2 = std::chrono::steady_clock::now();
-    system(("python src/python/verifier/verify_equivalences.py " + file_prefix +
+    system(("python " + quartz_root_path.string() +
+            "/src/python/verifier/verify_equivalences.py " + file_prefix +
             "pruning_unverified.json " + file_prefix + "pruning.json")
                .c_str());
     auto end2 = std::chrono::steady_clock::now();


### PR DESCRIPTION
This PR implements comparison by row representation in RepGen.

It also allows running RepGen and `gen_ecc_set.cpp` from any directory (not necessarily from `quartz/` or `build/` now).

Please change
```C++
constexpr bool kUseRowRepresentationToCompare = true;
```
to
```C++
constexpr bool kUseRowRepresentationToCompare = false;
```
in `utils/utils.h` if you want to use the previous RepGen version.