### PR TITLE
[Generator] Switch back to the previous canonical representation version

### DIFF
--- a/src/quartz/utils/utils.h
+++ b/src/quartz/utils/utils.h
@@ -31,7 +31,7 @@ constexpr PhaseShiftIdType kNoPhaseShift = -1;
 constexpr bool kCheckPhaseShiftOfPiOver4 = true;
 constexpr int kCheckPhaseShiftOfPiOver4Index = 10000;  // not used now
 
-constexpr bool kUseRowRepresentationToCompare = true;
+constexpr bool kUseRowRepresentationToCompare = false;
 
 constexpr int kDefaultQASMParamPrecision = 15;
 


### PR DESCRIPTION
Revert the row representation change in #173.

Will turn it on when there is evidence that the row representation is better.