### PR TITLE
[Verifier] Verify each circuit transformation step

### DIFF
--- a/src/quartz/circuitseq/circuitgate.h
+++ b/src/quartz/circuitseq/circuitgate.h
@@ -4,6 +4,8 @@
 #include "../utils/utils.h"
 
 #include <istream>
+#include <queue>
+#include <unordered_map>
 #include <vector>
 
 namespace quartz {
@@ -47,6 +49,34 @@ class CircuitGate {
                         std::vector<int> &output_params, Gate *&gate);
   [[nodiscard]] std::string to_qasm_style_string(Context *ctx,
                                                  int param_precision) const;
+
+  /**
+   * Check if two gates in two circuits are equivalent given a mapping of
+   * circuit wires.
+   * @param this_gate A gate in the first circuit.
+   * @param other_gate A gate in the second circuit.
+   * @param wires_mapping A mapping from the wires in the first circuit to the
+   * wires in the second circuit.
+   * @param update_mapping If true, map the output wires, and push the output
+   * wires in the first circuit to the queue;
+   * if false, also check if the output wires are already correctly mapped
+   * (only return true if the gates are equivalent and the output wires are
+   * correctly mapped).
+   * @param wires_to_search When |update_mapping| is true and the two gates
+   * are equivalent under the wires mapping, store the new wires to search in
+   * the topological sort procedure. Otherwise, this parameter has no effect.
+   * When |update_mapping| is false, this parameter can be nullptr.
+   * @param backward If true, the topological sort is performed from the end
+   * of the circuit to the beginning. Only the output wires instead of the
+   * input wires are compared when |update_mapping| is true.
+   * @return True iff the two gates are equivalent under the wires mapping.
+   */
+  static bool equivalent(
+      const CircuitGate *this_gate, const CircuitGate *other_gate,
+      std::unordered_map<CircuitWire *, CircuitWire *> &wires_mapping,
+      bool update_mapping,
+      std::queue<CircuitWire *> *wires_to_search,
+      bool backward = false);
 
   std::vector<CircuitWire *> input_wires;  // Include parameters!
   std::vector<CircuitWire *> output_wires;

--- a/src/quartz/circuitseq/circuitgate.h
+++ b/src/quartz/circuitseq/circuitgate.h
@@ -71,12 +71,11 @@ class CircuitGate {
    * input wires are compared when |update_mapping| is true.
    * @return True iff the two gates are equivalent under the wires mapping.
    */
-  static bool equivalent(
-      const CircuitGate *this_gate, const CircuitGate *other_gate,
-      std::unordered_map<CircuitWire *, CircuitWire *> &wires_mapping,
-      bool update_mapping,
-      std::queue<CircuitWire *> *wires_to_search,
-      bool backward = false);
+  static bool
+  equivalent(const CircuitGate *this_gate, const CircuitGate *other_gate,
+             std::unordered_map<CircuitWire *, CircuitWire *> &wires_mapping,
+             bool update_mapping, std::queue<CircuitWire *> *wires_to_search,
+             bool backward = false);
 
   std::vector<CircuitWire *> input_wires;  // Include parameters!
   std::vector<CircuitWire *> output_wires;

--- a/src/quartz/circuitseq/circuitseq.h
+++ b/src/quartz/circuitseq/circuitseq.h
@@ -106,17 +106,23 @@ class CircuitSeq {
   bool remove_last_gate();
 
   /**
-   * Remove a quantum gate.
+   * Remove a quantum gate in O(|get_num_gates()| - |gate_position|).
    * @param gate_position The position of the gate to be removed (0-indexed).
    * @return True iff the removal is successful.
    */
   bool remove_gate(int gate_position);
   /**
-   * Remove a quantum gate.
+   * Remove a quantum gate in O(|get_num_gates()|).
    * @param circuit_gate The gate to be removed.
    * @return True iff the removal is successful.
    */
   bool remove_gate(CircuitGate *circuit_gate);
+  /**
+   * Remove a quantum gate in O(|get_num_gates()| - |gate_position|).
+   * @param circuit_gate The gate to be removed.
+   * @return True iff the removal is successful.
+   */
+  bool remove_gate_near_end(CircuitGate *circuit_gate);
   /**
    * Remove the first quantum gate (if there is one).
    * @return True iff the removal is successful.
@@ -279,6 +285,14 @@ class CircuitSeq {
   get_permuted_seq(const std::vector<int> &qubit_permutation,
                    const std::vector<int> &input_param_permutation,
                    Context *ctx) const;
+  /**
+   * Get a circuit with |start_gates| and all gates topologically after them.
+   * @param start_gates The first gates at each qubit to include in the
+   * circuit to return.
+   */
+  [[nodiscard]] std::unique_ptr<CircuitSeq>
+  get_suffix_seq(const std::unordered_set<CircuitGate *> &start_gates,
+                 Context *ctx) const;
 
   /**
    * Get a circuit which replaces RZ gates with T, Tdg, S, Sdg, and Z gates.
@@ -307,6 +321,14 @@ class CircuitSeq {
    * @return The positions (0-indexed) of the first quantum gates.
    */
   [[nodiscard]] std::vector<int> first_quantum_gate_positions() const;
+  /**
+   * Check if a quantum gate can appear at last in some topological
+   * order of the CircuitSeq.
+   * @param circuit_gate The pointer to a quantum gate in the circuit.
+   * @return True iff the gate can appear at last in some topological
+   * order of the CircuitSeq.
+   */
+  [[nodiscard]] bool is_one_of_last_gates(CircuitGate *circuit_gate) const;
   /**
    * Returns quantum gates which can appear at last in some topological
    * order of the CircuitSeq.

--- a/src/quartz/generator/generator.cpp
+++ b/src/quartz/generator/generator.cpp
@@ -10,10 +10,6 @@ bool Generator::generate(
     bool invoke_python_verifier, EquivalenceSet *equiv_set,
     bool unique_parameters, bool verbose,
     std::chrono::steady_clock::duration *record_verification_time) {
-  std::filesystem::path this_file_path(__FILE__);
-  auto quartz_root_path =
-      this_file_path.parent_path().parent_path().parent_path().parent_path();
-
   auto empty_dag = std::make_unique<CircuitSeq>(num_qubits);
   empty_dag->hash(ctx_);  // generate other hash values
   std::vector<CircuitSeq *> dags_to_search(1, empty_dag.get());
@@ -61,7 +57,7 @@ bool Generator::generate(
       if (num_gates == max_num_quantum_gates) {
         break;
       }
-      bool ret = dataset->save_json(ctx_, quartz_root_path.string() +
+      bool ret = dataset->save_json(ctx_, kQuartzRootPath.string() +
                                               "/tmp_before_verify.json");
       assert(ret);
 
@@ -70,10 +66,10 @@ bool Generator::generate(
         start = std::chrono::steady_clock::now();
       }
       std::string command_string =
-          std::string("python ") + quartz_root_path.string() +
+          std::string("python ") + kQuartzRootPath.string() +
           "/src/python/verifier/verify_equivalences.py " +
-          quartz_root_path.string() + "/tmp_before_verify.json " +
-          quartz_root_path.string() + "/tmp_after_verify.json";
+          kQuartzRootPath.string() + "/tmp_before_verify.json " +
+          kQuartzRootPath.string() + "/tmp_after_verify.json";
       system(command_string.c_str());
       if (record_verification_time) {
         auto end = std::chrono::steady_clock::now();
@@ -82,7 +78,7 @@ bool Generator::generate(
 
       dags_to_search.clear();
       ret = equiv_set->load_json(
-          ctx_, quartz_root_path.string() + "/tmp_after_verify.json",
+          ctx_, kQuartzRootPath.string() + "/tmp_after_verify.json",
           /*from_verifier=*/true, &dags_to_search);
       assert(ret);
       for (auto &dag : dags_to_search) {

--- a/src/quartz/utils/utils.h
+++ b/src/quartz/utils/utils.h
@@ -1,6 +1,8 @@
 #pragma once
 
 #include <complex>
+#include <filesystem>
+
 using ParamType = double;
 #ifdef USE_ARBLIB
 #include "arb_complex.h"
@@ -34,6 +36,13 @@ constexpr int kCheckPhaseShiftOfPiOver4Index = 10000;  // not used now
 constexpr bool kUseRowRepresentationToCompare = false;
 
 constexpr int kDefaultQASMParamPrecision = 15;
+
+const std::filesystem::path kQuartzRootPath =
+    std::filesystem::canonical(__FILE__)
+        .parent_path()
+        .parent_path()
+        .parent_path()
+        .parent_path();
 
 struct PairHash {
  public:

--- a/src/quartz/utils/utils.h
+++ b/src/quartz/utils/utils.h
@@ -31,7 +31,7 @@ constexpr PhaseShiftIdType kNoPhaseShift = -1;
 constexpr bool kCheckPhaseShiftOfPiOver4 = true;
 constexpr int kCheckPhaseShiftOfPiOver4Index = 10000;  // not used now
 
-constexpr bool kUseRowRepresentationToCompare = true;
+constexpr bool kUseRowRepresentationToCompare = false;
 
 constexpr int kDefaultQASMParamPrecision = 15;
 

--- a/src/quartz/verifier/verifier.cpp
+++ b/src/quartz/verifier/verifier.cpp
@@ -4,8 +4,197 @@
 
 #include <algorithm>
 #include <cassert>
+#include <fstream>
+#include <queue>
+#include <unordered_set>
 
 namespace quartz {
+bool Verifier::verify_transformation_steps(Context *ctx,
+                                           const std::string &steps_file_prefix,
+                                           bool verbose) {
+  int step_count = 0;
+  std::ifstream fin(steps_file_prefix + ".txt");
+  assert(fin.is_open());
+  fin >> step_count;
+  fin.close();
+  std::vector<std::unique_ptr<CircuitSeq>> circuits;
+  circuits.reserve(step_count + 1);
+  for (int i = 0; i <= step_count; i++) {
+    circuits.push_back(CircuitSeq::from_qasm_file(
+        ctx, steps_file_prefix + std::to_string(i) + ".qasm"));
+    if (verbose) {
+      std::cout << "circuit " << i << std::endl;
+      std::cout << circuits[i]->to_string(/*line_number=*/true) << std::endl;
+    }
+    if (i > 0) {
+      if (verbose) {
+        std::cout << "Verifying circuit " << i - 1 << " -> circuit " << i
+                  << std::endl;
+      }
+      if (!equivalent(ctx, circuits[i - 1].get(), circuits[i].get(), verbose)) {
+        return false;
+      }
+    }
+  }
+  if (verbose) {
+    std::cout << step_count - 1 << " transformations verified." << std::endl;
+  }
+  return true;
+}
+
+bool Verifier::equivalent(Context *ctx, const CircuitSeq *circuit1,
+                          const CircuitSeq *circuit2, bool verbose) {
+  if (circuit1->get_num_qubits() != circuit2->get_num_qubits()) {
+    return false;
+  }
+  const int num_qubits = circuit1->get_num_qubits();
+
+  // Mappings for topological sort
+  std::unordered_map<CircuitWire *, CircuitWire *> wires_mapping;
+  std::queue<CircuitWire *> wires_to_search;
+  std::unordered_map<CircuitGate *, int> gate_remaining_in_degree;
+  for (int i = 0; i < num_qubits; i++) {
+    wires_mapping[circuit1->wires[i].get()] = circuit2->wires[i].get();
+    wires_to_search.push(circuit1->wires[i].get());
+  }
+  // Try to remove common first gates and record the frontier
+  std::vector<bool> qubit_blocked(num_qubits, false);
+  std::unordered_set<CircuitGate *> leftover_gates_start1;
+  std::unordered_set<CircuitGate *> leftover_gates_start2;
+  // (Partial) topological sort on circuit1
+  while (!wires_to_search.empty()) {
+    auto wire1 = wires_to_search.front();
+    assert(wires_mapping.count(wire1) > 0);
+    auto wire2 = wires_mapping[wire1];
+    wires_to_search.pop();
+    assert(wire1->output_gates.size() <= 1);
+    assert(wire2->output_gates.size() <= 1);
+    if (wire1->output_gates.empty() || wire2->output_gates.empty() ||
+        std::any_of(wire1->output_gates[0]->output_wires.begin(),
+                    wire1->output_gates[0]->output_wires.end(),
+                    [&qubit_blocked](CircuitWire *output_wire) {
+                      return qubit_blocked[output_wire->index];
+                    })) {
+      // Block qubits of potential unmatched gates
+      for (auto &gate : wire1->output_gates) {
+        for (auto &output_wire : gate->output_wires) {
+          qubit_blocked[output_wire->index] = true;
+        }
+        // Use std::unordered_set to deduplicate, similarly hereinafter
+        leftover_gates_start1.insert(gate);
+      }
+      for (auto &gate : wire2->output_gates) {
+        for (auto &output_wire : gate->output_wires) {
+          qubit_blocked[output_wire->index] = true;
+        }
+        leftover_gates_start2.insert(gate);
+      }
+      continue;
+    }
+
+    auto gate1 = wire1->output_gates[0];
+    auto gate2 = wire2->output_gates[0];
+    if (gate_remaining_in_degree.count(gate1) == 0) {
+      // A new gate
+      gate_remaining_in_degree[gate1] = gate1->gate->get_num_qubits();
+    }
+    if (!--gate_remaining_in_degree[gate1]) {
+      // Check if this gate is the same as the other gate and continue
+      // the topological sort (wires_to_search is updated in
+      // CircuitGate::equivalent())
+      if (!CircuitGate::equivalent(gate1, gate2, wires_mapping,
+                                   /*update_mapping=*/true, &wires_to_search)) {
+        // If not matched, block each qubit of both gates
+        for (auto &input_wire : gate1->input_wires) {
+          if (input_wire->is_qubit()) {
+            qubit_blocked[input_wire->index] = true;
+            // Note that this input wire might be not in the search queue now.
+            // We need to manually add the gate in circuit2 to the frontier.
+            assert(wires_mapping.count(input_wire) > 0);
+            for (auto &gate : wires_mapping[input_wire]->output_gates) {
+              leftover_gates_start2.insert(gate);
+            }
+          }
+        }
+        leftover_gates_start1.insert(gate1);
+        for (auto &output_wire : gate2->output_wires) {
+          qubit_blocked[output_wire->index] = true;
+        }
+        leftover_gates_start2.insert(gate2);
+      }
+    }
+  }
+
+  if (leftover_gates_start1.empty() && leftover_gates_start2.empty()) {
+    // The two circuits are equivalent.
+    return true;
+  }
+
+  auto c1 = circuit1->get_suffix_seq(leftover_gates_start1, ctx);
+  auto c2 = circuit2->get_suffix_seq(leftover_gates_start2, ctx);
+  // We should have removed the same number of gates
+  assert(circuit1->get_num_gates() - c1->get_num_gates() ==
+         circuit2->get_num_gates() - c2->get_num_gates());
+
+  // Remove common last gates
+  while (true) {
+    bool removed_anything = false;
+    for (int i = 0; i < num_qubits; i++) {
+      if (c1->outputs[i]->input_gates.empty() ||
+          c2->outputs[i]->input_gates.empty()) {
+        // At least of the two circuits does not have a gate at qubit i
+        continue;
+      }
+      assert(c1->outputs[i]->input_gates.size() == 1);
+      assert(c2->outputs[i]->input_gates.size() == 1);
+      auto gate1 = c1->outputs[i]->input_gates[0];
+      auto gate2 = c2->outputs[i]->input_gates[0];
+      if (gate1->gate != gate2->gate ||
+          gate1->input_wires.size() != gate2->input_wires.size() ||
+          !c1->is_one_of_last_gates(gate1) ||
+          !c2->is_one_of_last_gates(gate2)) {
+        continue;
+      }
+      bool matched = true;
+      for (int j = 0; j < (int)gate1->input_wires.size(); j++) {
+        if (gate1->input_wires[j]->is_qubit() !=
+            gate2->input_wires[j]->is_qubit()) {
+          matched = false;
+          break;
+        }
+        if (gate1->input_wires[j]->is_qubit()) {
+          if (gate1->input_wires[j]->index != gate2->input_wires[j]->index) {
+            matched = false;
+            break;
+          }
+        } else {
+          // parameters should not be mapped
+          if (gate1->input_wires[j] != gate2->input_wires[j]) {
+            matched = false;
+            break;
+          }
+        }
+      }
+      if (matched) {
+        c1->remove_gate_near_end(gate1);
+        c2->remove_gate_near_end(gate2);
+        removed_anything = true;
+      }
+    }
+    if (!removed_anything) {
+      break;
+    }
+  }
+
+  if (verbose) {
+    std::cout << "Checking Verifier::equivalent() on:" << std::endl;
+    std::cout << c1->to_string(/*line_number=*/true) << std::endl;
+    std::cout << c2->to_string(/*line_number=*/true) << std::endl;
+  }
+  // TODO
+  return true;
+}
+
 bool Verifier::equivalent_on_the_fly(Context *ctx, CircuitSeq *circuit1,
                                      CircuitSeq *circuit2) {
   // Disable the verifier.

--- a/src/quartz/verifier/verifier.h
+++ b/src/quartz/verifier/verifier.h
@@ -28,8 +28,7 @@ class Verifier {
    * equivalent.
    */
   bool equivalent(Context *ctx, const CircuitSeq *circuit1,
-                  const CircuitSeq *circuit2,
-                  bool verbose = false);
+                  const CircuitSeq *circuit2, bool verbose = false);
   // On-the-fly equivalence checking while generating circuits
   bool equivalent_on_the_fly(Context *ctx, CircuitSeq *circuit1,
                              CircuitSeq *circuit2);

--- a/src/quartz/verifier/verifier.h
+++ b/src/quartz/verifier/verifier.h
@@ -8,7 +8,28 @@ namespace quartz {
 // Verify if two circuits are equivalent and other things about DAGs.
 class Verifier {
  public:
-  bool equivalent(Context *ctx, CircuitSeq *circuit1, CircuitSeq *circuit2);
+  /**
+   * Verify all transformation steps.
+   * @param ctx The context to load the circuits from files.
+   * @param steps_file_prefix The parameter |store_all_steps_file_prefix| when
+   * calling Graph::optimize().
+   * @param verbose Print logs to the screen.
+   * @return True if we can verify all transformation steps.
+   */
+  bool verify_transformation_steps(Context *ctx,
+                                   const std::string &steps_file_prefix,
+                                   bool verbose = false);
+  /**
+   * Verify if two circuits are functionally equivalent. They are expected
+   * to differ by only one small circuit transformation.
+   * @param ctx The context for both circuits.
+   * @param verbose Print logs to the screen.
+   * @return True if we can prove that the two circuits are functionally
+   * equivalent.
+   */
+  bool equivalent(Context *ctx, const CircuitSeq *circuit1,
+                  const CircuitSeq *circuit2,
+                  bool verbose = false);
   // On-the-fly equivalence checking while generating circuits
   bool equivalent_on_the_fly(Context *ctx, CircuitSeq *circuit1,
                              CircuitSeq *circuit2);

--- a/src/test/gen_ecc_set.cpp
+++ b/src/test/gen_ecc_set.cpp
@@ -9,15 +9,12 @@
 using namespace quartz;
 
 int main() {
-  std::filesystem::path this_file_path(__FILE__);
-  auto quartz_root_path =
-      this_file_path.parent_path().parent_path().parent_path();
   // gen_ecc_set({GateType::u1, GateType::u2, GateType::u3, GateType::cx,
   //              GateType::add},
   //             "IBM_3_3_", true, 3, 4, 3);
   gen_ecc_set({GateType::h, GateType::cz},
-              quartz_root_path.string() + "/eccset/H_CZ_2_2_", true, false, 2,
-              0, 2);
+              kQuartzRootPath.string() + "/eccset/H_CZ_2_2_", true, false, 2, 0,
+              2);
   // for (int n = 5; n <= 8; n++) {
   //   std::string file_prefix = "Rigetti_";
   //   file_prefix += std::to_string(n);
@@ -30,12 +27,12 @@ int main() {
   //             "IBM_4_3_", true, 3, 4, 4);
   gen_ecc_set({GateType::t, GateType::tdg, GateType::h, GateType::x,
                GateType::cx, GateType::add},
-              quartz_root_path.string() + "/eccset/Clifford_T_5_3_", true,
-              false, 3, 0, 5);
+              kQuartzRootPath.string() + "/eccset/Clifford_T_5_3_", true, false,
+              3, 0, 5);
 
   for (int n = 2; n <= 4; n++) {
     for (int q = 3; q <= 3; q++) {
-      std::string file_prefix = quartz_root_path.string() + "/eccset/Nam_";
+      std::string file_prefix = kQuartzRootPath.string() + "/eccset/Nam_";
       file_prefix += std::to_string(n);
       file_prefix += "_";
       file_prefix += std::to_string(q);

--- a/src/test/gen_ecc_set.h
+++ b/src/test/gen_ecc_set.h
@@ -15,10 +15,6 @@ void gen_ecc_set(const std::vector<GateType> &supported_gates,
                  const std::string &file_prefix, bool unique_parameters,
                  bool generate_representative_set, int num_qubits,
                  int num_input_parameters, int max_num_quantum_gates) {
-  std::filesystem::path this_file_path(__FILE__);
-  auto quartz_root_path =
-      this_file_path.parent_path().parent_path().parent_path();
-
   ParamInfo param_info(/*num_input_symbolic_params=*/num_input_parameters);
   Context ctx(supported_gates, num_qubits, &param_info);
   Generator gen(&ctx);
@@ -58,7 +54,7 @@ void gen_ecc_set(const std::vector<GateType> &supported_gates,
     dataset1.save_json(&ctx, file_prefix + "pruning_unverified.json");
 
     auto start2 = std::chrono::steady_clock::now();
-    system(("python " + quartz_root_path.string() +
+    system(("python " + kQuartzRootPath.string() +
             "/src/python/verifier/verify_equivalences.py " + file_prefix +
             "pruning_unverified.json " + file_prefix + "pruning.json")
                .c_str());

--- a/src/test/test_optimization_steps.cpp
+++ b/src/test/test_optimization_steps.cpp
@@ -14,25 +14,22 @@ int main() {
                GateType::h, GateType::t, GateType::tdg, GateType::x,
                GateType::add},
               &param_info);
-  std::filesystem::path this_file_path(__FILE__);
-  auto quartz_root_path =
-      this_file_path.parent_path().parent_path().parent_path();
-  if (!std::filesystem::exists(quartz_root_path / "logs")) {
-    std::filesystem::create_directory(quartz_root_path / "logs");
+  if (!std::filesystem::exists(kQuartzRootPath / "logs")) {
+    std::filesystem::create_directory(kQuartzRootPath / "logs");
   }
   test_optimization(
       &ctx,
-      (quartz_root_path / "circuit/example-circuits/barenco_tof_3.qasm")
+      (kQuartzRootPath / "circuit/example-circuits/barenco_tof_3.qasm")
           .string(),
-      (quartz_root_path / "eccset/Clifford_T_5_3_complete_ECC_set.json")
+      (kQuartzRootPath / "eccset/Clifford_T_5_3_complete_ECC_set.json")
           .string(),
-      /*timeout=*/10, (quartz_root_path / "logs/barenco_tof_3_").string());
+      /*timeout=*/12, (kQuartzRootPath / "logs/barenco_tof_3_").string());
   Verifier verifier;
   bool verified = verifier.verify_transformation_steps(
-      &ctx, (quartz_root_path / "logs/barenco_tof_3_").string(),
+      &ctx, (kQuartzRootPath / "logs/barenco_tof_3_").string(),
       /*verbose=*/true);
   if (verified) {
-    std::cout << "Add transformations are verified." << std::endl;
+    std::cout << "All transformations are verified." << std::endl;
   } else {
     std::cout << "Some transformation is not verified." << std::endl;
   }

--- a/src/test/test_optimization_steps.cpp
+++ b/src/test/test_optimization_steps.cpp
@@ -1,6 +1,7 @@
 #include "test_optimization_steps.h"
 
 #include "quartz/gate/gate_utils.h"
+#include "quartz/verifier/verifier.h"
 
 #include <filesystem>
 #include <iostream>
@@ -26,4 +27,14 @@ int main() {
       (quartz_root_path / "eccset/Clifford_T_5_3_complete_ECC_set.json")
           .string(),
       /*timeout=*/10, (quartz_root_path / "logs/barenco_tof_3_").string());
+  Verifier verifier;
+  bool verified = verifier.verify_transformation_steps(
+      &ctx, (quartz_root_path / "logs/barenco_tof_3_").string(),
+      /*verbose=*/true);
+  if (verified) {
+    std::cout << "Add transformations are verified." << std::endl;
+  } else {
+    std::cout << "Some transformation is not verified." << std::endl;
+  }
+  return 0;
 }


### PR DESCRIPTION
This PR adds a function to verify circuit transformations. It first removes the common first/last gates from each circuit transformation step, then uses Z3 to verify if the remaining parts are equivalent. If the hash values differ by more than 1, it will not invoke Z3 and report they are not equivalent directly. Assuming the code is implemented correctly, it guarantees that the two circuits are equivalent if it returns true.

Example potential output of `test_optimization_steps`:
```
...
Verifying circuit 4 -> circuit 5
Checking Verifier::equivalent() on:
CircuitSeq {
0: Q0 = t(Q0)
1: Q0 = tdg(Q0)
}

CircuitSeq {
}

Considering a total of 2 circuits split into 1 hash values...
Processed 0 hash values that had only 1 circuit sequence, now processing the remaining 1 ones with 2 or more circuit sequences...
Start checking equivalence with different hash...
Solver invoked 0 times to find 0 equivalences with different hash, including 0 out of 0 possible equivalences under phase shift.
1 equivalences found in 1.078999999910593 seconds (solver invoked 1 times for 2 DAGs with 1 different hash values and 1 potential equivalences), output 1 equivalence classes.       
Json saved in 0.0 seconds.
5 transformations verified.
All transformations are verified.
```

This PR also combines the `quartz_root_path` in multiple files into a constant variable in `utils.h`. It also adds helper functions `remove_gate_near_end()`, `get_suffix_seq()`, and `is_one_of_last_gates()`.