### PR TITLE
[Optimizer] Do not modulo 2pi at circuit input

### DIFF
--- a/src/quartz/tasograph/tasograph.cpp
+++ b/src/quartz/tasograph/tasograph.cpp
@@ -1467,12 +1467,6 @@ Graph::_from_qasm_stream(Context *ctx,
           }
           if (negative)
             p = -p;
-          while (p < 0) {
-            p += 2 * PI;
-          }
-          while (p >= 2 * PI) {
-            p -= 2 * PI;
-          }
           auto src_op = graph->add_parameter(p);
           int src_idx = 0;
           auto dst_op = op;


### PR DESCRIPTION
Some parameters may not have a range [0, 2pi). We should not normalize them.

We still normalize to [0, 2pi) in rotation merging. We may need to fix further if a parameter expression is involved in both rotation merging and another gate with the parameter range not [0, 2pi).