### PR TITLE
Parser support for qasm3 qubits.

### DIFF
--- a/src/quartz/parser/qasm_parser.cpp
+++ b/src/quartz/parser/qasm_parser.cpp
@@ -200,8 +200,8 @@ bool QubitParser::parse_qasm3_decl(std::stringstream &ss) {
   return add_decl(ss, name, len_str);
 }
 
-bool QubitParser::add_decl(
-    std::stringstream &ss, std::string &name, std::string &lstr) {
+bool QubitParser::add_decl(std::stringstream &ss, std::string &name,
+                           std::string &lstr) {
   // Ensures qreg parsing is allowed.
   if (finalized_) {
     std::cerr << "Can only create qubit before finalization." << std::endl;

--- a/src/test/test_pi.cpp
+++ b/src/test/test_pi.cpp
@@ -20,11 +20,18 @@ int main() {
   CircuitSeq dag2(1);
   dag2.add_gate({0}, {p2}, ctx.get_gate(GateType::rx), &ctx);
 
-  auto c1 = dag1.to_qasm_style_string(&ctx);
-  auto c2 = dag2.to_qasm_style_string(&ctx);
-  if (c1 != c2) {
-    std::cout << "Failed to evaluate pi gate." << std::endl;
-    assert(false);
+  auto mat1 = dag1.get_matrix(&ctx);
+  auto mat2 = dag2.get_matrix(&ctx);
+
+  assert(mat1.size() == mat2.size());
+  for (int i = 0; i < mat1.size(); ++i) {
+    assert(mat1[i].size() == mat2[i].size());
+    for (int j = 0; j < mat1[i].size(); ++j) {
+      if (mat1[i][j] != mat2[i][j]) {
+        std::cout << "Disagree at " << i << ", " << j << "." << std::endl;
+        assert(false);
+      }
+    }
   }
 
   // Working directory is cmake-build-debug/ here.

--- a/src/test/test_qasm_parser.cpp
+++ b/src/test/test_qasm_parser.cpp
@@ -84,7 +84,7 @@ void test_symbolic_exprs() {
   }
 }
 
-void test_qubits() {
+void test_qasm2_qubits() {
   ParamInfo param_info(0);
   Context ctx({GateType::cx}, 5, &param_info);
 
@@ -92,7 +92,7 @@ void test_qubits() {
 
   std::string str = "OPENQASM 2.0;\n"
                     "include \"qelib1.inc\";\n"
-                    "qreg q[2];\n"
+                    "qreg q[2]   ;\n"
                     "qreg r[3];\n"
                     "cx q[0], q[1];\n"
                     "cx q[0], r[0];\n"
@@ -112,9 +112,41 @@ void test_qubits() {
   }
 }
 
+void test_qasm3_qubits() {
+  ParamInfo param_info(0);
+  Context ctx({GateType::cx}, 5, &param_info);
+
+  QASMParser parser(&ctx);
+
+  std::string str = "OPENQASM 2.0;\n"
+                    "include \"qelib1.inc\";\n"
+                    "qubit[2] q;\n"
+                    "qubit  [3] r   ;\n"
+                    "qreg s    [2]   ;\n"
+                    "cx q[0], q[1];\n"
+                    "cx q[0], r[0];\n"
+                    "cx r[1], r[2];\n"
+                    "cx s[0], s[1];\n";
+
+  CircuitSeq *seq = nullptr;
+  bool res = parser.load_qasm_str(str, seq);
+  if (!res) {
+    std::cout << "Parsing failed with many qubit declarations." << std::endl;
+    assert(false);
+  }
+
+  int qnum = seq->get_num_qubits();
+  if (qnum != 7) {
+    std::cout << "Unexpected qubit total: " << qnum << "." << std::endl;
+    assert(false);
+  }
+}
+
 int main() {
   std::cout << "[Symbolic Expression Tests]" << std::endl;
   test_symbolic_exprs();
-  std::cout << "[Qubit Parsing Tests]" << std::endl;
-  test_qubits();
+  std::cout << "[OpenQASM 2 Parsing Tests]" << std::endl;
+  test_qasm2_qubits();
+  std::cout << "[OpenQASM 3 Parsing Tests]" << std::endl;
+  test_qasm3_qubits();
 }


### PR DESCRIPTION
**Summary**

This pull request allows parsing of OpenQASM 3 qubit declarations.

**Details**

In OpenQASM 2, a qubit array is declared using the `qreg name[len];` statement, whereas in OpenQASM 3 the statement `qubit[len] name` is preferred. This pull request extends the `QASMParser` to support the `qubit` command.

**Main Changes**

- Every `[` symbol in each command is prefixed by a space. This ensures that the `qubit` in `qubit[len]` is disconnected from the designator `[len]`.
- The qreg parsing code has been factored out into `QubitParser`.
- The `QASMParser` supports OpenQASM 3 qubit declarations.
