### PR TITLE
Support for expressions made from multiple terms.

### DIFF
--- a/src/quartz/parser/qasm_parser.cpp
+++ b/src/quartz/parser/qasm_parser.cpp
@@ -179,7 +179,7 @@ int ParamParser::parse_expr(std::stringstream &ss) {
     token = token.substr(1);
   }
 
-  // Ensures that the string is token is non-empty.
+  // Ensures that the string token is non-empty.
   if (token == "") {
     std::cerr << "Unexpected end-of-line while parsing expr." << std::endl;
     assert(false);

--- a/src/quartz/parser/qasm_parser.h
+++ b/src/quartz/parser/qasm_parser.h
@@ -53,9 +53,15 @@ class ParamParser {
   bool parse_array_decl(std::stringstream &ss);
 
   /**
-   * Parses a stream which is known to contain a parameter expression. The
-   * following formats are supported, where n and m are decimal literals, i is
-   * an integer literal, and name is a string:
+   * Parses a stream which is known to contain a parameter expression. Each
+   * parameter expression consists of one or more terms composed together as
+   * follows, where t is a term and e is an expression:
+   *    | t
+   *    | -t
+   *    | e+t
+   *    | e-t
+   * For each term t, the following formats are supported, where n and m are
+   * decimal literals, i is an integer literal, and name is a string:
    *    | pi*n
    *    | n*pi
    *    | n*pi/m
@@ -143,6 +149,13 @@ class ParamParser {
    * parameter, in the context of ctx_, which corresponds to the reference.
    */
   std::unordered_map<std::string, std::unordered_map<int, int>> symb_params_;
+
+  /**
+   * Maps a pair of parameter identifiers, to the the identifier of a symbolic
+   * parameter, in the context of ctx_, which corresponds to sum of their
+   * corresponding parameters.
+   */
+  std::unordered_map<int, std::unordered_map<int, int>> sum_params_;
 
   /**
    * If true, then rational multiples of pi are evaluated exactly as symbolic

--- a/src/quartz/parser/qasm_parser.h
+++ b/src/quartz/parser/qasm_parser.h
@@ -53,16 +53,16 @@ class ParamParser {
   bool parse_array_decl(std::stringstream &ss);
 
   /**
-   * Parses a stream which is known to contain a parameter expression.
-   * Supported formats are as follows, where n and m are decimal literals, i
-   * is an integer literal, and name is a string:
-   * - pi*n
-   * - n*pi
-   * - n*pi/m
-   * - n
-   * - pi/m
-   * - n/(m*pi)
-   * - name[i]
+   * Parses a stream which is known to contain a parameter expression. The
+   * following formats are supported, where n and m are decimal literals, i is
+   * an integer literal, and name is a string:
+   *    | pi*n
+   *    | n*pi
+   *    | n*pi/m
+   *    | n
+   *    | pi/m
+   *    | n/(m*pi)
+   *    | name[i]
    * @param token the string stream which contains the parameter expression.
    * @return the parameter id for this expression in the current context.
    */
@@ -85,24 +85,40 @@ class ParamParser {
 
  private:
   /**
-   * Implementation details for parse_expr when the expression is a constant
-   * literal value or of the form n/(m*pi).
+   * Implementation details for each term in parse_expr. The supported formats
+   * for terms are as follows, where n and m are decimal literals, i is an
+   * integer literal, and name is a string:
+   *    | pi*n
+   *    | n*pi
+   *    | n*pi/m
+   *    | n
+   *    | pi/m
+   *    | n/(m*pi)
+   *    | name[i]
+   * @param negative if true, then the parameter should be negative.
+   * @param token the string which contains the parameter expression.
+   * @return the parameter id for this term in the current context.
+   */
+  int parse_term(bool negative, std::string token);
+
+  /**
+   * Implementation details for parse_term when the term is a constant literal
+   * value or of the form n/(m*pi).
    * @param negative if true, then the parameter should be negative.
    * @param p the literal value as a floating-point value.
    * @return the parameter id for this expression in the current context.
    */
-  // Handles constant parameters given as literal decimal expressions.
   int parse_number(bool negative, ParamType p);
 
   /**
-   * Implementation details for parse_expr when the expression is of the form
-   * pi*n, n*pi, n*pi/m, or pi/m
+   * Implementation details for parse_term when the term is of the form pi*n,
+   * n*pi, n*pi/m, or pi/m.
    * @param negative if true, then the parameter should be negative.
    * @param num either the value of n, or 1 if it is not in the format.
    * @param denom either the value of m, or 1 if it is not in the format.
    * @return the parameter id for this expression in the current context.
    */
-  int parse_pi_expr(bool negative, ParamType num, ParamType denom);
+  int parse_pi_term(bool negative, ParamType num, ParamType denom);
 
   /**
    * The context against which, all symbolic parameters are initialized, and


### PR DESCRIPTION
**Summary**

Allows for expressions with binary (+) and (-).

**Details**

The current version of `ParamParser` assumes that each expression is a single term. This term is either a multiple of pi, a literal value, or the name of a parameter variable. However, it is not possible to add or subtract terms in a single expression. On the other hand, many tools (such as `dumps(circ)` in qiskit) generate OpenQASM files with expressions consisting of two or more terms. These terms often mix constants with parameter variables.

The pull request adds simple support for multi-term expressions. The parser assumes that each expression is of the form `t` , `-t` , `e+t`,  and `e-t` , where `e` is an expression and `t` is a term. This inductive definition is relatively easy to parse, and should support the parameters generated by `dumps`.