### PR TITLE
[Context] Halved parameter flag.

### DIFF
--- a/src/quartz/context/context.cpp
+++ b/src/quartz/context/context.cpp
@@ -244,6 +244,10 @@ bool Context::param_is_expression(int id) const {
   return param_info_->param_is_expression(id);
 }
 
+bool Context::param_is_halved(int id) const {
+  return param_info_->param_is_halved(id);
+}
+
 CircuitWire *Context::get_param_wire(int id) const {
   return param_info_->get_param_wire(id);
 }

--- a/src/quartz/context/context.cpp
+++ b/src/quartz/context/context.cpp
@@ -30,8 +30,9 @@ Context::Context(const std::vector<GateType> &supported_gates,
   may_use_halved_params_ = false;
   for (const auto &g : gates_) {
     for (int i = 0; i < g.second->get_num_parameters(); ++i) {
-      bool is_halved = g.second->is_param_halved(i);
-      may_use_halved_params_ = may_use_halved_params_ || is_halved;
+      if (g.second->is_param_halved(i)) {
+        may_use_halved_params_ = true;
+      }
     }
   }
 }

--- a/src/quartz/context/context.cpp
+++ b/src/quartz/context/context.cpp
@@ -30,7 +30,7 @@ Context::Context(const std::vector<GateType> &supported_gates,
   is_halved_ = false;
   for (const auto &g : gates_) {
     for (int i = 0; i < g.second->get_num_parameters(); ++i) {
-      is_halved_ ||= g.second->is_param_halved(i);
+      is_halved_ || = g.second->is_param_halved(i);
     }
   }
 }

--- a/src/quartz/context/context.cpp
+++ b/src/quartz/context/context.cpp
@@ -30,7 +30,7 @@ Context::Context(const std::vector<GateType> &supported_gates,
   is_halved_ = false;
   for (const auto &g : gates_) {
     for (int i = 0; i < g.second->get_num_parameters(); ++i) {
-      is_halved_ |= g.second->is_param_halved(i);
+      is_halved_ ||= g.second->is_param_halved(i);
     }
   }
 }

--- a/src/quartz/context/context.cpp
+++ b/src/quartz/context/context.cpp
@@ -27,10 +27,11 @@ Context::Context(const std::vector<GateType> &supported_gates,
   }
 
   // Precomputes whether any of the gates use halved parameters.
-  is_halved_ = false;
+  may_use_halved_params_ = false;
   for (const auto &g : gates_) {
     for (int i = 0; i < g.second->get_num_parameters(); ++i) {
-      is_halved_ || = g.second->is_param_halved(i);
+      bool is_halved = g.second->is_param_halved(i);
+      may_use_halved_params_ = may_use_halved_params_ || is_halved;
     }
   }
 }
@@ -216,7 +217,7 @@ int Context::get_new_param_id(const ParamType &param) {
 }
 
 int Context::get_new_param_id() {
-  return param_info_->get_new_param_id(is_halved_);
+  return param_info_->get_new_param_id(may_use_halved_params_);
 }
 
 int Context::get_new_param_expression_id(

--- a/src/quartz/context/context.h
+++ b/src/quartz/context/context.h
@@ -163,6 +163,7 @@ class Context {
   bool insert_gate(GateType tp);
 
   size_t global_unique_id;
+  bool is_halved_;
   std::unordered_map<GateType, std::unique_ptr<Gate>> gates_;
   std::unordered_map<
       GateType, std::unordered_map<std::vector<bool>, std::unique_ptr<Gate>>>

--- a/src/quartz/context/context.h
+++ b/src/quartz/context/context.h
@@ -100,6 +100,7 @@ class Context {
   [[nodiscard]] bool param_is_symbolic(int id) const;
   [[nodiscard]] bool param_has_value(int id) const;
   [[nodiscard]] bool param_is_expression(int id) const;
+  [[nodiscard]] bool param_is_halved(int id) const;
 
   [[nodiscard]] CircuitWire *get_param_wire(int id) const;
 

--- a/src/quartz/context/context.h
+++ b/src/quartz/context/context.h
@@ -164,7 +164,7 @@ class Context {
   bool insert_gate(GateType tp);
 
   size_t global_unique_id;
-  bool is_halved_;
+  bool may_use_halved_params_;
   std::unordered_map<GateType, std::unique_ptr<Gate>> gates_;
   std::unordered_map<
       GateType, std::unordered_map<std::vector<bool>, std::unique_ptr<Gate>>>

--- a/src/quartz/context/param_info.cpp
+++ b/src/quartz/context/param_info.cpp
@@ -140,6 +140,11 @@ bool ParamInfo::param_is_expression(int id) const {
          !parameter_wires_[id]->input_gates.empty();
 }
 
+bool ParamInfo::param_is_halved(int id) const {
+  return id >= 0 && id < (int)is_parameter_halved_.size() &&
+         is_parameter_halved_[id];
+}
+
 CircuitWire *ParamInfo::get_param_wire(int id) const {
   if (id >= 0 && id < (int)parameter_wires_.size()) {
     return parameter_wires_[id].get();

--- a/src/quartz/context/param_info.cpp
+++ b/src/quartz/context/param_info.cpp
@@ -56,6 +56,7 @@ std::vector<ParamType> ParamInfo::get_all_input_param_values() const {
 
 int ParamInfo::get_new_param_id(const ParamType &param) {
   int id = (int)is_parameter_symbolic_.size();
+  assert(id == (int)is_parameter_halved_.size());
   is_parameter_symbolic_.push_back(false);
   is_parameter_halved_.push_back(false);
   auto wire = std::make_unique<CircuitWire>();

--- a/src/quartz/context/param_info.cpp
+++ b/src/quartz/context/param_info.cpp
@@ -12,10 +12,10 @@ bool is_symbolic_constant(Gate *op) {
   return rv;
 }
 
-ParamInfo::ParamInfo(int num_input_symbolic_params) {
+ParamInfo::ParamInfo(int num_input_symbolic_params, bool is_halved) {
   gen_random_parameters(num_input_symbolic_params);
   for (int i = 0; i < num_input_symbolic_params; i++) {
-    get_new_param_id();
+    get_new_param_id(is_halved);
   }
 }
 
@@ -57,6 +57,7 @@ std::vector<ParamType> ParamInfo::get_all_input_param_values() const {
 int ParamInfo::get_new_param_id(const ParamType &param) {
   int id = (int)is_parameter_symbolic_.size();
   is_parameter_symbolic_.push_back(false);
+  is_parameter_halved_.push_back(false);
   auto wire = std::make_unique<CircuitWire>();
   wire->type = CircuitWire::input_param;
   wire->index = id;
@@ -65,9 +66,10 @@ int ParamInfo::get_new_param_id(const ParamType &param) {
   return id;
 }
 
-int ParamInfo::get_new_param_id() {
+int ParamInfo::get_new_param_id(bool is_halved) {
   int id = (int)is_parameter_symbolic_.size();
   is_parameter_symbolic_.push_back(true);
+  is_parameter_halved_.push_back(is_halved);
   // Make sure to generate a random parameter for each symbolic parameter.
   gen_random_parameters(id + 1);
   auto wire = std::make_unique<CircuitWire>();
@@ -98,6 +100,7 @@ int ParamInfo::get_new_param_expression_id(
   }
   int id = (int)is_parameter_symbolic_.size();
   is_parameter_symbolic_.push_back(true);
+  is_parameter_halved_.push_back(false);
   auto circuit_gate = std::make_unique<CircuitGate>();
   circuit_gate->gate = op;
   for (auto &input_id : parameter_indices) {

--- a/src/quartz/context/param_info.h
+++ b/src/quartz/context/param_info.h
@@ -76,6 +76,7 @@ class ParamInfo {
   [[nodiscard]] bool param_is_symbolic(int id) const;
   [[nodiscard]] bool param_has_value(int id) const;
   [[nodiscard]] bool param_is_expression(int id) const;
+  [[nodiscard]] bool param_is_halved(int id) const;
 
   [[nodiscard]] CircuitWire *get_param_wire(int id) const;
 

--- a/src/quartz/context/param_info.h
+++ b/src/quartz/context/param_info.h
@@ -20,11 +20,11 @@ class ParamInfo {
   /**
    * Default constructor: initialize 0 parameters.
    */
-  ParamInfo() : ParamInfo(0) {}
+  ParamInfo() : ParamInfo(0, false) {}
   /**
    * Initialize |num_input_symbolic_params| input symbolic parameters.
    */
-  explicit ParamInfo(int num_input_symbolic_params);
+  explicit ParamInfo(int num_input_symbolic_params, bool is_halved);
 
   /**
    * Generate random values for random testing for input symbolic parameters.
@@ -58,9 +58,10 @@ class ParamInfo {
   int get_new_param_id(const ParamType &param);
   /**
    * Create a new symbolic parameter.
+   * @param is_halved If true, then used by a gate with period 4*pi.
    * @return The index of the new symbolic parameter.
    */
-  int get_new_param_id();
+  int get_new_param_id(bool is_halved);
   /**
    * Create a new parameter expression. If all input parameters are concrete,
    * compute the result directly instead of creating the expression.
@@ -101,6 +102,7 @@ class ParamInfo {
   std::vector<ParamType> parameter_values_;
   std::vector<std::unique_ptr<CircuitWire>> parameter_wires_;
   std::vector<bool> is_parameter_symbolic_;
+  std::vector<bool> is_parameter_halved_;
   // A holder for parameter expressions.
   std::vector<std::unique_ptr<CircuitGate>> parameter_expressions_;
 

--- a/src/quartz/gate/gate.cpp
+++ b/src/quartz/gate/gate.cpp
@@ -44,6 +44,8 @@ bool Gate::is_sparse() const { return false; }
 
 bool Gate::is_diagonal() const { return false; }
 
+bool Gate::is_param_halved(int i) const { return false; }
+
 int Gate::get_num_control_qubits() const { return 0; }
 
 std::vector<bool> Gate::get_control_state() const {

--- a/src/quartz/gate/gate.h
+++ b/src/quartz/gate/gate.h
@@ -41,6 +41,13 @@ class Gate {
    */
   [[nodiscard]] virtual bool is_diagonal() const;
   /**
+   * @param i the index of the parameter to check
+   * @return True if this gate is parameterized and parameter i has a period of
+   * 4*pi as opposed to 2*pi (e.g., rx, ry, rz).
+   * Default value is false.
+   */
+  [[nodiscard]] virtual bool is_param_halved(int i) const;
+  /**
    * @return The number of control qubits for controlled gates; or 0 if it is
    * not a controlled gate.
    * Default value is 0.

--- a/src/quartz/gate/rx.h
+++ b/src/quartz/gate/rx.h
@@ -20,6 +20,7 @@ class RXGate : public Gate {
     }
     return cached_matrices[theta].get();
   }
+  bool is_param_halved(int i) const override { return true; }
   std::unordered_map<float, std::unique_ptr<Matrix<2>>> cached_matrices;
 };
 

--- a/src/quartz/gate/ry.h
+++ b/src/quartz/gate/ry.h
@@ -19,6 +19,7 @@ class RYGate : public Gate {
     }
     return cached_matrices[theta].get();
   }
+  bool is_param_halved(int i) const override { return true; }
   std::unordered_map<float, std::unique_ptr<Matrix<2>>> cached_matrices;
 };
 

--- a/src/quartz/gate/rz.h
+++ b/src/quartz/gate/rz.h
@@ -21,6 +21,7 @@ class RZGate : public Gate {
     return cached_matrices[theta].get();
   }
   bool is_sparse() const override { return true; }
+  bool is_param_halved(int i) const override { return true; }
   std::unordered_map<float, std::unique_ptr<Matrix<2>>> cached_matrices;
 };
 

--- a/src/quartz/gate/u3.h
+++ b/src/quartz/gate/u3.h
@@ -26,6 +26,7 @@ class U3Gate : public Gate {
     }
     return cached_matrices[theta][phi][lambda].get();
   }
+  bool is_param_halved(int i) const override { return i == 0; }
   std::unordered_map<
       float, std::unordered_map<
                  float, std::unordered_map<float, std::unique_ptr<Matrix<2>>>>>

--- a/src/test/gen_ecc_set.h
+++ b/src/test/gen_ecc_set.h
@@ -15,7 +15,7 @@ void gen_ecc_set(const std::vector<GateType> &supported_gates,
                  const std::string &file_prefix, bool unique_parameters,
                  bool generate_representative_set, int num_qubits,
                  int num_input_parameters, int max_num_quantum_gates) {
-  ParamInfo param_info(/*num_input_symbolic_params=*/num_input_parameters);
+  ParamInfo param_info(num_input_parameters, false);
   Context ctx(supported_gates, num_qubits, &param_info);
   Generator gen(&ctx);
 

--- a/src/test/test_all.cpp
+++ b/src/test/test_all.cpp
@@ -11,7 +11,7 @@ using namespace quartz;
 
 int main() {
   std::cout << "Hello, World!" << std::endl;
-  ParamInfo param_info(/*num_input_symbolic_params=*/2);
+  ParamInfo param_info(/*num_input_symbolic_params=*/2, false);
   Context ctx({GateType::x, GateType::y, GateType::add, GateType::neg,
                GateType::u2, GateType::u3, GateType::cx},
               2, &param_info);

--- a/src/test/test_bfs.cpp
+++ b/src/test/test_bfs.cpp
@@ -9,7 +9,7 @@ int main() {
   const bool run_bfs_unverified = false;
   const bool run_bfs_verified = true;  // with representative pruning
 
-  ParamInfo param_info(/*num_input_symbolic_params=*/num_input_parameters);
+  ParamInfo param_info(num_input_parameters, false);
   Context ctx({GateType::h}, num_qubits, &param_info);
   Generator gen(&ctx);
 

--- a/src/test/test_constants.cpp
+++ b/src/test/test_constants.cpp
@@ -7,7 +7,7 @@
 using namespace quartz;
 
 int main() {
-  ParamInfo param_info(0);
+  ParamInfo param_info;
   Context ctx({GateType::rx}, 2, &param_info);
 
   QASMParser parser(&ctx);

--- a/src/test/test_generator.cpp
+++ b/src/test/test_generator.cpp
@@ -6,7 +6,7 @@
 using namespace quartz;
 
 int main() {
-  ParamInfo param_info(/*num_input_symbolic_params=*/3);
+  ParamInfo param_info(/*num_input_symbolic_params=*/3, false);
   Context ctx({GateType::x, GateType::y, GateType::cx, GateType::h}, 3,
               &param_info);
   Generator gen(&ctx);

--- a/src/test/test_generator.h
+++ b/src/test/test_generator.h
@@ -11,7 +11,7 @@ void test_generator(const std::vector<GateType> &support_gates, int num_qubits,
                     int max_num_input_parameters, int max_num_gates,
                     bool verbose, const std::string &save_file_name,
                     bool count_minimal_representations = false) {
-  ParamInfo param_info(/*num_input_symbolic_params=*/max_num_input_parameters);
+  ParamInfo param_info(max_num_input_parameters, false);
   Context ctx(support_gates, num_qubits, &param_info);
   Generator generator(&ctx);
   Dataset dataset;

--- a/src/test/test_mult.cpp
+++ b/src/test/test_mult.cpp
@@ -7,7 +7,7 @@
 using namespace quartz;
 
 int main() {
-  ParamInfo param_info(0);
+  ParamInfo param_info;
   Context ctx({GateType::rx, GateType::mult}, 1, &param_info);
 
   auto p0 = ctx.get_new_param_id(2.0);

--- a/src/test/test_optimize.cpp
+++ b/src/test/test_optimize.cpp
@@ -5,7 +5,7 @@
 using namespace quartz;
 
 int main() {
-  ParamInfo param_info(/*num_input_symbolic_params=*/2);
+  ParamInfo param_info(/*num_input_symbolic_params=*/2, false);
   Context ctx({GateType::input_qubit, GateType::input_param, GateType::cx,
                GateType::h, GateType::rz, GateType::x, GateType::add},
               /*num_qubits=*/3, &param_info);

--- a/src/test/test_phase_shift.cpp
+++ b/src/test/test_phase_shift.cpp
@@ -15,7 +15,7 @@ int main() {
   const int num_input_parameters = 1;
   const int max_num_gates = 2;
   const int max_num_param_gates = 1;
-  ParamInfo param_info(/*num_input_symbolic_params=*/num_input_parameters);
+  ParamInfo param_info(num_input_parameters, false);
   Context ctx({GateType::rz, GateType::u1, GateType::add}, num_qubits,
               &param_info);
 

--- a/src/test/test_pi.cpp
+++ b/src/test/test_pi.cpp
@@ -7,7 +7,7 @@
 using namespace quartz;
 
 int main() {
-  ParamInfo param_info(0);
+  ParamInfo param_info;
   Context ctx({GateType::rx, GateType::pi}, 1, &param_info);
 
   auto p0 = ctx.get_new_param_id(PI / 2);

--- a/src/test/test_pruning.h
+++ b/src/test/test_pruning.h
@@ -16,7 +16,7 @@ void test_pruning(
     int max_num_param_gates = 1, bool run_representative_pruning = true,
     bool run_original = true, bool run_original_unverified = false,
     bool run_original_verified = true, bool unique_parameters = false) {
-  ParamInfo param_info(/*num_input_symbolic_params=*/num_input_parameters);
+  ParamInfo param_info(num_input_parameters, false);
   Context ctx(supported_gates, num_qubits, &param_info);
   Generator gen(&ctx);
 

--- a/src/test/test_qasm_parser.cpp
+++ b/src/test/test_qasm_parser.cpp
@@ -350,7 +350,7 @@ int main() {
   test_qasm3_qubits();
   std::cout << "[Sybmolic Parameter Parsing Tests]" << std::endl;
   test_param_parsing();
-  std::cout << "[Sybmolic Summation Parsing Tests]" << std::endl;
+  std::cout << "[Symbolic Summation Parsing Tests]" << std::endl;
   test_sum_parsing();
   std::cout << "[Halved Symbolic Parameters]" << std::endl;
   test_halved_param_ids();

--- a/src/test/test_qasm_parser.cpp
+++ b/src/test/test_qasm_parser.cpp
@@ -16,7 +16,7 @@ bool has_exprs(Context &ctx, CircuitSeq *seq) {
 }
 
 void test_symbolic_exprs() {
-  ParamInfo param_info(0);
+  ParamInfo param_info;
   Context ctx({GateType::rx, GateType::ry, GateType::rz, GateType::cx,
                GateType::mult, GateType::pi},
               2, &param_info);
@@ -87,7 +87,7 @@ void test_symbolic_exprs() {
 }
 
 void test_qasm2_qubits() {
-  ParamInfo param_info(0);
+  ParamInfo param_info;
   Context ctx({GateType::cx}, 5, &param_info);
 
   QASMParser parser(&ctx);
@@ -116,7 +116,7 @@ void test_qasm2_qubits() {
 }
 
 void test_qasm3_qubits() {
-  ParamInfo param_info(0);
+  ParamInfo param_info;
   Context ctx({GateType::cx}, 7, &param_info);
 
   QASMParser parser(&ctx);
@@ -147,7 +147,7 @@ void test_qasm3_qubits() {
 }
 
 void test_param_parsing() {
-  ParamInfo param_info(0);
+  ParamInfo param_info;
   Context ctx({GateType::cx, GateType::rx}, 2, &param_info);
 
   QASMParser parser(&ctx);
@@ -224,7 +224,7 @@ void test_param_parsing() {
 }
 
 void test_sum_parsing() {
-  ParamInfo param_info(0);
+  ParamInfo param_info;
   Context ctx({GateType::rx, GateType::mult, GateType::add, GateType::pi}, 2,
               &param_info);
 

--- a/src/test/test_qasm_parser.cpp
+++ b/src/test/test_qasm_parser.cpp
@@ -284,6 +284,63 @@ void test_sum_parsing() {
   }
 }
 
+bool test_halved_param_context(Context &ctx, bool is_halved) {
+  auto g = ctx.get_gate(GateType::neg);
+
+  auto param_id = ctx.get_new_param_id();
+  auto const_id = ctx.get_new_param_id(0.5);
+  auto exprs_id = ctx.get_new_param_expression_id({param_id}, g);
+
+  if (ctx.param_is_halved(param_id) != is_halved) {
+    std::cout << "is_param_halved returned wrong val for symb." << std::endl;
+    return false;
+  }
+
+  if (ctx.param_is_halved(const_id)) {
+    std::cout << "is_param_halved returned wrong val for const." << std::endl;
+    return false;
+  }
+
+  if (ctx.param_is_halved(exprs_id)) {
+    std::cout << "is_param_halved returned wrong val for expr." << std::endl;
+    return false;
+  }
+
+  return true;
+}
+
+void test_halved_param_ids() {
+  // Default parameters constructed by ParamInfo.
+  ParamInfo param_info_1(4, false);
+  if (param_info_1.param_is_halved(2)) {
+    std::cout << "ParamInfo(4,false): param_is_halved(2) == true" << std::endl;
+    assert(false);
+  }
+
+  // Halved parameters constructed by ParamInfo.
+  ParamInfo param_info_2(4, true);
+  if (!param_info_2.param_is_halved(2)) {
+    std::cout << "ParamInfo(4,true): param_is_halved(2) == false" << std::endl;
+    assert(false);
+  }
+
+  // Default parameters constructed by a Context.
+  ParamInfo param_info_3;
+  Context ctx_3({GateType::x, GateType::ry, GateType::neg}, 2, &param_info_3);
+  if (!test_halved_param_context(ctx_3, true)) {
+    std::cout << "Context failed to handle halved param gate." << std::endl;
+    assert(false);
+  }
+
+  // Halved parameters constructed by a Context.
+  ParamInfo param_info_4;
+  Context ctx_4({GateType::x, GateType::y, GateType::neg}, 2, &param_info_4);
+  if (!test_halved_param_context(ctx_4, false)) {
+    std::cout << "Context failed to handle standard gates." << std::endl;
+    assert(false);
+  }
+}
+
 int main() {
   std::cout << "[Symbolic Expression Tests]" << std::endl;
   test_symbolic_exprs();
@@ -295,4 +352,6 @@ int main() {
   test_param_parsing();
   std::cout << "[Sybmolic Summation Parsing Tests]" << std::endl;
   test_sum_parsing();
+  std::cout << "[Halved Symbolic Parameters]" << std::endl;
+  test_halved_param_ids();
 }

--- a/src/test/test_sparsity.cpp
+++ b/src/test/test_sparsity.cpp
@@ -26,7 +26,7 @@ int nnz(const std::vector<Vector> &mat, double eps) {
 void test_sparsity(const std::vector<GateType> &supported_gates,
                    const std::string &file_prefix, int num_qubits,
                    int num_input_parameters, int max_num_quantum_gates) {
-  ParamInfo param_info(/*num_input_symbolic_params=*/num_input_parameters);
+  ParamInfo param_info(num_input_parameters, false);
   Context ctx(supported_gates, num_qubits, &param_info);
   Generator gen(&ctx);
 


### PR DESCRIPTION
**Summary**

This pull request introduces a flag for each parameter, which identifies whether it is halved or not. A halved parameter is a symbolic parameter that can be used in gates which take parameters of the form $\theta / 2$. Examples of such gates include `rx`, `ry`, and `rz`.

**Details**

This pull request makes two changes to Quartz. First, each gate now has an `is_param_halved(i)` method, which returns true if parameter `i` is of the form $\theta / 2$. The parameter index is taken an argument, since gates such as `u3` have both halved parameters and standard parameters.

This new metadata is then used by the `Context` to determine if any halved parameter gates are in use. If such a gate is in use, then the context conservatively assumes that the parameter will appear in a halved parameter gate.

This pull request should not change the behaviour of Quartz in any way.

**Purpose**

This pull request is a partial solution to issue #190. In particular, this pull request adds support for the halved_parameter flag. This is to ensure that the maintainers of Quartz are satisfied with the solution, before integrating it with the `QasmParser`.