### PR TITLE
Parser support for halved parameters.

### DIFF
--- a/src/quartz/circuitseq/circuitseq.cpp
+++ b/src/quartz/circuitseq/circuitseq.cpp
@@ -994,11 +994,22 @@ CircuitSeq::from_qasm_style_string(Context *ctx, const std::string &str) {
 
 std::string CircuitSeq::to_qasm_style_string(Context *ctx,
                                              int param_precision) const {
+  // Checks if parameters are in use.
+  for (auto param : get_input_param_indices(ctx)) {
+    if (ctx->param_is_symbolic(param)) {
+      std::cerr << "to_qasm_style_string only supports consts." << std::endl;
+      break;
+    }
+  }
+
+  // Generates header.
   std::string result = "OPENQASM 2.0;\n"
                        "include \"qelib1.inc\";\n"
                        "qreg q[";
   result += std::to_string(get_num_qubits());
   result += "];\n";
+
+  // Populates gate list.
   for (auto &gate : gates) {
     result += gate->to_qasm_style_string(ctx, param_precision);
   }

--- a/src/quartz/parser/qasm_parser.cpp
+++ b/src/quartz/parser/qasm_parser.cpp
@@ -130,8 +130,8 @@ int ParamParser::parse_symb_param(bool negative, std::string name, int i,
                                   bool is_halved) {
   // Attempts to look up the symbolic parameter identifier.
   if (symb_params_[name].count(i) == 0) {
-    std::cerr << "Invalid parameter reference: "
-              << name << "[" << i << "]" << std::endl;
+    std::cerr << "Invalid parameter reference: " << name << "[" << i << "]"
+              << std::endl;
     assert(false);
     return -1;
   }

--- a/src/quartz/parser/qasm_parser.h
+++ b/src/quartz/parser/qasm_parser.h
@@ -114,9 +114,10 @@ class ParamParser {
    * value or of the form n/(m*pi).
    * @param negative if true, then the parameter should be negative.
    * @param p the literal value as a floating-point value.
+   * @param is_halved if true, then the parameter is used in a halved context.
    * @return the parameter id for this expression in the current context.
    */
-  int parse_number(bool negative, ParamType p);
+  int parse_number(bool negative, ParamType p, bool is_halved);
 
   /**
    * Implementation details for parse_term when the term is of the form pi*n,
@@ -124,9 +125,11 @@ class ParamParser {
    * @param negative if true, then the parameter should be negative.
    * @param num either the value of n, or 1 if it is not in the format.
    * @param denom either the value of m, or 1 if it is not in the format.
+   * @param is_halved if true, then the parameter is used in a halved context.
    * @return the parameter id for this expression in the current context.
    */
-  int parse_pi_term(bool negative, ParamType num, ParamType denom);
+  int parse_pi_term(bool negative, ParamType num, ParamType denom,
+                    bool is_halved);
 
   /**
    * The context against which, all symbolic parameters are initialized, and

--- a/src/quartz/parser/qasm_parser.h
+++ b/src/quartz/parser/qasm_parser.h
@@ -132,6 +132,17 @@ class ParamParser {
                     bool is_halved);
 
   /**
+   * Implementation details for parse_term when the term is of the form either
+   * name[i] or -name[i].
+   * @param negative if true, then the parameter should be negative.
+   * @param name the name of symbolic parameter variable.
+   * @param i the index into the symbolic parameter variable.
+   * @param is_halved if true, then the parameter is used in a halved context.
+   * @return the parameter id for this expression in the current context.
+   */
+  int parse_symb_param(bool negative, std::string name, int i, bool is_halved);
+
+  /**
    * The context against which, all symbolic parameters are initialized, and
    * all expressions are evaluated.
    */

--- a/src/test/test_qasm_parser.cpp
+++ b/src/test/test_qasm_parser.cpp
@@ -471,9 +471,9 @@ void test_halved_param_ids() {
 //
 void test_printing_halved_params() {
   ParamInfo param_info;
-  Context ctx({GateType::p, GateType::rx, GateType::add, GateType::neg,
-               GateType::pi},
-              &param_info);
+  Context ctx(
+      {GateType::p, GateType::rx, GateType::add, GateType::neg, GateType::pi},
+      &param_info);
 
   QASMParser parser(&ctx);
   parser.use_symbolic_pi(true);
@@ -494,7 +494,8 @@ void test_printing_halved_params() {
   std::string act = seq->to_qasm_style_string(&ctx, 0.1);
   if (act != str) {
     std::cout << "to_qasm_style_string: failed to handle halved parameters."
-              << std::endl << act << std::endl;
+              << std::endl
+              << act << std::endl;
     assert(false);
   }
 }

--- a/src/test/test_qasm_parser.cpp
+++ b/src/test/test_qasm_parser.cpp
@@ -466,6 +466,39 @@ void test_halved_param_ids() {
   }
 }
 
+//
+// Tests to_qasm_style_string with mixed constants.
+//
+void test_printing_halved_params() {
+  ParamInfo param_info;
+  Context ctx({GateType::p, GateType::rx, GateType::add, GateType::neg,
+               GateType::pi},
+              &param_info);
+
+  QASMParser parser(&ctx);
+  parser.use_symbolic_pi(true);
+
+  std::string str = "OPENQASM 2.0;\n"
+                    "include \"qelib1.inc\";\n"
+                    "qreg q[1];\n"
+                    "rx(2) q[0];\n"
+                    "p(2) q[0];\n";
+
+  CircuitSeq *seq = nullptr;
+  if (!parser.load_qasm_str(str, seq)) {
+    std::cout << "Unexpected parsing failure." << std::endl;
+    assert(false);
+    return;
+  }
+
+  std::string act = seq->to_qasm_style_string(&ctx, 0.1);
+  if (act != str) {
+    std::cout << "to_qasm_style_string: failed to handle halved parameters."
+              << std::endl << act << std::endl;
+    assert(false);
+  }
+}
+
 int main() {
   std::cout << "[Symbolic Expression Tests]" << std::endl;
   test_symbolic_exprs();
@@ -479,4 +512,6 @@ int main() {
   test_sum_parsing();
   std::cout << "[Halved Symbolic Parameters]" << std::endl;
   test_halved_param_ids();
+  std::cout << "[Printing Halved Constant Parameters]" << std::endl;
+  test_printing_halved_params();
 }


### PR DESCRIPTION
**Summary**

This pull request extends the OpenQASM parser and code generator to support halved parameters.

**Related Issues**

This pull request should resolve issue #190.

**Details**

To parse gates with halved parameters, the following three changes are made to `QasmParser`.

- If a halved symbolic parameter `p[i]` is used in a context where parameters are not halved, then the parameter is scaled by `2`. Formally, it is replaced by `p[i] + p[i]`.
- If a standard symbolic parameter is used in a context where parameters are halved, then an error is raised.
- If a constant parameter is used in a context where parameters are halved, then the parameter is scaled by `1/2`.

To print gates with halved parameters, `to_qasm_style_string` now scales constant halved parameters by a factor of `2`.

Evidently, these changes increase the complexity of symbolic parameter parsing. For this reason, the symbolic parameter parsing code has been factored out into its own method `ParamParser::parse_symb_param`. While testing these changes, it was noted that `ParamParser::parse_symb_param` did not support negative parameters, which is also resolved in this pull request.

**Note**

The current circuit generator does not support symbolic parameters. This pull request does not introduce this feature. However, an error message was added to indicate when a symbolic parameter could possibly get discarded.