### PR TITLE
[bug] [verifier] Fix a bug when finding common subcircuits

### DIFF
--- a/src/quartz/circuitseq/circuitseq.cpp
+++ b/src/quartz/circuitseq/circuitseq.cpp
@@ -1286,25 +1286,21 @@ CircuitSeq::get_permuted_seq(const std::vector<int> &qubit_permutation,
 std::unique_ptr<CircuitSeq>
 CircuitSeq::get_suffix_seq(const std::unordered_set<CircuitGate *> &start_gates,
                            Context *ctx) const {
-  // For topological sort
-  std::unordered_map<CircuitGate *, int> gate_remaining_in_degree;
-  for (auto &gate : start_gates) {
-    gate_remaining_in_degree[gate] = 0;  // ready to include
-  }
+  // Note: we should not do a topological sort because it is possible that
+  // |start_gates| does not touch all qubits.
+  // For example, start gates can be T(Q1) when the circuit is
+  // T(Q1) T(Q3) CX(Q1, Q3) CX(Q0, Q2) CX(Q0, Q1),
+  // in which case the suffix sequence is T(Q1) CX(Q1, Q3) CX(Q0, Q1).
+  std::unordered_set<CircuitGate *> visited_gates = start_gates;
   auto result = std::make_unique<CircuitSeq>(get_num_qubits());
-  // The result should be a subsequence of this circuit
+  // The result should be a subsequence of this circuit.
+  // Note that |gates| is a topological order
   for (auto &gate : gates) {
-    if (gate_remaining_in_degree.count(gate.get()) > 0 &&
-        gate_remaining_in_degree[gate.get()] <= 0) {
+    if (visited_gates.count(gate.get()) > 0) {
       result->add_gate(gate.get(), ctx);
       for (auto &output_wire : gate->output_wires) {
         for (auto &output_gate : output_wire->output_gates) {
-          // For topological sort
-          if (gate_remaining_in_degree.count(output_gate) == 0) {
-            gate_remaining_in_degree[output_gate] =
-                output_gate->gate->get_num_qubits();
-          }
-          gate_remaining_in_degree[output_gate]--;
+          visited_gates.insert(output_gate);
         }
       }
     }

--- a/src/quartz/verifier/verifier.cpp
+++ b/src/quartz/verifier/verifier.cpp
@@ -108,7 +108,9 @@ bool Verifier::equivalent(Context *ctx, const CircuitSeq *circuit1,
       // CircuitGate::equivalent())
       if (!CircuitGate::equivalent(gate1, gate2, wires_mapping,
                                    /*update_mapping=*/true, &wires_to_search)) {
-        // If not matched, block each qubit of both gates
+        // If not matched, block each qubit of gate1.
+        // Note that we should not block qubits of gate2 because it's not
+        // on the frontier.
         for (auto &input_wire : gate1->input_wires) {
           if (input_wire->is_qubit()) {
             qubit_blocked[input_wire->index] = true;
@@ -121,9 +123,6 @@ bool Verifier::equivalent(Context *ctx, const CircuitSeq *circuit1,
           }
         }
         leftover_gates_start1.insert(gate1);
-        for (auto &output_wire : gate2->output_wires) {
-          qubit_blocked[output_wire->index] = true;
-        }
         leftover_gates_start2.insert(gate2);
       }
     }


### PR DESCRIPTION
This PR fixes a bug in #176.

Before this PR, the common parts of two circuits may not be removed correctly. It was possible that one gate was removed in the first circuit but left in the second circuit, causing the verifier to be unable to verify. I did assert that the numbers of gates removed for both circuits were the same, but the assertion was not triggered in release mode.