### PR TITLE
[verifier] Use trigonometric functions for concrete parameters

### DIFF
--- a/src/python/verifier/verifier.py
+++ b/src/python/verifier/verifier.py
@@ -602,7 +602,7 @@ def compute_params(param_info):
         if param_info[i] == "":  # symbolic
             params.append(symbolic_params.pop(0))
         elif isinstance(param_info[i], (int, float)):  # concrete
-            params.append(param_info[i])
+            params.append((math.cos(param_info[i]), math.sin(param_info[i])))
         else:  # expression
             op = param_info[i][0]
             current_inputs = []


### PR DESCRIPTION
In the verifier, all parameters `theta` are stored in the `cos(theta), sin(theta)` format. This PR aligns concrete parameters with this format so that some other functions work properly.