### PR TITLE
[Verifier] Distinguish parameters only for arithmetic expressions from concrete parameters which uses trigonometric functions

### DIFF
--- a/src/python/verifier/verifier.py
+++ b/src/python/verifier/verifier.py
@@ -601,7 +601,9 @@ def compute_params(param_info):
     for i in range(len(param_info)):
         if param_info[i] == "":  # symbolic
             params.append(symbolic_params.pop(0))
-        elif isinstance(param_info[i], (int, float)):  # concrete
+        elif isinstance(param_info[i], int):  # concrete parameter for calculation
+            params.append(param_info[i])
+        elif isinstance(param_info[i], float):  # concrete parameter to be directly used
             params.append((math.cos(param_info[i]), math.sin(param_info[i])))
         else:  # expression
             op = param_info[i][0]

--- a/src/quartz/circuitseq/circuitgate.cpp
+++ b/src/quartz/circuitseq/circuitgate.cpp
@@ -265,7 +265,7 @@ std::string CircuitGate::to_qasm_style_string(Context *ctx,
     for (auto input_wire : input_wires) {
       if (input_wire->is_parameter()) {
         // Ensures the wire is valid.
-        assert(ctx->param_has_value(input_wire->index));
+        assert(ctx->param_is_const(input_wire->index));
 
         // Determines the parameter value with respect to reparameterization.
         std::ostringstream out;

--- a/src/quartz/circuitseq/circuitseq.cpp
+++ b/src/quartz/circuitseq/circuitseq.cpp
@@ -996,7 +996,7 @@ std::string CircuitSeq::to_qasm_style_string(Context *ctx,
                                              int param_precision) const {
   // Checks if parameters are in use.
   for (auto param : get_input_param_indices(ctx)) {
-    if (ctx->param_is_symbolic(param)) {
+    if (!ctx->param_is_const(param)) {
       std::cerr << "to_qasm_style_string only supports consts." << std::endl;
       break;
     }

--- a/src/quartz/context/context.cpp
+++ b/src/quartz/context/context.cpp
@@ -402,10 +402,23 @@ bool Context::load_param_info_from_json(std::istream &fin) {
       assert(id == i);
     } else {
       // concrete parameter
-      fin.unget();
-      ParamType val;
-      fin >> val;
-      int id = get_new_param_id(val);
+      bool is_float = false;
+      std::string s;  // record the number string
+      while (ch != ',' && ch != ']') {
+        s += ch;
+        if (ch == '.' || ch == 'e' || ch == 'E') {
+          is_float = true;
+        }
+        fin >> ch;
+      }
+      fin.unget();  // put the ',' or ']' back
+      ParamType val = std::stod(s);
+      int id;
+      if (is_float) {
+        id = get_new_param_id(val);
+      } else {
+        id = get_new_arithmetic_param_id(val);
+      }
       assert(id == i);
     }
   }

--- a/src/quartz/context/context.cpp
+++ b/src/quartz/context/context.cpp
@@ -217,6 +217,10 @@ int Context::get_new_param_id(const ParamType &param) {
   return param_info_->get_new_param_id(param);
 }
 
+int Context::get_new_arithmetic_param_id(const ParamType &param) {
+  return param_info_->get_new_arithmetic_param_id(param);
+}
+
 int Context::get_new_param_id() {
   return param_info_->get_new_param_id(may_use_halved_params_);
 }
@@ -238,8 +242,8 @@ bool Context::param_is_symbolic(int id) const {
   return param_info_->param_is_symbolic(id);
 }
 
-bool Context::param_has_value(int id) const {
-  return param_info_->param_has_value(id);
+bool Context::param_is_const(int id) const {
+  return param_info_->param_is_const(id);
 }
 
 bool Context::param_is_expression(int id) const {
@@ -261,7 +265,7 @@ Context::compute_parameters(const std::vector<ParamType> &input_parameters) {
 
 std::vector<int> Context::get_param_permutation(
     const std::vector<int> &input_param_permutation) {
-  int num_parameters = (int)param_info_->is_parameter_symbolic_.size();
+  int num_parameters = (int)param_info_->parameter_class_.size();
   std::vector<int> result = input_param_permutation;
   result.resize(num_parameters, -1);  // fill with -1
   for (int i = (int)input_param_permutation.size(); i < num_parameters; i++) {
@@ -307,7 +311,7 @@ std::vector<int> Context::get_param_permutation(
 void Context::generate_parameter_expressions(
     int max_num_operators_per_expression) {
   assert(max_num_operators_per_expression == 1);
-  int num_input_parameters = (int)param_info_->is_parameter_symbolic_.size();
+  int num_input_parameters = (int)param_info_->parameter_class_.size();
   assert(num_input_parameters > 0);
   if (!param_info_->parameter_expressions_.empty()) {
     std::cerr << "Context::generate_parameter_expressions() called twice for a "
@@ -350,25 +354,7 @@ std::vector<InputParamMaskType> Context::get_param_masks() const {
 }
 
 std::string Context::param_info_to_json() const {
-  std::string result = "[";
-  result += "[";
-  result += std::to_string(param_info_->is_parameter_symbolic_.size());
-  for (int i = 0; i < (int)param_info_->is_parameter_symbolic_.size(); i++) {
-    result += ", ";
-    if (param_is_expression(i)) {
-      result += param_info_->parameter_wires_[i]->input_gates[0]->to_json();
-    } else if (param_info_->is_parameter_symbolic_[i]) {
-      result += "\"\"";
-    } else {
-      result += to_string_with_precision(param_info_->parameter_values_[i],
-                                         /*precision=*/17);
-    }
-  }
-  result += "], ";
-  result += to_json_style_string_with_precision(param_info_->random_parameters_,
-                                                /*precision=*/17);
-  result += "]";
-  return result;
+  return param_info_->to_json();
 }
 
 bool Context::load_param_info_from_json(std::istream &fin) {
@@ -386,8 +372,8 @@ bool Context::load_param_info_from_json(std::istream &fin) {
   }
   int num_params;
   fin >> num_params;
-  param_info_->is_parameter_symbolic_.clear();
-  param_info_->is_parameter_symbolic_.reserve(num_params);
+  param_info_->parameter_class_.clear();
+  param_info_->parameter_class_.reserve(num_params);
   param_info_->parameter_wires_.clear();
   param_info_->parameter_wires_.reserve(num_params);
   param_info_->parameter_values_.clear();

--- a/src/quartz/context/context.h
+++ b/src/quartz/context/context.h
@@ -82,6 +82,12 @@ class Context {
    */
   int get_new_param_id(const ParamType &param);
   /**
+   * Create a new concrete (integer) parameter that can only be used in
+   * arithmetic expressions.
+   * @return The index of the new concrete parameter.
+   */
+  int get_new_arithmetic_param_id(const ParamType &param);
+  /**
    * Create a new symbolic parameter.
    * @return The index of the new symbolic parameter.
    */
@@ -98,7 +104,7 @@ class Context {
   [[nodiscard]] int get_num_parameters() const;
   [[nodiscard]] int get_num_input_symbolic_parameters() const;
   [[nodiscard]] bool param_is_symbolic(int id) const;
-  [[nodiscard]] bool param_has_value(int id) const;
+  [[nodiscard]] bool param_is_const(int id) const;
   [[nodiscard]] bool param_is_expression(int id) const;
   [[nodiscard]] bool param_is_halved(int id) const;
 

--- a/src/quartz/parser/qasm_parser.cpp
+++ b/src/quartz/parser/qasm_parser.cpp
@@ -66,7 +66,8 @@ std::string strip(const std::string &input) {
   return std::string(st, ed.base());
 }
 
-int ParamParser::parse_number(bool negative, ParamType p, bool is_arithmetic, bool is_halved) {
+int ParamParser::parse_number(bool negative, ParamType p, bool is_arithmetic,
+                              bool is_halved) {
   // Handles negative constants.
   if (negative) {
     p = -p;

--- a/src/quartz/parser/qasm_parser.cpp
+++ b/src/quartz/parser/qasm_parser.cpp
@@ -66,7 +66,7 @@ std::string strip(const std::string &input) {
   return std::string(st, ed.base());
 }
 
-int ParamParser::parse_number(bool negative, ParamType p, bool is_halved) {
+int ParamParser::parse_number(bool negative, ParamType p, bool is_arithmetic, bool is_halved) {
   // Handles negative constants.
   if (negative) {
     p = -p;
@@ -79,7 +79,12 @@ int ParamParser::parse_number(bool negative, ParamType p, bool is_halved) {
 
   // Constructs the constant parameter if it does not already exist.
   if (number_params_.count(p) == 0) {
-    int param_id = ctx_->get_new_param_id(p);
+    int param_id;
+    if (is_arithmetic) {
+      param_id = ctx_->get_new_arithmetic_param_id(p);
+    } else {
+      param_id = ctx_->get_new_param_id(p);
+    }
     number_params_[p] = param_id;
   }
   return number_params_[p];
@@ -89,7 +94,7 @@ int ParamParser::parse_pi_term(bool negative, ParamType n, ParamType d,
                                bool is_halved) {
   // If pi is not symbolic, then falls back to constants.
   if (!symbolic_pi_) {
-    return parse_number(negative, n * PI / d, is_halved);
+    return parse_number(negative, n * PI / d, false, is_halved);
   }
 
   // Handles negative coefficients.
@@ -107,7 +112,7 @@ int ParamParser::parse_pi_term(bool negative, ParamType n, ParamType d,
     // Checks if fraction of pi already exists.
     // If (n == 1) then this will cache the final expression.
     if (pi_params_[1].count(d) == 0) {
-      int id = parse_number(false, d, false);
+      int id = parse_number(false, d, true, false);
       auto gate = ctx_->get_gate(GateType::pi);
       pi_params_[1][d] = ctx_->get_new_param_expression_id({id}, gate);
     }
@@ -115,7 +120,7 @@ int ParamParser::parse_pi_term(bool negative, ParamType n, ParamType d,
     // Scales the fraction of pi when the numerator is not equal to 1.
     // If (n != 1), then this will cache the final expression.
     if (n != 1) {
-      int nid = parse_number(false, n, false);
+      int nid = parse_number(false, n, true, false);
       int pid = pi_params_[1][d];
       auto gate = ctx_->get_gate(GateType::mult);
       pi_params_[n][d] = ctx_->get_new_param_expression_id({nid, pid}, gate);
@@ -126,7 +131,7 @@ int ParamParser::parse_pi_term(bool negative, ParamType n, ParamType d,
   return pi_params_[n][d];
 }
 
-int ParamParser::parse_symb_param(bool negative, std::string name, int i,
+int ParamParser::parse_symb_param(bool negative, const std::string &name, int i,
                                   bool is_halved) {
   // Attempts to look up the symbolic parameter identifier.
   if (symb_params_[name].count(i) == 0) {
@@ -352,7 +357,7 @@ int ParamParser::parse_term(bool negative, std::string token, bool is_halved) {
       ParamType p = std::stod(token.substr(0, token.find('/')));
       p /= PI;
       p /= std::stod(token.substr(lparen_pos + 1, mult_pos - lparen_pos - 1));
-      return parse_number(negative, p, is_halved);
+      return parse_number(negative, p, false, is_halved);
     } else {
       // Case: 0.123*pi or 0.123*pi/2
       auto d = token.substr(0, token.find('*'));
@@ -366,7 +371,7 @@ int ParamParser::parse_term(bool negative, std::string token, bool is_halved) {
     }
   } else {
     // Case: 0.123
-    return parse_number(negative, std::stod(token), is_halved);
+    return parse_number(negative, std::stod(token), false, is_halved);
   }
 
   // This line should be unreachable.

--- a/src/quartz/parser/qasm_parser.h
+++ b/src/quartz/parser/qasm_parser.h
@@ -114,10 +114,12 @@ class ParamParser {
    * value or of the form n/(m*pi).
    * @param negative if true, then the parameter should be negative.
    * @param p the literal value as a floating-point value.
+   * @param is_arithmetic if true, then the parameter is only used in arithmetic
+   * expressions and cannot be used directly for quantum gates.
    * @param is_halved if true, then the parameter is used in a halved context.
    * @return the parameter id for this expression in the current context.
    */
-  int parse_number(bool negative, ParamType p, bool is_halved);
+  int parse_number(bool negative, ParamType p, bool is_arithmetic, bool is_halved);
 
   /**
    * Implementation details for parse_term when the term is of the form pi*n,
@@ -140,7 +142,7 @@ class ParamParser {
    * @param is_halved if true, then the parameter is used in a halved context.
    * @return the parameter id for this expression in the current context.
    */
-  int parse_symb_param(bool negative, std::string name, int i, bool is_halved);
+  int parse_symb_param(bool negative, const std::string &name, int i, bool is_halved);
 
   /**
    * The context against which, all symbolic parameters are initialized, and

--- a/src/quartz/parser/qasm_parser.h
+++ b/src/quartz/parser/qasm_parser.h
@@ -119,7 +119,8 @@ class ParamParser {
    * @param is_halved if true, then the parameter is used in a halved context.
    * @return the parameter id for this expression in the current context.
    */
-  int parse_number(bool negative, ParamType p, bool is_arithmetic, bool is_halved);
+  int parse_number(bool negative, ParamType p, bool is_arithmetic,
+                   bool is_halved);
 
   /**
    * Implementation details for parse_term when the term is of the form pi*n,
@@ -142,7 +143,8 @@ class ParamParser {
    * @param is_halved if true, then the parameter is used in a halved context.
    * @return the parameter id for this expression in the current context.
    */
-  int parse_symb_param(bool negative, const std::string &name, int i, bool is_halved);
+  int parse_symb_param(bool negative, const std::string &name, int i,
+                       bool is_halved);
 
   /**
    * The context against which, all symbolic parameters are initialized, and

--- a/src/quartz/tasograph/tasograph.cpp
+++ b/src/quartz/tasograph/tasograph.cpp
@@ -986,7 +986,7 @@ void Graph::rotation_merging(GateType target_rotation) {
     } else if (it.first.ptr->tp == GateType::input_param) {
       todos.push(it.first);
       assert(param_idx.find(it.first) != param_idx.end());
-      assert(context->param_has_value(param_idx[it.first]));
+      assert(context->param_is_const(param_idx[it.first]));
     }
   }
 
@@ -2890,7 +2890,7 @@ ParamType Graph::get_param_value(const Op &op) const {
   if (idx == param_idx.end()) {
     return 0;  // not a parameter
   }
-  if (!context->param_has_value(idx->second)) {
+  if (!context->param_is_const(idx->second)) {
     return 0;  // not constant
   }
   return context->get_param_value(idx->second);
@@ -2901,7 +2901,7 @@ bool Graph::param_has_value(const Op &op) const {
   if (idx == param_idx.end()) {
     return false;  // not a parameter
   }
-  if (!context->param_has_value(idx->second)) {
+  if (!context->param_is_const(idx->second)) {
     return false;  // not constant
   }
   return true;


### PR DESCRIPTION
#203 fixes concrete parameters in the verifier, but causes troubles for symbolic constant expressions like `pi / 2` in the verifier. This PR introduces an enum-like class (but not an enum class so as to allow for member functions) `ParamClass`, and prints [parameters only for arithmetic expressions] as an **integer** while printing [concrete parameters] as **floating-point values**.