### PR TITLE
[optimizer] Add a benchmark for optimization steps

### DIFF
--- a/src/benchmark/CMakeLists.txt
+++ b/src/benchmark/CMakeLists.txt
@@ -7,6 +7,8 @@ file(GLOB_RECURSE NAM_SMALL_CIRCUITS "nam_small_circuits.cpp")
 add_executable(benchmark_nam_small_circuits ${NAM_SMALL_CIRCUITS})
 file(GLOB_RECURSE NAM_MIDDLE_CIRCUITS "nam_middle_circuits.cpp")
 add_executable(benchmark_nam_middle_circuits ${NAM_MIDDLE_CIRCUITS})
+file(GLOB_RECURSE OPTIMIZATION_STEPS "benchmark_optimization_steps.cpp")
+add_executable(benchmark_optimization_steps ${OPTIMIZATION_STEPS})
 
 # TODO: Rename them
 file(GLOB_RECURSE ILP_NUM_STAGES "ilp_num_stages.cpp")

--- a/src/benchmark/benchmark_optimization_steps.cpp
+++ b/src/benchmark/benchmark_optimization_steps.cpp
@@ -1,0 +1,65 @@
+#include "quartz/gate/gate_utils.h"
+#include "quartz/verifier/verifier.h"
+#include "test/test_optimization_steps.h"
+
+#include <filesystem>
+#include <iostream>
+
+using namespace quartz;
+
+const std::vector<std::string> kCircuitNames = {
+    "tof_3",         "barenco_tof_3",  "mod5_4",      "tof_4",
+    "tof_5",         "barenco_tof_4",  "mod_mult_55", "vbe_adder_3",
+    "barenco_tof_5", "csla_mux_3",     "rc_adder_6",  "gf2^4_mult",
+    "tof_10",        "mod_red_21",     "gf2^5_mult",  "csum_mux_9",
+    "qcla_com_7",    "barenco_tof_10", "gf2^6_mult",  "qcla_adder_10",
+    "gf2^7_mult",    "gf2^8_mult",     "qcla_mod_7",  "adder_8",
+    "gf2^9_mult",    "gf2^10_mult"};
+int main() {
+  ParamInfo param_info;
+  Context ctx({GateType::input_qubit, GateType::input_param, GateType::cx,
+               GateType::h, GateType::rz, GateType::x, GateType::pi,
+               GateType::mult, GateType::add},
+              &param_info);
+  EquivalenceSet eqs;
+  // Load equivalent dags from file
+  if (!eqs.load_json(
+          &ctx,
+          (kQuartzRootPath / "eccset/Nam_6_3_complete_ECC_set.json").string(),
+          /*from_verifier=*/false)) {
+    std::cout
+        << "Failed to load equivalence file \""
+        << (kQuartzRootPath / "eccset/Nam_6_3_complete_ECC_set.json").string()
+        << "\"." << std::endl;
+    assert(false);
+  }
+  if (!std::filesystem::exists(kQuartzRootPath / "benchmark-logs")) {
+    std::filesystem::create_directory(kQuartzRootPath / "benchmark-logs");
+  }
+  Verifier verifier;
+  auto xfers = GraphXfer::get_all_xfers_from_ecc(
+      &ctx,
+      (kQuartzRootPath / "eccset/Nam_6_3_complete_ECC_set.json").string());
+  for (const auto &circuit : kCircuitNames) {
+    freopen(((kQuartzRootPath / "benchmark-logs" / circuit).string() + ".log")
+                .c_str(),
+            "w", stdout);
+    test_optimization(&ctx,
+                      (kQuartzRootPath / "circuit/nam-benchmarks" /
+                       (circuit + ".qasm.toffoli_flip"))
+                          .string(),
+                      xfers,
+                      /*timeout=*/1,
+                      (kQuartzRootPath / "benchmark-logs" / circuit).string() +
+                          "_");
+    bool verified = verifier.verify_transformation_steps(
+        &ctx, (kQuartzRootPath / "benchmark-logs" / circuit).string() + "_",
+        /*verbose=*/false);
+    if (verified) {
+      std::cout << "All transformations are verified." << std::endl;
+    } else {
+      std::cout << "Some transformation is not verified." << std::endl;
+    }
+  }
+  return 0;
+}

--- a/src/quartz/tasograph/substitution.h
+++ b/src/quartz/tasograph/substitution.h
@@ -130,6 +130,8 @@ class GraphXfer {
   ccz_cx_u1_xfer(Context *src_ctx, Context *dst_ctx, Context *union_ctx);
   static std::pair<GraphXfer *, GraphXfer *>
   ccz_cx_t_xfer(Context *src_ctx, Context *dst_ctx, Context *union_ctx);
+  static std::vector<GraphXfer *>
+  get_all_xfers_from_ecc(Context *ctx, const std::string &equiv_file_name);
 
  public:
   Context *src_ctx_;

--- a/src/quartz/tasograph/tasograph.cpp
+++ b/src/quartz/tasograph/tasograph.cpp
@@ -1921,42 +1921,9 @@ Graph::optimize(Context *ctx, const std::string &equiv_file_name,
   if (cost_function == nullptr) {
     cost_function = [](Graph *graph) { return graph->total_cost(); };
   }
-
-  EquivalenceSet eqs;
-  // Load equivalent dags from file
-  if (!eqs.load_json(ctx, equiv_file_name, /*from_verifier=*/false)) {
-    std::cout << "Failed to load equivalence file \"" << equiv_file_name
-              << "\"." << std::endl;
-    assert(false);
-  }
-
   // Get xfer from the equivalent set
-  auto eccs = eqs.get_all_equivalence_sets();
-  std::vector<GraphXfer *> xfers;
-  for (const auto &ecc : eccs) {
-    CircuitSeq *representative = ecc.front();
-    /*int representative_depth = representative->get_circuit_depth();
-    for (auto &circuit : ecc) {
-      int circuit_depth = circuit->get_circuit_depth();
-      if (circuit_depth < representative_depth) {
-        representative = circuit;
-        representative_depth = circuit_depth;
-      }
-    }*/
-    for (auto &circuit : ecc) {
-      if (circuit != representative) {
-        auto xfer =
-            GraphXfer::create_GraphXfer(ctx, circuit, representative, true);
-        if (xfer != nullptr) {
-          xfers.push_back(xfer);
-        }
-        xfer = GraphXfer::create_GraphXfer(ctx, representative, circuit, true);
-        if (xfer != nullptr) {
-          xfers.push_back(xfer);
-        }
-      }
-    }
-  }
+  std::vector<GraphXfer *> xfers =
+      GraphXfer::get_all_xfers_from_ecc(ctx, equiv_file_name);
   if (print_message) {
     std::cout << "Number of xfers: " << xfers.size() << std::endl;
   }

--- a/src/test/test_optimization_steps.cpp
+++ b/src/test/test_optimization_steps.cpp
@@ -17,17 +17,19 @@ int main() {
   if (!std::filesystem::exists(kQuartzRootPath / "logs")) {
     std::filesystem::create_directory(kQuartzRootPath / "logs");
   }
+  auto xfers = GraphXfer::get_all_xfers_from_ecc(
+      &ctx, (kQuartzRootPath / "eccset/Clifford_T_5_3_complete_ECC_set.json")
+                .string());
   test_optimization(
       &ctx,
       (kQuartzRootPath / "circuit/example-circuits/barenco_tof_3.qasm")
           .string(),
-      (kQuartzRootPath / "eccset/Clifford_T_5_3_complete_ECC_set.json")
-          .string(),
+      xfers,
       /*timeout=*/12, (kQuartzRootPath / "logs/barenco_tof_3_").string());
   Verifier verifier;
   bool verified = verifier.verify_transformation_steps(
       &ctx, (kQuartzRootPath / "logs/barenco_tof_3_").string(),
-      /*verbose=*/true);
+      /*verbose=*/false);
   if (verified) {
     std::cout << "All transformations are verified." << std::endl;
   } else {

--- a/src/test/test_optimization_steps.h
+++ b/src/test/test_optimization_steps.h
@@ -13,7 +13,7 @@ using namespace quartz;
 
 void test_optimization(
     Context *ctx, const std::string &file_name,
-    const std::string &equivalent_file_name, double timeout,
+    const std::vector<GraphXfer *> &xfers, double timeout,
     const std::string &store_all_steps_file_prefix = std::string()) {
   QASMParser qasm_parser(ctx);
   CircuitSeq *dag = nullptr;
@@ -27,10 +27,10 @@ void test_optimization(
   std::cout << graph.total_cost() << " gates in circuit before optimizing."
             << std::endl;
   auto start = std::chrono::steady_clock::now();
-  auto new_graph =
-      graph.optimize(ctx, equivalent_file_name, file_name, /*print_message=*/
-                     true, /*cost_function=*/nullptr, /*cost_upper_bound=*/-1,
-                     timeout, store_all_steps_file_prefix);
+  auto new_graph = graph.optimize(xfers, graph.total_cost() * 1.05, file_name,
+                                  /*log_file_name=*/"", /*print_message=*/
+                                  true, /*cost_function=*/nullptr, timeout,
+                                  store_all_steps_file_prefix);
   auto end = std::chrono::steady_clock::now();
   std::cout << "After optimizing graph in "
             << (double)std::chrono::duration_cast<std::chrono::milliseconds>(


### PR DESCRIPTION
Also extracts the code to get all transformations from an ECC set to a separate function. Note that `EquivalenceSet::load_json` clears existing parameters in the `ParamInfo` object, it's better to load the transformations at the beginning to avoid clearing parameters if the `ParamInfo` is reused later.