### PR TITLE
[Parser] Let parameter parser reuse the same concrete constant parameters across files

### DIFF
--- a/src/quartz/parser/qasm_parser.cpp
+++ b/src/quartz/parser/qasm_parser.cpp
@@ -66,6 +66,19 @@ std::string strip(const std::string &input) {
   return std::string(st, ed.base());
 }
 
+ParamParser::ParamParser(Context *ctx)
+    : ctx_(ctx), symbolic_pi_(false), first_file_(true) {
+  // Initiate the constant parameter map from the context.
+  const auto &param_values =
+      ctx_->get_param_info()->get_all_input_param_values();
+  const auto &param_class = ctx_->get_param_info()->parameter_class_;
+  for (int i = 0; i < (int)param_class.size(); i++) {
+    if (param_class[i] == ParamClass::concrete_const) {
+      number_params_[param_values[i]] = i;
+    }
+  }
+}
+
 int ParamParser::parse_number(bool negative, ParamType p, bool is_arithmetic,
                               bool is_halved) {
   // Handles negative constants.

--- a/src/quartz/parser/qasm_parser.h
+++ b/src/quartz/parser/qasm_parser.h
@@ -40,8 +40,7 @@ std::string strip(const std::string &input);
  */
 class ParamParser {
  public:
-  ParamParser(Context *ctx)
-      : ctx_(ctx), symbolic_pi_(false), first_file_(true) {}
+  ParamParser(Context *ctx);
 
   /**
    * Adds an angle array declaration to the registry of symbolic parameters.


### PR DESCRIPTION
If two OpenQASM files contain the same concrete constant parameters like `pi*0.125`, the parser will now reuse the same parameter.