### PR TITLE
[verifier] Remove unused qubits when verifying transformation steps

### DIFF
--- a/src/quartz/verifier/verifier.cpp
+++ b/src/quartz/verifier/verifier.cpp
@@ -204,6 +204,10 @@ bool Verifier::equivalent(Context *ctx, const CircuitSeq *circuit1,
     }
   }
   if (remaining_qubits < num_qubits) {
+    if (verbose) {
+      std::cout << "Reducing the number of qubits from " << num_qubits << " to "
+                << remaining_qubits << std::endl;
+    }
     c1 = c1->get_permuted_seq(qubit_permutation, {}, ctx, remaining_qubits);
     c2 = c2->get_permuted_seq(qubit_permutation, {}, ctx, remaining_qubits);
   }


### PR DESCRIPTION
This PR removes unused qubits when verifying transformation steps, so that we don't need to create 2^40 variables in the verifier if the circuit contains 40 qubits but only 2 or 3 qubits are used.

This PR also lets `CircuitSeq::get_permuted_seq` support reducing the number of qubits when cloning (requiring that qubits not cloned are unused), and fixes a potential bug that may cause `CircuitSeq::outputs` to be not in the correct order when qubits are permuted.