### PR TITLE
[verifier] [bug] Fix a bug when removing common prefix gates and do not generate hashing distribution in test_optimization_steps.h

### DIFF
--- a/src/benchmark/benchmark_optimization_steps.cpp
+++ b/src/benchmark/benchmark_optimization_steps.cpp
@@ -40,6 +40,8 @@ int main() {
   auto xfers = GraphXfer::get_all_xfers_from_ecc(
       &ctx,
       (kQuartzRootPath / "eccset/Nam_6_3_complete_ECC_set.json").string());
+  int verified_count = 0;
+  int not_verified_count = 0;
   for (const auto &circuit : kCircuitNames) {
     freopen(((kQuartzRootPath / "benchmark-logs" / circuit).string() + ".log")
                 .c_str(),
@@ -57,9 +59,14 @@ int main() {
         /*verbose=*/false);
     if (verified) {
       std::cout << "All transformations are verified." << std::endl;
+      verified_count++;
     } else {
       std::cout << "Some transformation is not verified." << std::endl;
+      not_verified_count++;
+      std::cerr << circuit << " not verified." << std::endl;
     }
   }
+  std::cerr << verified_count << " cases verified, " << not_verified_count
+            << " cases not verified." << std::endl;
   return 0;
 }

--- a/src/quartz/dataset/dataset.cpp
+++ b/src/quartz/dataset/dataset.cpp
@@ -175,6 +175,13 @@ bool Dataset::insert(Context *ctx, std::unique_ptr<CircuitSeq> dag) {
   return ret;
 }
 
+bool Dataset::insert_with_hash(const CircuitSeqHashType &hash_value,
+                               std::unique_ptr<CircuitSeq> dag) {
+  bool ret = dataset.count(hash_value) == 0;
+  dataset[hash_value].push_back(std::move(dag));
+  return ret;
+}
+
 bool Dataset::insert_to_nearby_set_if_exists(Context *ctx,
                                              std::unique_ptr<CircuitSeq> dag) {
   const auto hash_value = dag->hash(ctx);

--- a/src/quartz/dataset/dataset.h
+++ b/src/quartz/dataset/dataset.h
@@ -40,7 +40,18 @@ class Dataset {
   // Returns true iff the hash value is new to the |dataset|.
   bool insert(Context *ctx, std::unique_ptr<CircuitSeq> dag);
 
-  // Inserts the circuitseq to an existing set if the hash value plus or minus 1
+  /**
+   * Insert a CircuitSeq with a pre-defined hash value. This function is used
+   * when the hash value cannot be computed, and should NOT be used in Quartz's
+   * generator.
+   * @param hash_value The hash value to be inserted.
+   * @param dag The CircuitSeq to be inserted.
+   * @return True iff the hash value is new to the |dataset|.
+   */
+  bool insert_with_hash(const CircuitSeqHashType &hash_value,
+                        std::unique_ptr<CircuitSeq> dag);
+
+  // Inserts the CircuitSeq to an existing set if the hash value plus or minus 1
   // is found. Returns true iff there is no such existing set.
   bool insert_to_nearby_set_if_exists(Context *ctx,
                                       std::unique_ptr<CircuitSeq> dag);

--- a/src/test/test_optimization_steps.h
+++ b/src/test/test_optimization_steps.h
@@ -21,9 +21,11 @@ void test_optimization(
     std::cerr << "Parser failed" << std::endl;
     return;
   }
-  ctx->gen_input_and_hashing_dis(dag->get_num_qubits());
+  // Do not generate (this is only for CircuitSeq::hash())
+  // because the number of qubits can be large.
+  // ctx->gen_input_and_hashing_dis(dag->get_num_qubits());
 
-  quartz::Graph graph(ctx, dag);
+  Graph graph(ctx, dag);
   std::cout << graph.total_cost() << " gates in circuit before optimizing."
             << std::endl;
   auto start = std::chrono::steady_clock::now();


### PR DESCRIPTION
This PR fixes a bug in `Verifier::equivalent` when removing common prefix gates, that if the first circuit is a prefix of the second circuit, this function would also remove the entire second circuit before this PR. After this PR, this function will correctly keep the remaining part of the second circuit.

This PR also avoids generating the hashing distribution in `test_optimization_steps.h`. The hashing distribution is only for `CircuitSeq::hash()`, and it takes up space of Theta(2^num_qubits). This size is huge when the number of qubits is greater than 30. We can test circuits with more than 30 qubits after this PR.

Also adds some debugging output when `verbose` is true.