### PR TITLE
[QASM] Print out pi symbolically if possible

### DIFF
--- a/src/quartz/context/context.cpp
+++ b/src/quartz/context/context.cpp
@@ -205,6 +205,18 @@ ParamType Context::get_param_value(int id) const {
   return param_info_->get_param_value(id);
 }
 
+std::string Context::get_param_symbolic_string(int id, int precision,
+                                               bool is_param_halved) const {
+  if (is_param_halved) {
+    return "2*" +
+           param_info_->get_param_symbolic_string(id, precision,
+                                                  /*operator_precedence=*/2);
+  } else {
+    return param_info_->get_param_symbolic_string(id, precision,
+                                                  /*operator_precedence=*/0);
+  }
+}
+
 void Context::set_param_value(int id, const ParamType &param) {
   return param_info_->set_param_value(id, param);
 }

--- a/src/quartz/context/context.h
+++ b/src/quartz/context/context.h
@@ -67,6 +67,17 @@ class Context {
    */
   [[nodiscard]] ParamType get_param_value(int id) const;
   /**
+   * Get the value of a symbolic constant expression with respect to
+   * reparameterization.
+   * @param id The parameter expression id.
+   * @param precision The precision of concrete constant parameters in the
+   * returned string.
+   * @param is_param_halved If true, the returned string is multiplied by 2.
+   * @return The string for the symbolic constant expression.
+   */
+  [[nodiscard]] std::string
+  get_param_symbolic_string(int id, int precision, bool is_param_halved) const;
+  /**
    * Set the value of a concrete parameter.
    */
   void set_param_value(int id, const ParamType &param);

--- a/src/quartz/context/param_info.cpp
+++ b/src/quartz/context/param_info.cpp
@@ -43,6 +43,52 @@ ParamType ParamInfo::get_param_value(int id) const {
   return parameter_values_[id];
 }
 
+std::string
+ParamInfo::get_param_symbolic_string(int id, int precision,
+                                     int operator_precedence) const {
+  assert(id >= 0 && id < (int)parameter_class_.size());
+  assert(parameter_class_[id].is_const());
+  if (parameter_class_[id] == ParamClass::concrete_const) {
+    std::ostringstream out;
+    out.precision(precision);
+    out << parameter_values_[id];
+    return out.str();
+  } else if (parameter_class_[id] == ParamClass::arithmetic_int) {
+    return std::to_string((long long)parameter_values_[id]);
+  }
+  assert(parameter_class_[id] == ParamClass::symbolic_constexpr);
+  auto op = parameter_wires_[id]->input_gates[0]->gate->tp;
+  int current_precedence = -1;
+  if (op == GateType::add) {
+    current_precedence = 1;
+  } else if (op == GateType::mult || op == GateType::pi ||
+             op == GateType::neg) {
+    current_precedence = 2;
+  } else {
+    assert(false);
+  }
+  std::vector<std::string> child_str;
+  child_str.reserve(parameter_wires_[id]->input_gates[0]->input_wires.size());
+  for (auto &input_wire : parameter_wires_[id]->input_gates[0]->input_wires) {
+    child_str.emplace_back(ParamInfo::get_param_symbolic_string(
+        input_wire->index, precision, current_precedence));
+  }
+  std::string result;
+  if (op == GateType::add) {
+    result = child_str[0] + "+" + child_str[1];
+  } else if (op == GateType::mult) {
+    result = child_str[0] + "*" + child_str[1];
+  } else if (op == GateType::pi) {
+    result = "pi/" + child_str[0];
+  } else if (op == GateType::neg) {
+    result = "-" + child_str[0];
+  }
+  if (current_precedence < operator_precedence) {
+    result = "(" + result + ")";
+  }
+  return result;
+}
+
 void ParamInfo::set_param_value(int id, const ParamType &param) {
   assert(id >= 0 && id < (int)parameter_class_.size());
   assert(parameter_class_[id] == ParamClass::concrete_const ||

--- a/src/quartz/context/param_info.h
+++ b/src/quartz/context/param_info.h
@@ -98,6 +98,22 @@ class ParamInfo {
    */
   [[nodiscard]] ParamType get_param_value(int id) const;
   /**
+   * Get the value of a symbolic constant expression.
+   * @param id The expression id.
+   * @param precision The precision of concrete constant parameters in the
+   * returned string.
+   * @param operator_precedence The operator precedence from outside.
+   * If the inner precedence is strictly lower (in number) than the outer one,
+   * then we must add parentheses.
+   * 0: no need to add parentheses outside
+   * 1: add
+   * 2: mult, pi, neg  // expressions like PI/4*-3 are allowed
+   * @return The string for the symbolic constant expression.
+   */
+  [[nodiscard]] std::string
+  get_param_symbolic_string(int id, int precision,
+                            int operator_precedence) const;
+  /**
    * Set the value of a concrete parameter.
    */
   void set_param_value(int id, const ParamType &param);

--- a/src/test/test_pi.cpp
+++ b/src/test/test_pi.cpp
@@ -11,7 +11,7 @@ int main() {
   Context ctx({GateType::rx, GateType::pi}, 1, &param_info);
 
   auto p0 = ctx.get_new_param_id(PI / 2);
-  auto p1 = ctx.get_new_param_id(2.0);
+  auto p1 = ctx.get_new_arithmetic_param_id(2);
   auto p2 = ctx.get_new_param_expression_id({p1}, ctx.get_gate(GateType::pi));
 
   CircuitSeq dag1(1);
@@ -33,6 +33,10 @@ int main() {
       }
     }
   }
+  std::cout << dag1.to_string(/*line_number=*/true, &ctx) << std::endl;
+  std::cout << dag1.to_qasm_style_string(&ctx) << std::endl;
+  std::cout << dag2.to_string(/*line_number=*/true, &ctx) << std::endl;
+  std::cout << dag2.to_qasm_style_string(&ctx) << std::endl;
 
   // Working directory is cmake-build-debug/ here.
   system("python ../src/test/test_pi.py");


### PR DESCRIPTION
Close #201 

This PR prints out `pi` symbolically if it is stored symbolically in Quartz.

Example in `test_pi`:
```c++
  ParamInfo param_info;
  Context ctx({GateType::rx, GateType::pi}, 1, &param_info);
  auto p1 = ctx.get_new_arithmetic_param_id(2);
  auto p2 = ctx.get_new_param_expression_id({p1}, ctx.get_gate(GateType::pi));
  CircuitSeq dag2(1);
  dag2.add_gate({0}, {p2}, ctx.get_gate(GateType::rx), &ctx);
  std::cout << dag2.to_qasm_style_string(&ctx) << std::endl;
```

Result: 
```
OPENQASM 2.0;
include "qelib1.inc";
qreg q[1];
rx(2*pi/2) q[0];
```
The `2*pi/2` is due to an artifact that caused us to divide the parameter by 2 and then multiply it by 2.

The JSON file format used by the verifier is not affected by this PR.