### PR TITLE
[Parser] Fix parser crashing on circuits with no gates

### DIFF
--- a/src/quartz/parser/qasm_parser.cpp
+++ b/src/quartz/parser/qasm_parser.cpp
@@ -505,4 +505,6 @@ int QubitParser::finalize() {
   return num_qubits;
 }
 
+bool QubitParser::is_finalized() { return finalized_; }
+
 }  // namespace quartz

--- a/src/quartz/parser/qasm_parser.h
+++ b/src/quartz/parser/qasm_parser.h
@@ -248,6 +248,11 @@ class QubitParser {
    */
   int finalize();
 
+  /**
+   * @return If finalize() has been called.
+   */
+  [[nodiscard]] bool is_finalized();
+
  private:
   /**
    * Implementation details for parse_qasm2_decl and parse_qasm3_decl. This
@@ -483,6 +488,12 @@ bool QASMParser::load_qasm_stream(
       std::cerr << "Unknown gate: " << command << std::endl;
       assert(false);
     }
+  }
+
+  if (!qubit_parser.is_finalized()) {
+    // A circuit with no gates.
+    int num_qubits = qubit_parser.finalize();
+    seq = new CircuitSeq(num_qubits);
   }
 
   // Successfully parsed file.


### PR DESCRIPTION
Before this PR, `seq` is still a `nullptr` after calling the parser if the circuit has no gates. This PR fixes this issue by creating an empty circuit.